### PR TITLE
Add initial plugin structure with admin instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,10 @@
+# Council Debt Counters
+
+This WordPress plugin provides animated counters to display UK council debt figures. Counters can be embedded using a shortcode and configured through the WordPress admin interface.
+
+Currently the plugin includes an admin page with instructions for uploading starting debt figures via CSV. Additional functionality such as data uploading and counter rendering will be added in future versions.
+
+## Installation
+1. Copy the plugin folder to your `wp-content/plugins` directory.
+2. Activate **Council Debt Counters** in the WordPress admin.
+3. Visit **Debt Counters** in the admin menu for instructions on adding your data.

--- a/admin/views/instructions-page.php
+++ b/admin/views/instructions-page.php
@@ -1,0 +1,14 @@
+<div class="wrap">
+    <h1><?php esc_html_e( 'Council Debt Counters', 'council-debt-counters' ); ?></h1>
+    <p>
+        <?php esc_html_e( 'To get started, you will need baseline debt figures for each council.', 'council-debt-counters' ); ?>
+    </p>
+    <ol>
+        <li><?php esc_html_e( 'Download or prepare a CSV file with two columns: council name and total debt (numeric).', 'council-debt-counters' ); ?></li>
+        <li><?php esc_html_e( 'Go to the Data Loader section (coming soon) to upload your CSV.', 'council-debt-counters' ); ?></li>
+        <li><?php esc_html_e( 'Alternatively, you can manually enter or override figures once the data loader is available.', 'council-debt-counters' ); ?></li>
+    </ol>
+    <p>
+        <?php esc_html_e( 'After uploading, you can use the [council_counter] shortcode to display animated figures in posts or pages.', 'council-debt-counters' ); ?>
+    </p>
+</div>

--- a/council-debt-counters.php
+++ b/council-debt-counters.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Plugin Name: Council Debt Counters
+ * Description: Animated counters visualising council debt figures.
+ * Version: 0.1.0
+ * Author: OpenAI Codex
+ * License: GPL2+
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit; // Exit if accessed directly.
+}
+
+require_once plugin_dir_path( __FILE__ ) . 'includes/class-settings-page.php';
+require_once plugin_dir_path( __FILE__ ) . 'includes/class-counter-manager.php';
+require_once plugin_dir_path( __FILE__ ) . 'includes/class-shortcode-renderer.php';
+require_once plugin_dir_path( __FILE__ ) . 'includes/class-data-loader.php';
+
+// Initialize plugin components.
+add_action( 'plugins_loaded', function() {
+    \CouncilDebtCounters\Settings_Page::init();
+} );

--- a/includes/class-counter-manager.php
+++ b/includes/class-counter-manager.php
@@ -1,0 +1,10 @@
+<?php
+namespace CouncilDebtCounters;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class Counter_Manager {
+    // Placeholder for future counter registration and management.
+}

--- a/includes/class-data-loader.php
+++ b/includes/class-data-loader.php
@@ -1,0 +1,10 @@
+<?php
+namespace CouncilDebtCounters;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class Data_Loader {
+    // Placeholder for future CSV loading functionality.
+}

--- a/includes/class-settings-page.php
+++ b/includes/class-settings-page.php
@@ -1,0 +1,37 @@
+<?php
+namespace CouncilDebtCounters;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class Settings_Page {
+
+    /**
+     * Register hooks.
+     */
+    public static function init() {
+        add_action( 'admin_menu', [ __CLASS__, 'add_menu' ] );
+    }
+
+    /**
+     * Add admin menu page.
+     */
+    public static function add_menu() {
+        add_menu_page(
+            __( 'Council Debt Counters', 'council-debt-counters' ),
+            __( 'Debt Counters', 'council-debt-counters' ),
+            'manage_options',
+            'council-debt-counters',
+            [ __CLASS__, 'render_page' ],
+            'dashicons-chart-line'
+        );
+    }
+
+    /**
+     * Render settings page content.
+     */
+    public static function render_page() {
+        include plugin_dir_path( __DIR__ ) . 'admin/views/instructions-page.php';
+    }
+}

--- a/includes/class-shortcode-renderer.php
+++ b/includes/class-shortcode-renderer.php
@@ -1,0 +1,10 @@
+<?php
+namespace CouncilDebtCounters;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class Shortcode_Renderer {
+    // Placeholder for future shortcode rendering.
+}


### PR DESCRIPTION
## Summary
- create the plugin architecture
- implement an admin page to guide users on providing starting debt numbers via CSV
- add placeholder classes for counters, shortcode rendering, and data loading

## Testing
- `vendor/bin/phpunit` *(fails: Test directory not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846e58c82fc8331898c7650d7f4a42f