### PR TITLE
Implement council post type and ACF fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,14 @@
 
 This WordPress plugin provides animated counters to display UK council debt figures. Counters can be embedded using a shortcode and configured through the WordPress admin interface.
 
+The plugin registers a custom **Council** post type where you can store detailed information about each local authority. The free version allows up to **two councils**; enter a valid license key on the settings page to create more.
+
+This plugin depends on the **Advanced Custom Fields** (ACF) plugin. Please install and activate ACF before using Council Debt Counters.
+
 Currently the plugin includes an admin page with instructions for uploading starting debt figures via CSV. Additional functionality such as data uploading and counter rendering will be added in future versions.
 
 ## Installation
 1. Copy the plugin folder to your `wp-content/plugins` directory.
 2. Activate **Council Debt Counters** in the WordPress admin.
-3. Visit **Debt Counters** in the admin menu for instructions on adding your data.
+3. Ensure the Advanced Custom Fields plugin is installed and active.
+4. Visit **Debt Counters** in the admin menu to enter your license key and start adding councils.

--- a/admin/views/instructions-page.php
+++ b/admin/views/instructions-page.php
@@ -1,14 +1,27 @@
 <div class="wrap">
     <h1><?php esc_html_e( 'Council Debt Counters', 'council-debt-counters' ); ?></h1>
-    <p>
-        <?php esc_html_e( 'To get started, you will need baseline debt figures for each council.', 'council-debt-counters' ); ?>
-    </p>
-    <ol>
-        <li><?php esc_html_e( 'Download or prepare a CSV file with two columns: council name and total debt (numeric).', 'council-debt-counters' ); ?></li>
-        <li><?php esc_html_e( 'Go to the Data Loader section (coming soon) to upload your CSV.', 'council-debt-counters' ); ?></li>
-        <li><?php esc_html_e( 'Alternatively, you can manually enter or override figures once the data loader is available.', 'council-debt-counters' ); ?></li>
-    </ol>
-    <p>
-        <?php esc_html_e( 'After uploading, you can use the [council_counter] shortcode to display animated figures in posts or pages.', 'council-debt-counters' ); ?>
-    </p>
+    <p><?php esc_html_e( 'This plugin requires the Advanced Custom Fields (ACF) plugin. Please ensure it is installed and activated.', 'council-debt-counters' ); ?></p>
+    <p><?php esc_html_e( 'To get started, upload baseline debt figures or manually enter data for each council.', 'council-debt-counters' ); ?></p>
+
+    <form method="post" action="options.php">
+        <?php
+        settings_fields( 'council-debt-counters' );
+        do_settings_sections( 'council-debt-counters' );
+        ?>
+        <table class="form-table" role="presentation">
+            <tr>
+                <th scope="row"><label for="<?php echo esc_attr( License_Manager::OPTION_KEY ); ?>"><?php esc_html_e( 'License Key', 'council-debt-counters' ); ?></label></th>
+                <td>
+                    <input name="<?php echo esc_attr( License_Manager::OPTION_KEY ); ?>" type="text" id="<?php echo esc_attr( License_Manager::OPTION_KEY ); ?>" value="<?php echo esc_attr( License_Manager::get_license_key() ); ?>" class="regular-text" />
+                    <p class="description"><?php esc_html_e( 'Enter a valid license key to unlock unlimited councils.', 'council-debt-counters' ); ?></p>
+                </td>
+            </tr>
+        </table>
+        <?php submit_button(); ?>
+    </form>
 </div>
+<?php
+if ( isset( $_GET['cdc_limit'] ) ) {
+    echo '<div class="notice notice-warning"><p>' . esc_html__( 'The free version is limited to two councils. Enter a license key to add more.', 'council-debt-counters' ) . '</p></div>';
+}
+?>

--- a/council-debt-counters.php
+++ b/council-debt-counters.php
@@ -17,8 +17,12 @@ require_once plugin_dir_path( __FILE__ ) . 'includes/class-settings-page.php';
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-counter-manager.php';
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-shortcode-renderer.php';
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-data-loader.php';
+require_once plugin_dir_path( __FILE__ ) . 'includes/class-license-manager.php';
+require_once plugin_dir_path( __FILE__ ) . 'includes/class-council-post-type.php';
+require_once plugin_dir_path( __FILE__ ) . 'includes/class-acf-manager.php';
 
-// Initialize plugin components.
 add_action( 'plugins_loaded', function() {
     \CouncilDebtCounters\Settings_Page::init();
+    \CouncilDebtCounters\Council_Post_Type::init();
+    \CouncilDebtCounters\ACF_Manager::init();
 } );

--- a/includes/class-acf-manager.php
+++ b/includes/class-acf-manager.php
@@ -1,0 +1,114 @@
+<?php
+namespace CouncilDebtCounters;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class ACF_Manager {
+    /**
+     * Register hooks
+     */
+    public static function init() {
+        add_action( 'plugins_loaded', [ __CLASS__, 'check_acf_dependency' ] );
+        add_action( 'acf/init', [ __CLASS__, 'register_fields' ] );
+    }
+
+    /**
+     * Display admin notice if ACF is not active.
+     */
+    public static function check_acf_dependency() {
+        if ( ! function_exists( 'acf_add_local_field_group' ) ) {
+            add_action( 'admin_notices', function() {
+                echo '<div class="notice notice-error"><p>' . esc_html__( 'Council Debt Counters requires the Advanced Custom Fields plugin to be installed and activated.', 'council-debt-counters' ) . '</p></div>';
+            } );
+        }
+    }
+
+    /**
+     * Register ACF fields for the council post type.
+     */
+    public static function register_fields() {
+        if ( ! function_exists( 'acf_add_local_field_group' ) ) {
+            return;
+        }
+
+        acf_add_local_field_group([
+            'key' => 'group_cdc_council',
+            'title' => __( 'Council Details', 'council-debt-counters' ),
+            'fields' => [
+                [
+                    'key' => 'field_cdc_council_name',
+                    'label' => __( 'Council Name', 'council-debt-counters' ),
+                    'name' => 'council_name',
+                    'type' => 'text',
+                ],
+                [
+                    'key' => 'field_cdc_council_type',
+                    'label' => __( 'Council Type', 'council-debt-counters' ),
+                    'name' => 'council_type',
+                    'type' => 'select',
+                    'choices' => [
+                        'district'   => __( 'District', 'council-debt-counters' ),
+                        'county'     => __( 'County', 'council-debt-counters' ),
+                        'unitary'    => __( 'Unitary', 'council-debt-counters' ),
+                        'metropolitan' => __( 'Metropolitan', 'council-debt-counters' ),
+                        'london_borough' => __( 'London Borough', 'council-debt-counters' ),
+                    ],
+                    'ui' => 1,
+                ],
+                [
+                    'key' => 'field_cdc_population',
+                    'label' => __( 'Population', 'council-debt-counters' ),
+                    'name' => 'population',
+                    'type' => 'number',
+                ],
+                [
+                    'key' => 'field_cdc_elected_members',
+                    'label' => __( 'Elected Members', 'council-debt-counters' ),
+                    'name' => 'elected_members',
+                    'type' => 'number',
+                ],
+                [
+                    'key' => 'field_cdc_council_tax_revenue',
+                    'label' => __( 'Annual Council Tax Revenue', 'council-debt-counters' ),
+                    'name' => 'council_tax_revenue',
+                    'type' => 'number',
+                ],
+                [
+                    'key' => 'field_cdc_total_debt',
+                    'label' => __( 'Total Debt', 'council-debt-counters' ),
+                    'name' => 'total_debt',
+                    'type' => 'number',
+                ],
+                [
+                    'key' => 'field_cdc_debt_per_household',
+                    'label' => __( 'Debt Per Household', 'council-debt-counters' ),
+                    'name' => 'debt_per_household',
+                    'type' => 'number',
+                ],
+                [
+                    'key' => 'field_cdc_band_a_props',
+                    'label' => __( 'Properties in Band A', 'council-debt-counters' ),
+                    'name' => 'band_a_properties',
+                    'type' => 'number',
+                ],
+                [
+                    'key' => 'field_cdc_band_b_props',
+                    'label' => __( 'Properties in Band B', 'council-debt-counters' ),
+                    'name' => 'band_b_properties',
+                    'type' => 'number',
+                ],
+            ],
+            'location' => [
+                [
+                    [
+                        'param' => 'post_type',
+                        'operator' => '==',
+                        'value' => 'council',
+                    ],
+                ],
+            ],
+        ] );
+    }
+}

--- a/includes/class-council-post-type.php
+++ b/includes/class-council-post-type.php
@@ -1,0 +1,68 @@
+<?php
+namespace CouncilDebtCounters;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class Council_Post_Type {
+    /**
+     * Register hooks.
+     */
+    public static function init() {
+        add_action( 'init', [ __CLASS__, 'register' ] );
+        add_action( 'admin_menu', [ __CLASS__, 'maybe_hide_add_new' ], 99 );
+        add_action( 'load-post-new.php', [ __CLASS__, 'enforce_limit' ] );
+    }
+
+    /**
+     * Register the council custom post type.
+     */
+    public static function register() {
+        register_post_type( 'council', [
+            'labels' => [
+                'name'          => __( 'Councils', 'council-debt-counters' ),
+                'singular_name' => __( 'Council', 'council-debt-counters' ),
+            ],
+            'public'       => false,
+            'show_ui'      => true,
+            'show_in_menu' => true,
+            'capability_type' => 'post',
+            'supports'     => [ 'title' ],
+        ] );
+    }
+
+    /**
+     * Get count of existing council posts.
+     */
+    public static function count_councils() {
+        $count = wp_count_posts( 'council' );
+        return (int) $count->publish + (int) $count->draft + (int) $count->pending;
+    }
+
+    /**
+     * Hide Add New menu item when limit reached and license invalid.
+     */
+    public static function maybe_hide_add_new() {
+        if ( License_Manager::is_valid() ) {
+            return;
+        }
+        if ( self::count_councils() >= 2 ) {
+            global $submenu;
+            if ( isset( $submenu['edit.php?post_type=council'][10] ) ) {
+                unset( $submenu['edit.php?post_type=council'][10] );
+            }
+        }
+    }
+
+    /**
+     * Prevent creation of more councils when limit reached.
+     */
+    public static function enforce_limit() {
+        $screen = get_current_screen();
+        if ( $screen && 'council' === $screen->post_type && ! License_Manager::is_valid() && self::count_councils() >= 2 ) {
+            wp_safe_redirect( admin_url( 'edit.php?post_type=council&cdc_limit=1' ) );
+            exit;
+        }
+    }
+}

--- a/includes/class-license-manager.php
+++ b/includes/class-license-manager.php
@@ -1,0 +1,26 @@
+<?php
+namespace CouncilDebtCounters;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class License_Manager {
+    const OPTION_KEY = 'cdc_license_key';
+    const OPTION_VALID = 'cdc_license_valid';
+
+    /**
+     * Determine if the installed license is valid.
+     * This is a placeholder for real validation logic.
+     */
+    public static function is_valid() {
+        return (bool) get_option( self::OPTION_VALID );
+    }
+
+    /**
+     * Return the stored license key.
+     */
+    public static function get_license_key() {
+        return get_option( self::OPTION_KEY, '' );
+    }
+}

--- a/includes/class-settings-page.php
+++ b/includes/class-settings-page.php
@@ -7,16 +7,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 class Settings_Page {
 
-    /**
-     * Register hooks.
-     */
     public static function init() {
         add_action( 'admin_menu', [ __CLASS__, 'add_menu' ] );
+        add_action( 'admin_init', [ __CLASS__, 'register_settings' ] );
     }
 
-    /**
-     * Add admin menu page.
-     */
     public static function add_menu() {
         add_menu_page(
             __( 'Council Debt Counters', 'council-debt-counters' ),
@@ -28,9 +23,11 @@ class Settings_Page {
         );
     }
 
-    /**
-     * Render settings page content.
-     */
+    public static function register_settings() {
+        register_setting( 'council-debt-counters', License_Manager::OPTION_KEY );
+        register_setting( 'council-debt-counters', License_Manager::OPTION_VALID );
+    }
+
     public static function render_page() {
         include plugin_dir_path( __DIR__ ) . 'admin/views/instructions-page.php';
     }


### PR DESCRIPTION
## Summary
- add Council custom post type limited to two entries in the free version
- add License manager and settings integration
- add ACF field group to store council information
- show ACF requirement and license field on the settings page
- update README with new setup instructions

## Testing
- `vendor/bin/phpunit` *(fails: Test directory "/workspace/./tests" not found)*

------
https://chatgpt.com/codex/tasks/task_e_684734122de483319fd33b41624bc986