### PR TITLE
Add settings submenu for Councils

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This WordPress plugin provides animated counters to display UK council debt figures. Counters can be embedded using a shortcode and configured through the WordPress admin interface.
 
-The plugin registers a custom **Council** post type where you can store detailed information about each local authority. The free version allows up to **two councils**; enter a valid license key on the settings page to create more.
+The plugin registers a custom **Council** post type where you can store detailed information about each local authority. The post type is hidden from the regular WordPress menu so users cannot manually add councils from the Posts screen. It remains visible in ACF location rules and can be managed from the plugin's own **Debt Counters → Councils** submenu. The free version allows up to **two councils**; enter a valid license key on the settings page to create more.
 
 This plugin depends on the **Advanced Custom Fields** (ACF) plugin. Please install and activate ACF before using Council Debt Counters.
 

--- a/admin/views/instructions-page.php
+++ b/admin/views/instructions-page.php
@@ -2,6 +2,7 @@
     <h1><?php esc_html_e( 'Council Debt Counters', 'council-debt-counters' ); ?></h1>
     <p><?php esc_html_e( 'This plugin requires the Advanced Custom Fields (ACF) plugin. Please ensure it is installed and activated.', 'council-debt-counters' ); ?></p>
     <p><?php esc_html_e( 'To get started, upload baseline debt figures or manually enter data for each council.', 'council-debt-counters' ); ?></p>
+    <p><?php esc_html_e( 'Manage councils from the "Councils" submenu under Debt Counters.', 'council-debt-counters' ); ?></p>
 
     <form method="post" action="options.php">
         <?php

--- a/includes/class-council-post-type.php
+++ b/includes/class-council-post-type.php
@@ -11,7 +11,6 @@ class Council_Post_Type {
      */
     public static function init() {
         add_action( 'init', [ __CLASS__, 'register' ] );
-        add_action( 'admin_menu', [ __CLASS__, 'maybe_hide_add_new' ], 99 );
         add_action( 'load-post-new.php', [ __CLASS__, 'enforce_limit' ] );
     }
 
@@ -24,11 +23,13 @@ class Council_Post_Type {
                 'name'          => __( 'Councils', 'council-debt-counters' ),
                 'singular_name' => __( 'Council', 'council-debt-counters' ),
             ],
-            'public'       => false,
-            'show_ui'      => true,
-            'show_in_menu' => true,
-            'capability_type' => 'post',
-            'supports'     => [ 'title' ],
+            'public'             => false,
+            'show_ui'            => true,
+            'show_in_menu'       => false,
+            'show_in_admin_bar'  => false,
+            'capability_type'    => 'post',
+            'supports'           => [ 'title' ],
+            'publicly_queryable' => false,
         ] );
     }
 
@@ -38,21 +39,6 @@ class Council_Post_Type {
     public static function count_councils() {
         $count = wp_count_posts( 'council' );
         return (int) $count->publish + (int) $count->draft + (int) $count->pending;
-    }
-
-    /**
-     * Hide Add New menu item when limit reached and license invalid.
-     */
-    public static function maybe_hide_add_new() {
-        if ( License_Manager::is_valid() ) {
-            return;
-        }
-        if ( self::count_councils() >= 2 ) {
-            global $submenu;
-            if ( isset( $submenu['edit.php?post_type=council'][10] ) ) {
-                unset( $submenu['edit.php?post_type=council'][10] );
-            }
-        }
     }
 
     /**

--- a/includes/class-settings-page.php
+++ b/includes/class-settings-page.php
@@ -12,15 +12,6 @@ class Settings_Page {
     public static function init() {
         add_action( 'admin_menu', [ __CLASS__, 'add_menu' ] );
         add_action( 'admin_init', [ __CLASS__, 'register_settings' ] );
-        // Add submenu for document management
-        add_submenu_page(
-            'council-debt-counters',
-            __( 'Manage Documents', 'council-debt-counters' ),
-            __( 'Manage Documents', 'council-debt-counters' ),
-            'manage_options',
-            'cdc-manage-docs',
-            [ __CLASS__, 'render_docs_page' ]
-        );
     }
 
     public static function add_menu() {
@@ -31,6 +22,23 @@ class Settings_Page {
             'council-debt-counters',
             [ __CLASS__, 'render_page' ],
             'dashicons-chart-line'
+        );
+
+        add_submenu_page(
+            'council-debt-counters',
+            __( 'Councils', 'council-debt-counters' ),
+            __( 'Councils', 'council-debt-counters' ),
+            'manage_options',
+            'edit.php?post_type=council'
+        );
+
+        add_submenu_page(
+            'council-debt-counters',
+            __( 'Manage Documents', 'council-debt-counters' ),
+            __( 'Manage Documents', 'council-debt-counters' ),
+            'manage_options',
+            'cdc-manage-docs',
+            [ __CLASS__, 'render_docs_page' ]
         );
     }
 


### PR DESCRIPTION
## Summary
- clarify in README that councils are managed from the plugin menu
- link the built‑in council list via a new "Councils" submenu
- update instructions page with guidance on where to manage councils

## Testing
- `php -l includes/class-settings-page.php`
- `php -l admin/views/instructions-page.php`

------
https://chatgpt.com/codex/tasks/task_e_684738ae791c8331a89b5d8a83a0d5f4