### PR TITLE
Fix missing class reference and add troubleshooting log

### DIFF
--- a/admin/views/instructions-page.php
+++ b/admin/views/instructions-page.php
@@ -1,3 +1,8 @@
+<?php
+use CouncilDebtCounters\License_Manager;
+
+if ( ! defined( 'ABSPATH' ) ) exit;
+?>
 <div class="wrap">
     <h1><?php esc_html_e( 'Council Debt Counters', 'council-debt-counters' ); ?></h1>
     <p><?php esc_html_e( 'This plugin requires the Advanced Custom Fields (ACF) plugin. Please ensure it is installed and activated.', 'council-debt-counters' ); ?></p>

--- a/admin/views/troubleshooting-page.php
+++ b/admin/views/troubleshooting-page.php
@@ -1,0 +1,21 @@
+<?php
+use CouncilDebtCounters\Error_Logger;
+
+if ( ! defined( 'ABSPATH' ) ) exit;
+
+$log = Error_Logger::get_log();
+
+if ( isset( $_POST['cdc_clear_log'] ) ) {
+    Error_Logger::clear_log();
+    $log = '';
+    echo '<div class="notice notice-success"><p>' . esc_html__( 'Log cleared.', 'council-debt-counters' ) . '</p></div>';
+}
+?>
+<div class="wrap">
+    <h1><?php esc_html_e( 'Troubleshooting', 'council-debt-counters' ); ?></h1>
+    <p><?php esc_html_e( 'View recent plugin errors for debugging purposes.', 'council-debt-counters' ); ?></p>
+    <form method="post">
+        <textarea readonly rows="20" style="width:100%;" aria-label="<?php esc_attr_e( 'Error log', 'council-debt-counters' ); ?>"><?php echo esc_textarea( $log ); ?></textarea>
+        <p><button type="submit" name="cdc_clear_log" class="button"><?php esc_html_e( 'Clear Log', 'council-debt-counters' ); ?></button></p>
+    </form>
+</div>

--- a/council-debt-counters.php
+++ b/council-debt-counters.php
@@ -17,11 +17,13 @@ require_once plugin_dir_path( __FILE__ ) . 'includes/class-settings-page.php';
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-counter-manager.php';
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-shortcode-renderer.php';
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-data-loader.php';
+require_once plugin_dir_path( __FILE__ ) . 'includes/class-error-logger.php';
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-license-manager.php';
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-council-post-type.php';
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-acf-manager.php';
 
 add_action( 'plugins_loaded', function() {
+    \CouncilDebtCounters\Error_Logger::init();
     \CouncilDebtCounters\Settings_Page::init();
     \CouncilDebtCounters\Council_Post_Type::init();
     \CouncilDebtCounters\ACF_Manager::init();

--- a/includes/class-docs-manager.php
+++ b/includes/class-docs-manager.php
@@ -36,15 +36,18 @@ class Docs_Manager {
     public static function upload_document( $file ) {
         $ext = strtolower( pathinfo( $file['name'], PATHINFO_EXTENSION ) );
         if ( ! in_array( $ext, self::ALLOWED_EXTENSIONS ) ) {
+            Error_Logger::log( 'Attempted upload of invalid file type: ' . $file['name'] );
             return __( 'Invalid file type. Only XLSX, CSV, and PDF are allowed.', 'council-debt-counters' );
         }
         if ( ! self::can_upload() ) {
+            Error_Logger::log( 'Document upload blocked - free limit reached' );
             return __( 'Free version limit reached. Upgrade to Pro for unlimited documents.', 'council-debt-counters' );
         }
         $target = self::get_docs_path() . basename( $file['name'] );
         if ( move_uploaded_file( $file['tmp_name'], $target ) ) {
             return true;
         }
+        Error_Logger::log( 'Failed to move uploaded document: ' . $file['name'] );
         return __( 'Upload failed.', 'council-debt-counters' );
     }
 

--- a/includes/class-error-logger.php
+++ b/includes/class-error-logger.php
@@ -1,0 +1,44 @@
+<?php
+namespace CouncilDebtCounters;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class Error_Logger {
+    const LOG_FILENAME = 'troubleshooting.log';
+
+    public static function init() {
+        set_error_handler( [ __CLASS__, 'handle_error' ] );
+    }
+
+    public static function log( string $message ) {
+        $file = self::get_log_file_path();
+        $entry = '[' . date( 'Y-m-d H:i:s' ) . "] " . $message . "\n";
+        file_put_contents( $file, $entry, FILE_APPEND | LOCK_EX );
+    }
+
+    public static function handle_error( $errno, $errstr, $errfile, $errline ) {
+        if ( ! ( error_reporting() & $errno ) ) {
+            return false;
+        }
+        self::log( "Error {$errno} at {$errfile}:{$errline} - {$errstr}" );
+        return false; // Let default handler run as well
+    }
+
+    public static function get_log() {
+        $file = self::get_log_file_path();
+        return file_exists( $file ) ? file_get_contents( $file ) : '';
+    }
+
+    public static function clear_log() {
+        $file = self::get_log_file_path();
+        if ( file_exists( $file ) ) {
+            file_put_contents( $file, '' );
+        }
+    }
+
+    private static function get_log_file_path() {
+        return plugin_dir_path( dirname( __FILE__ ) ) . self::LOG_FILENAME;
+    }
+}

--- a/includes/class-settings-page.php
+++ b/includes/class-settings-page.php
@@ -40,6 +40,15 @@ class Settings_Page {
             'cdc-manage-docs',
             [ __CLASS__, 'render_docs_page' ]
         );
+
+        add_submenu_page(
+            'council-debt-counters',
+            __( 'Troubleshooting', 'council-debt-counters' ),
+            __( 'Troubleshooting', 'council-debt-counters' ),
+            'manage_options',
+            'cdc-troubleshooting',
+            [ __CLASS__, 'render_troubleshooting_page' ]
+        );
     }
 
     public static function register_settings() {
@@ -53,5 +62,9 @@ class Settings_Page {
 
     public static function render_docs_page() {
         include plugin_dir_path( __DIR__ ) . 'admin/views/docs-manager-page.php';
+    }
+
+    public static function render_troubleshooting_page() {
+        include plugin_dir_path( __DIR__ ) . 'admin/views/troubleshooting-page.php';
     }
 }


### PR DESCRIPTION
## Summary
- ensure `License_Manager` is referenced with namespace on the instructions page
- introduce `Error_Logger` class with file-based logging
- hook logger into plugin loader
- log upload errors and add troubleshooting submenu
- display log contents on a new troubleshooting admin page

## Testing
- `php -l council-debt-counters.php`
- `php -l includes/class-error-logger.php`
- `php -l includes/class-docs-manager.php`
- `php -l admin/views/instructions-page.php`
- `php -l admin/views/troubleshooting-page.php`
- `php -l includes/class-settings-page.php`
- `vendor/bin/phpunit` *(fails: Test directory not found)*

------
https://chatgpt.com/codex/tasks/task_e_68473de8b1d0833187150bc2af037227