### PR TITLE
Fix docs manager load and capture fatal errors

### DIFF
--- a/council-debt-counters.php
+++ b/council-debt-counters.php
@@ -18,6 +18,7 @@ require_once plugin_dir_path( __FILE__ ) . 'includes/class-counter-manager.php';
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-shortcode-renderer.php';
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-data-loader.php';
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-error-logger.php';
+require_once plugin_dir_path( __FILE__ ) . 'includes/class-docs-manager.php';
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-license-manager.php';
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-council-post-type.php';
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-acf-manager.php';

--- a/includes/class-error-logger.php
+++ b/includes/class-error-logger.php
@@ -10,6 +10,7 @@ class Error_Logger {
 
     public static function init() {
         set_error_handler( [ __CLASS__, 'handle_error' ] );
+        register_shutdown_function( [ __CLASS__, 'handle_shutdown' ] );
     }
 
     public static function log( string $message ) {
@@ -24,6 +25,13 @@ class Error_Logger {
         }
         self::log( "Error {$errno} at {$errfile}:{$errline} - {$errstr}" );
         return false; // Let default handler run as well
+    }
+
+    public static function handle_shutdown() {
+        $error = error_get_last();
+        if ( $error && in_array( $error['type'], [ E_ERROR, E_PARSE, E_CORE_ERROR, E_COMPILE_ERROR, E_USER_ERROR ] ) ) {
+            self::log( "Fatal {$error['type']} at {$error['file']}:{$error['line']} - {$error['message']}" );
+        }
     }
 
     public static function get_log() {


### PR DESCRIPTION
## Summary
- include Docs Manager class
- log fatal shutdown errors in troubleshooting log

## Testing
- `vendor/bin/phpunit` *(fails: Test directory not found)*

------
https://chatgpt.com/codex/tasks/task_e_684740803a748331b65e79868af3cb19