### PR TITLE
Fix troubleshooting textarea display and document link path

### DIFF
--- a/admin/views/docs-manager-page.php
+++ b/admin/views/docs-manager-page.php
@@ -60,7 +60,7 @@ if ( isset( $_FILES['cdc_upload_doc'] ) && $_FILES['cdc_upload_doc']['size'] > 0
                             <input type="hidden" name="cdc_doc_name" value="<?php echo esc_attr( $doc ); ?>" />
                             <button type="submit" name="cdc_delete_doc" class="button button-secondary" onclick="return confirm('<?php esc_attr_e( 'Are you sure you want to delete this document?', 'council-debt-counters' ); ?>');"><?php esc_html_e( 'Delete', 'council-debt-counters' ); ?></button>
                         </form>
-                        <a href="<?php echo esc_url( plugins_url( 'docs/' . $doc, dirname( __DIR__, 2 ) ) ); ?>" target="_blank" class="button">View</a>
+                        <a href="<?php echo esc_url( plugins_url( 'docs/' . $doc, dirname( __DIR__, 2 ) . '/council-debt-counters.php' ) ); ?>" target="_blank" rel="noopener noreferrer" class="button">View</a>
                     </td>
                 </tr>
             <?php endforeach; endif; ?>

--- a/admin/views/troubleshooting-page.php
+++ b/admin/views/troubleshooting-page.php
@@ -1,13 +1,16 @@
 <?php
-use CouncilDebtCounters\Error_Logger;
+
+// Access the error logger via its fully-qualified name to avoid namespace
+// issues when this view is included from within a namespaced context.
+
 
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-$log = Error_Logger::get_log();
+$log = \CouncilDebtCounters\Error_Logger::get_log();
 
 if ( isset( $_POST['cdc_clear_log'] ) ) {
-    Error_Logger::clear_log();
-    $log = '';
+    \CouncilDebtCounters\Error_Logger::clear_log();
+    $log = \CouncilDebtCounters\Error_Logger::get_log();
     echo '<div class="notice notice-success"><p>' . esc_html__( 'Log cleared.', 'council-debt-counters' ) . '</p></div>';
 }
 ?>
@@ -15,7 +18,7 @@ if ( isset( $_POST['cdc_clear_log'] ) ) {
     <h1><?php esc_html_e( 'Troubleshooting', 'council-debt-counters' ); ?></h1>
     <p><?php esc_html_e( 'View recent plugin errors for debugging purposes.', 'council-debt-counters' ); ?></p>
     <form method="post">
-        <textarea readonly rows="20" style="width:100%;" aria-label="<?php esc_attr_e( 'Error log', 'council-debt-counters' ); ?>"><?php echo esc_textarea( $log ); ?></textarea>
+        <textarea readonly rows="20" style="width:100%;" aria-label="<?php echo esc_attr__( 'Error log', 'council-debt-counters' ); ?>"><?php echo esc_textarea( $log ); ?></textarea>
         <p><button type="submit" name="cdc_clear_log" class="button"><?php esc_html_e( 'Clear Log', 'council-debt-counters' ); ?></button></p>
     </form>
 </div>


### PR DESCRIPTION
## Summary
- refresh the error log value after clearing it and make sure the textarea always outputs the label text
- correct the link to uploaded documents and add noopener security
- avoid namespace issues on the troubleshooting page by calling `Error_Logger` with its fully-qualified name

## Testing
- `find . -name '*.php' -print0 | xargs -0 -n 1 php -l`


------
https://chatgpt.com/codex/tasks/task_e_6847423129e48331bd4d3a3d3936b618