### PR TITLE
Add Bootstrap council admin UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ The plugin registers a custom **Council** post type where you can store detailed
 
 This plugin depends on the **Advanced Custom Fields** (ACF) plugin. Please install and activate ACF before using Council Debt Counters.
 
+Councils can be added, edited, and deleted from the **Debt Counters → Councils** page which uses a clean Bootstrap design. The ACF field groups assigned to the `council` post type are displayed on this screen so you can capture all relevant information before uploading finance documents.
+
 Currently the plugin includes an admin page with instructions for uploading starting debt figures via CSV. Additional functionality such as data uploading and counter rendering will be added in future versions.
 
 ## Installation

--- a/admin/views/councils-page.php
+++ b/admin/views/councils-page.php
@@ -1,0 +1,64 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) exit;
+
+$action  = isset( $_GET['action'] ) ? sanitize_text_field( $_GET['action'] ) : '';
+$post_id = isset( $_GET['post'] ) ? intval( $_GET['post'] ) : 0;
+
+if ( $action === 'delete' && $post_id ) {
+    check_admin_referer( 'cdc_delete_council_' . $post_id );
+    wp_delete_post( $post_id, true );
+    echo '<div class="alert alert-success"><p>' . esc_html__( 'Council deleted.', 'council-debt-counters' ) . '</p></div>';
+    $action = '';
+}
+
+if ( $action === 'edit' ) {
+    echo '<div class="wrap">';
+    echo '<h1>' . esc_html( $post_id ? __( 'Edit Council', 'council-debt-counters' ) : __( 'Add Council', 'council-debt-counters' ) ) . '</h1>';
+    $args = [
+        'post_id'     => $post_id ? $post_id : 'new_post',
+        'new_post'    => [
+            'post_type'   => 'council',
+            'post_status' => 'publish',
+        ],
+        'return'      => admin_url( 'admin.php?page=cdc-manage-councils' ),
+        'submit_value' => __( 'Save Council', 'council-debt-counters' ),
+    ];
+    if ( function_exists( 'acf_form' ) ) {
+        acf_form( $args );
+    }
+    echo '</div>';
+    return;
+}
+
+$councils = get_posts([
+    'post_type'   => 'council',
+    'numberposts' => -1,
+    'post_status' => [ 'publish', 'draft' ],
+]);
+?>
+<div class="wrap">
+    <h1><?php esc_html_e( 'Councils', 'council-debt-counters' ); ?></h1>
+    <a href="<?php echo esc_url( admin_url( 'admin.php?page=cdc-manage-councils&action=edit' ) ); ?>" class="btn btn-primary mb-3"><?php esc_html_e( 'Add New', 'council-debt-counters' ); ?></a>
+    <table class="table table-striped">
+        <thead>
+            <tr>
+                <th><?php esc_html_e( 'Name', 'council-debt-counters' ); ?></th>
+                <th><?php esc_html_e( 'Actions', 'council-debt-counters' ); ?></th>
+            </tr>
+        </thead>
+        <tbody>
+            <?php if ( empty( $councils ) ) : ?>
+                <tr><td colspan="2"><?php esc_html_e( 'No councils found.', 'council-debt-counters' ); ?></td></tr>
+            <?php else : foreach ( $councils as $council ) : ?>
+                <tr>
+                    <td><?php echo esc_html( get_the_title( $council ) ); ?></td>
+                    <td>
+                        <a href="<?php echo esc_url( admin_url( 'admin.php?page=cdc-manage-councils&action=edit&post=' . $council->ID ) ); ?>" class="btn btn-sm btn-secondary"><?php esc_html_e( 'Edit', 'council-debt-counters' ); ?></a>
+                        <a href="<?php echo esc_url( wp_nonce_url( admin_url( 'admin.php?page=cdc-manage-councils&action=delete&post=' . $council->ID ), 'cdc_delete_council_' . $council->ID ) ); ?>" class="btn btn-sm btn-danger" onclick="return confirm('<?php esc_attr_e( 'Delete this council?', 'council-debt-counters' ); ?>');"><?php esc_html_e( 'Delete', 'council-debt-counters' ); ?></a>
+                    </td>
+                </tr>
+            <?php endforeach; endif; ?>
+        </tbody>
+    </table>
+    <p><a href="<?php echo esc_url( admin_url( 'edit.php?post_type=acf-field-group' ) ); ?>"><?php esc_html_e( 'Manage field groups', 'council-debt-counters' ); ?></a></p>
+</div>

--- a/council-debt-counters.php
+++ b/council-debt-counters.php
@@ -21,12 +21,14 @@ require_once plugin_dir_path( __FILE__ ) . 'includes/class-error-logger.php';
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-docs-manager.php';
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-license-manager.php';
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-council-post-type.php';
+require_once plugin_dir_path( __FILE__ ) . 'includes/class-council-admin-page.php';
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-acf-manager.php';
 
 add_action( 'plugins_loaded', function() {
     \CouncilDebtCounters\Error_Logger::init();
     \CouncilDebtCounters\Settings_Page::init();
     \CouncilDebtCounters\Council_Post_Type::init();
+    \CouncilDebtCounters\Council_Admin_Page::init();
     \CouncilDebtCounters\ACF_Manager::init();
 } );
 

--- a/includes/class-council-admin-page.php
+++ b/includes/class-council-admin-page.php
@@ -1,0 +1,54 @@
+<?php
+namespace CouncilDebtCounters;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class Council_Admin_Page {
+    const PAGE_SLUG = 'cdc-manage-councils';
+
+    /**
+     * Register hooks.
+     */
+    public static function init() {
+        add_action( 'admin_menu', [ __CLASS__, 'add_page' ] );
+        add_action( 'admin_enqueue_scripts', [ __CLASS__, 'enqueue_assets' ] );
+        add_action( 'admin_head', [ __CLASS__, 'maybe_acf_head' ] );
+    }
+
+    public static function add_page() {
+        add_submenu_page(
+            'council-debt-counters',
+            __( 'Councils', 'council-debt-counters' ),
+            __( 'Councils', 'council-debt-counters' ),
+            'manage_options',
+            self::PAGE_SLUG,
+            [ __CLASS__, 'render_page' ]
+        );
+    }
+
+    public static function enqueue_assets( $hook ) {
+        if ( $hook !== 'debt-counters_page_' . self::PAGE_SLUG ) {
+            return;
+        }
+        wp_enqueue_style( 'bootstrap-5', 'https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/css/bootstrap.min.css', [], '5.3.1' );
+        wp_enqueue_script( 'bootstrap-5', 'https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/js/bootstrap.bundle.min.js', [], '5.3.1', true );
+        if ( function_exists( 'acf_enqueue_uploader' ) ) {
+            acf_enqueue_uploader();
+        }
+    }
+
+    public static function maybe_acf_head() {
+        $screen = get_current_screen();
+        if ( $screen && $screen->id === 'debt-counters_page_' . self::PAGE_SLUG && isset( $_GET['action'] ) && 'edit' === $_GET['action'] ) {
+            if ( function_exists( 'acf_form_head' ) ) {
+                acf_form_head();
+            }
+        }
+    }
+
+    public static function render_page() {
+        include plugin_dir_path( __DIR__ ) . 'admin/views/councils-page.php';
+    }
+}

--- a/includes/class-settings-page.php
+++ b/includes/class-settings-page.php
@@ -6,6 +6,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 use CouncilDebtCounters\Docs_Manager;
+use CouncilDebtCounters\Council_Admin_Page;
 
 class Settings_Page {
 
@@ -29,7 +30,8 @@ class Settings_Page {
             __( 'Councils', 'council-debt-counters' ),
             __( 'Councils', 'council-debt-counters' ),
             'manage_options',
-            'edit.php?post_type=council'
+            Council_Admin_Page::PAGE_SLUG,
+            [ Council_Admin_Page::class, 'render_page' ]
         );
 
         add_submenu_page(


### PR DESCRIPTION
## Summary
- create `Council_Admin_Page` to manage councils in the admin
- load Bootstrap assets for a clean UI
- add new view for adding, editing and deleting councils using ACF forms
- connect the new page via menu and initialization hooks
- update docs about the new council management interface

## Testing
- `composer install`
- `vendor/bin/phpunit` *(fails: Test directory not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847472534408331aa04a71282084391