### PR TITLE
Add admin debt counters and OpenAI API integration prep

### DIFF
--- a/admin/js/council-form.js
+++ b/admin/js/council-form.js
@@ -1,23 +1,52 @@
 (function() {
+    function formatCurrency(val) {
+        if (isNaN(val)) return '';
+        return new Intl.NumberFormat('en-GB', { style: 'currency', currency: 'GBP', maximumFractionDigits: 1 }).format(val);
+    }
+
+    function addHelper(field) {
+        var helper = document.createElement('div');
+        helper.className = 'text-muted mt-1 cdc-helper';
+        field.parentElement.appendChild(helper);
+        function update() {
+            var val = parseFloat(field.value);
+            helper.textContent = val ? formatCurrency(val) : '';
+        }
+        field.addEventListener('input', update);
+        update();
+    }
+
     document.addEventListener('DOMContentLoaded', function() {
-        var totalField = document.querySelector('input[name="acf[field_cdc_total_external_borrowing]"]');
-        if (!totalField) return;
+        document.querySelectorAll('input[type="number"]').forEach(function(field) {
+            addHelper(field);
+        });
 
-        var output = document.createElement('div');
-        output.id = 'cdc-debt-rates';
-        output.className = 'mt-2 alert alert-info';
-        totalField.parentElement.appendChild(output);
-
-        function updateRates() {
-            var val = parseFloat(totalField.value);
-            if (isNaN(val)) val = 0;
-            var perDay = val / 365;
-            var perHour = perDay / 24;
-            var perSecond = perHour / 3600;
-            output.textContent = 'Debt per day: £' + perDay.toFixed(2) + ', per hour: £' + perHour.toFixed(2) + ', per second: £' + perSecond.toFixed(2);
+        var extField = document.querySelector('input[name="acf[field_cdc_total_external_borrowing]"]');
+        var interestField = document.querySelector('input[name="acf[field_cdc_interest_paid]"]');
+        var totalField = document.querySelector('input[name="acf[field_cdc_total_debt]"]');
+        var ratesOutput = document.createElement('div');
+        ratesOutput.id = 'cdc-debt-rates';
+        ratesOutput.className = 'mt-2 alert alert-info';
+        if (extField) {
+            extField.parentElement.appendChild(ratesOutput);
         }
 
-        totalField.addEventListener('input', updateRates);
-        updateRates();
+        function updateAll() {
+            var external = parseFloat(extField ? extField.value : 0) || 0;
+            var interest = parseFloat(interestField ? interestField.value : 0) || 0;
+            var total = external + interest;
+            if (totalField) {
+                totalField.value = total.toFixed(2);
+                totalField.dispatchEvent(new Event('input'));
+            }
+            var perDay = external / 365;
+            var perHour = perDay / 24;
+            var perSecond = perHour / 3600;
+            ratesOutput.textContent = 'Debt per day: £' + perDay.toFixed(2) + ', per hour: £' + perHour.toFixed(2) + ', per second: £' + perSecond.toFixed(2);
+        }
+
+        if (extField) extField.addEventListener('input', updateAll);
+        if (interestField) interestField.addEventListener('input', updateAll);
+        updateAll();
     });
 })();

--- a/admin/views/councils-page.php
+++ b/admin/views/councils-page.php
@@ -43,15 +43,20 @@ $councils = get_posts([
         <thead>
             <tr>
                 <th><?php esc_html_e( 'Name', 'council-debt-counters' ); ?></th>
+                <th><?php esc_html_e( 'Debt Counter', 'council-debt-counters' ); ?></th>
                 <th><?php esc_html_e( 'Actions', 'council-debt-counters' ); ?></th>
             </tr>
         </thead>
         <tbody>
             <?php if ( empty( $councils ) ) : ?>
-                <tr><td colspan="2"><?php esc_html_e( 'No councils found.', 'council-debt-counters' ); ?></td></tr>
+                <tr><td colspan="3"><?php esc_html_e( 'No councils found.', 'council-debt-counters' ); ?></td></tr>
             <?php else : foreach ( $councils as $council ) : ?>
                 <tr>
                     <td><?php echo esc_html( get_the_title( $council ) ); ?></td>
+                    <td>
+                        <?php echo do_shortcode( '[council_counter id="' . $council->ID . '"]' ); ?>
+                        <code>[council_counter id="<?php echo esc_attr( $council->ID ); ?>"]</code>
+                    </td>
                     <td>
                         <a href="<?php echo esc_url( admin_url( 'admin.php?page=cdc-manage-councils&action=edit&post=' . $council->ID ) ); ?>" class="btn btn-sm btn-secondary"><?php esc_html_e( 'Edit', 'council-debt-counters' ); ?></a>
                         <a href="<?php echo esc_url( wp_nonce_url( admin_url( 'admin.php?page=cdc-manage-councils&action=delete&post=' . $council->ID ), 'cdc_delete_council_' . $council->ID ) ); ?>" class="btn btn-sm btn-danger" onclick="return confirm('<?php esc_attr_e( 'Delete this council?', 'council-debt-counters' ); ?>');"><?php esc_html_e( 'Delete', 'council-debt-counters' ); ?></a>

--- a/admin/views/debt-adjustments-page.php
+++ b/admin/views/debt-adjustments-page.php
@@ -1,0 +1,50 @@
+<?php
+use CouncilDebtCounters\Debt_Adjustments_Page;
+
+if ( ! defined( 'ABSPATH' ) ) exit;
+
+$councils = get_posts([
+    'post_type'   => 'council',
+    'numberposts' => -1,
+    'post_status' => [ 'publish', 'draft' ],
+]);
+
+$success = '';
+
+if ( isset( $_POST['cdc_add_adjustment'] ) && isset( $_POST['cdc_council_id'] ) ) {
+    $cid    = intval( $_POST['cdc_council_id'] );
+    $amount = floatval( $_POST['cdc_amount'] );
+    $note   = sanitize_text_field( $_POST['cdc_note'] );
+    Debt_Adjustments_Page::add_adjustment( $cid, $amount, $note );
+    $success = __( 'Adjustment saved.', 'council-debt-counters' );
+}
+?>
+<div class="wrap">
+    <h1><?php esc_html_e( 'Debt Adjustments', 'council-debt-counters' ); ?></h1>
+    <?php if ( $success ) : ?>
+        <div class="notice notice-success"><p><?php echo esc_html( $success ); ?></p></div>
+    <?php endif; ?>
+    <form method="post" class="mb-4">
+        <table class="form-table">
+            <tr>
+                <th scope="row"><label for="cdc_council_id"><?php esc_html_e( 'Council', 'council-debt-counters' ); ?></label></th>
+                <td>
+                    <select name="cdc_council_id" id="cdc_council_id">
+                        <?php foreach ( $councils as $c ) : ?>
+                            <option value="<?php echo esc_attr( $c->ID ); ?>"><?php echo esc_html( get_the_title( $c ) ); ?></option>
+                        <?php endforeach; ?>
+                    </select>
+                </td>
+            </tr>
+            <tr>
+                <th scope="row"><label for="cdc_amount"><?php esc_html_e( 'Amount', 'council-debt-counters' ); ?></label></th>
+                <td><input type="number" name="cdc_amount" id="cdc_amount" step="0.01" required class="regular-text" /></td>
+            </tr>
+            <tr>
+                <th scope="row"><label for="cdc_note"><?php esc_html_e( 'Note', 'council-debt-counters' ); ?></label></th>
+                <td><input type="text" name="cdc_note" id="cdc_note" class="regular-text" /></td>
+            </tr>
+        </table>
+        <p><button type="submit" class="button button-primary" name="cdc_add_adjustment"><?php esc_html_e( 'Add Adjustment', 'council-debt-counters' ); ?></button></p>
+    </form>
+</div>

--- a/admin/views/instructions-page.php
+++ b/admin/views/instructions-page.php
@@ -22,6 +22,13 @@ if ( ! defined( 'ABSPATH' ) ) exit;
                     <p class="description"><?php esc_html_e( 'Enter a valid license key to unlock unlimited councils.', 'council-debt-counters' ); ?></p>
                 </td>
             </tr>
+            <tr>
+                <th scope="row"><label for="cdc_openai_api_key"><?php esc_html_e( 'OpenAI API Key', 'council-debt-counters' ); ?></label></th>
+                <td>
+                    <input name="cdc_openai_api_key" type="text" id="cdc_openai_api_key" value="<?php echo esc_attr( get_option( 'cdc_openai_api_key', '' ) ); ?>" class="regular-text" />
+                    <p class="description"><?php esc_html_e( 'Optional: provide an OpenAI API key to assist with generating council information.', 'council-debt-counters' ); ?></p>
+                </td>
+            </tr>
         </table>
         <?php submit_button(); ?>
     </form>

--- a/council-debt-counters.php
+++ b/council-debt-counters.php
@@ -23,6 +23,8 @@ require_once plugin_dir_path( __FILE__ ) . 'includes/class-license-manager.php';
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-council-post-type.php';
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-council-admin-page.php';
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-acf-manager.php';
+require_once plugin_dir_path( __FILE__ ) . 'includes/class-openai-helper.php';
+require_once plugin_dir_path( __FILE__ ) . 'includes/class-debt-adjustments-page.php';
 
 add_action( 'plugins_loaded', function() {
     \CouncilDebtCounters\Error_Logger::init();
@@ -30,6 +32,8 @@ add_action( 'plugins_loaded', function() {
     \CouncilDebtCounters\Council_Post_Type::init();
     \CouncilDebtCounters\Council_Admin_Page::init();
     \CouncilDebtCounters\ACF_Manager::init();
+    \CouncilDebtCounters\Shortcode_Renderer::init();
+    \CouncilDebtCounters\Debt_Adjustments_Page::init();
 } );
 
 /**

--- a/includes/class-acf-manager.php
+++ b/includes/class-acf-manager.php
@@ -95,6 +95,7 @@ class ACF_Manager {
                     'label' => __( 'Total Debt', 'council-debt-counters' ),
                     'name' => 'total_debt',
                     'type' => 'number',
+                    'readonly' => 1,
                 ],
                 [
                     'key' => 'field_cdc_total_external_borrowing',

--- a/includes/class-debt-adjustments-page.php
+++ b/includes/class-debt-adjustments-page.php
@@ -1,0 +1,43 @@
+<?php
+namespace CouncilDebtCounters;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class Debt_Adjustments_Page {
+    const SLUG = 'cdc-debt-adjustments';
+
+    public static function init() {
+        add_action( 'admin_menu', [ __CLASS__, 'add_menu' ] );
+    }
+
+    public static function add_menu() {
+        add_submenu_page(
+            'council-debt-counters',
+            __( 'Debt Adjustments', 'council-debt-counters' ),
+            __( 'Debt Adjustments', 'council-debt-counters' ),
+            'manage_options',
+            self::SLUG,
+            [ __CLASS__, 'render' ]
+        );
+    }
+
+    public static function render() {
+        include plugin_dir_path( __DIR__ ) . 'admin/views/debt-adjustments-page.php';
+    }
+
+    public static function add_adjustment( int $council_id, float $amount, string $note = '' ) {
+        $entries = get_post_meta( $council_id, 'cdc_debt_adjustments', true );
+        if ( ! is_array( $entries ) ) {
+            $entries = [];
+        }
+        $entries[] = [
+            'amount' => $amount,
+            'note'   => $note,
+            'date'   => current_time( 'mysql' ),
+        ];
+        update_post_meta( $council_id, 'cdc_debt_adjustments', $entries );
+        Error_Logger::log( 'Debt adjustment of ' . $amount . ' added to council ' . $council_id );
+    }
+}

--- a/includes/class-error-logger.php
+++ b/includes/class-error-logger.php
@@ -8,6 +8,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 class Error_Logger {
     const LOG_FILENAME = 'troubleshooting.log';
 
+    public static function log_info( string $message ) {
+        self::log( 'INFO: ' . $message );
+    }
+
     public static function init() {
         set_error_handler( [ __CLASS__, 'handle_error' ] );
         register_shutdown_function( [ __CLASS__, 'handle_shutdown' ] );

--- a/includes/class-openai-helper.php
+++ b/includes/class-openai-helper.php
@@ -1,0 +1,46 @@
+<?php
+namespace CouncilDebtCounters;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class OpenAI_Helper {
+    const API_ENDPOINT = 'https://api.openai.com/v1/chat/completions';
+
+    public static function query( string $prompt ) {
+        $api_key = get_option( 'cdc_openai_api_key', '' );
+        if ( empty( $api_key ) ) {
+            return new \WP_Error( 'missing_key', __( 'OpenAI API key not configured.', 'council-debt-counters' ) );
+        }
+
+        $args = [
+            'headers' => [
+                'Content-Type'  => 'application/json',
+                'Authorization' => 'Bearer ' . $api_key,
+            ],
+            'body'    => wp_json_encode([
+                'model' => 'gpt-3.5-turbo',
+                'messages' => [
+                    [ 'role' => 'user', 'content' => $prompt ]
+                ],
+            ]),
+            'timeout' => 20,
+        ];
+
+        $response = wp_remote_post( self::API_ENDPOINT, $args );
+        if ( is_wp_error( $response ) ) {
+            Error_Logger::log( 'OpenAI API request failed: ' . $response->get_error_message() );
+            return $response;
+        }
+
+        $body = wp_remote_retrieve_body( $response );
+        $data = json_decode( $body, true );
+        if ( isset( $data['choices'][0]['message']['content'] ) ) {
+            return $data['choices'][0]['message']['content'];
+        }
+
+        Error_Logger::log( 'OpenAI API unexpected response: ' . $body );
+        return new \WP_Error( 'invalid_response', __( 'Unexpected response from OpenAI API.', 'council-debt-counters' ) );
+    }
+}

--- a/includes/class-settings-page.php
+++ b/includes/class-settings-page.php
@@ -51,11 +51,21 @@ class Settings_Page {
             'cdc-troubleshooting',
             [ __CLASS__, 'render_troubleshooting_page' ]
         );
+
+        add_submenu_page(
+            'council-debt-counters',
+            __( 'Debt Adjustments', 'council-debt-counters' ),
+            __( 'Debt Adjustments', 'council-debt-counters' ),
+            'manage_options',
+            Debt_Adjustments_Page::SLUG,
+            [ Debt_Adjustments_Page::class, 'render' ]
+        );
     }
 
     public static function register_settings() {
         register_setting( 'council-debt-counters', License_Manager::OPTION_KEY );
         register_setting( 'council-debt-counters', License_Manager::OPTION_VALID );
+        register_setting( 'council-debt-counters', 'cdc_openai_api_key' );
     }
 
     public static function render_page() {

--- a/includes/class-shortcode-renderer.php
+++ b/includes/class-shortcode-renderer.php
@@ -6,5 +6,58 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class Shortcode_Renderer {
-    // Placeholder for future shortcode rendering.
+
+    public static function init() {
+        add_shortcode( 'council_counter', [ __CLASS__, 'render_counter' ] );
+        add_action( 'wp_enqueue_scripts', [ __CLASS__, 'register_assets' ] );
+    }
+
+    public static function register_assets() {
+        wp_register_style( 'cdc-counter', plugins_url( 'public/css/counter.css', dirname( __DIR__ ) . '/council-debt-counters.php' ), [], '0.1.0' );
+        wp_register_script( 'cdc-counter', plugins_url( 'public/js/counter.js', dirname( __DIR__ ) . '/council-debt-counters.php' ), [], '0.1.0', true );
+        wp_register_style( 'bootstrap-5', 'https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/css/bootstrap.min.css', [], '5.3.1' );
+        wp_register_script( 'bootstrap-5', 'https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/js/bootstrap.bundle.min.js', [], '5.3.1', true );
+    }
+
+    public static function render_counter( $atts ) {
+        $atts = shortcode_atts( [ 'id' => 0 ], $atts );
+        $id   = intval( $atts['id'] );
+        if ( ! $id ) {
+            return '';
+        }
+
+        $total = get_field( 'total_debt', $id );
+        if ( ! $total ) {
+            $total = 0;
+        }
+
+        wp_enqueue_style( 'bootstrap-5' );
+        wp_enqueue_style( 'cdc-counter' );
+        wp_enqueue_script( 'bootstrap-5' );
+        wp_enqueue_script( 'cdc-counter' );
+
+        $details  = [
+            'external_borrowing' => get_field( 'total_external_borrowing', $id ),
+            'pwlb'               => get_field( 'pwlb_borrowing', $id ),
+            'cfr'                => get_field( 'capital_financing_requirement', $id ),
+        ];
+
+        ob_start();
+        ?>
+        <div class="cdc-counter-wrapper mb-3">
+            <div class="cdc-counter display-4 fw-bold" data-target="<?php echo esc_attr( $total ); ?>">£0</div>
+            <button class="btn btn-link p-0" type="button" data-bs-toggle="collapse" data-bs-target="#cdc-detail-<?php echo esc_attr( $id ); ?>" aria-expanded="false" aria-controls="cdc-detail-<?php echo esc_attr( $id ); ?>">
+                <?php esc_html_e( 'View details', 'council-debt-counters' ); ?>
+            </button>
+            <div class="collapse" id="cdc-detail-<?php echo esc_attr( $id ); ?>">
+                <ul class="mt-2 list-unstyled">
+                    <li><?php esc_html_e( 'Total External Borrowing:', 'council-debt-counters' ); ?> £<?php echo number_format_i18n( (float) $details['external_borrowing'], 0 ); ?></li>
+                    <li><?php esc_html_e( 'PWLB Borrowing:', 'council-debt-counters' ); ?> £<?php echo number_format_i18n( (float) $details['pwlb'], 0 ); ?></li>
+                    <li><?php esc_html_e( 'Capital Financing Requirement:', 'council-debt-counters' ); ?> £<?php echo number_format_i18n( (float) $details['cfr'], 0 ); ?></li>
+                </ul>
+            </div>
+        </div>
+        <?php
+        return ob_get_clean();
+    }
 }

--- a/public/css/counter.css
+++ b/public/css/counter.css
@@ -1,0 +1,2 @@
+.cdc-counter-wrapper { text-align:center; }
+.cdc-counter { font-family: monospace; letter-spacing:2px; }

--- a/public/js/counter.js
+++ b/public/js/counter.js
@@ -1,0 +1,27 @@
+(function() {
+    function animate(el) {
+        var target = parseFloat(el.dataset.target);
+        if (isNaN(target)) return;
+        var duration = 2000;
+        var step = Math.max(target / (duration / 50), 1);
+        var current = 0;
+        var int = setInterval(function() {
+            current += step;
+            if (current >= target) {
+                current = target;
+                clearInterval(int);
+            }
+            el.textContent = current.toLocaleString('en-GB', {
+                style: 'currency',
+                currency: 'GBP',
+                maximumFractionDigits: 0
+            });
+        }, 50);
+    }
+
+    document.addEventListener('DOMContentLoaded', function() {
+        document.querySelectorAll('.cdc-counter').forEach(function(el) {
+            animate(el);
+        });
+    });
+})();


### PR DESCRIPTION
## Summary
- add OpenAI helper and API key option
- register shortcode for animated debt counters and display counters on admin list
- compute council title from ACF field and auto-calc total debt
- provide debt adjustment admin page
- improve admin helper JS and bootstrap styled counters
- extend logging capabilities

## Testing
- `vendor/bin/phpunit -c phpunit.xml` *(fails: Test directory not found)*

------
https://chatgpt.com/codex/tasks/task_e_68475230f0c483319ba09b6a46415a6d