### PR TITLE
Add remote licence validation with admin UI

### DIFF
--- a/admin/js/license-check.js
+++ b/admin/js/license-check.js
@@ -1,0 +1,32 @@
+(function(){
+    document.addEventListener('DOMContentLoaded', function(){
+        var btn = document.getElementById('cdc-check-license');
+        if(!btn) return;
+        var input = document.getElementById('cdc_license_key');
+        var result = document.getElementById('cdc-license-result');
+        btn.addEventListener('click', function(e){
+            e.preventDefault();
+            if(!input) return;
+            result.textContent = 'Checking...';
+            fetch(ajaxurl, {
+                method: 'POST',
+                headers: {'Content-Type':'application/x-www-form-urlencoded; charset=UTF-8'},
+                body: new URLSearchParams({
+                    action: 'cdc_check_license',
+                    nonce: CDC_LICENSE_CHECK.nonce,
+                    key: input.value
+                })
+            }).then(function(resp){
+                return resp.json();
+            }).then(function(data){
+                if(data.success){
+                    result.textContent = data.data.message;
+                } else {
+                    result.textContent = data.data && data.data.message ? data.data.message : 'Error validating license.';
+                }
+            }).catch(function(){
+                result.textContent = 'Error validating license.';
+            });
+        });
+    });
+})();

--- a/admin/views/instructions-page.php
+++ b/admin/views/instructions-page.php
@@ -19,6 +19,12 @@ if ( ! defined( 'ABSPATH' ) ) exit;
                 <th scope="row"><label for="<?php echo esc_attr( License_Manager::OPTION_KEY ); ?>"><?php esc_html_e( 'License Key', 'council-debt-counters' ); ?></label></th>
                 <td>
                     <input name="<?php echo esc_attr( License_Manager::OPTION_KEY ); ?>" type="text" id="<?php echo esc_attr( License_Manager::OPTION_KEY ); ?>" value="<?php echo esc_attr( License_Manager::get_license_key() ); ?>" class="regular-text" />
+                    <button type="button" id="cdc-check-license" class="button" style="margin-left:10px;">
+                        <?php esc_html_e( 'Check License', 'council-debt-counters' ); ?>
+                    </button>
+                    <p id="cdc-license-result" class="description">
+                        <?php echo License_Manager::is_valid() ? esc_html__( 'License is valid.', 'council-debt-counters' ) : ''; ?>
+                    </p>
                     <p class="description"><?php esc_html_e( 'Enter a valid license key to unlock unlimited councils.', 'council-debt-counters' ); ?></p>
                 </td>
             </tr>

--- a/council-debt-counters.php
+++ b/council-debt-counters.php
@@ -34,6 +34,7 @@ add_action( 'plugins_loaded', function() {
     \CouncilDebtCounters\ACF_Manager::init();
     \CouncilDebtCounters\Shortcode_Renderer::init();
     \CouncilDebtCounters\Debt_Adjustments_Page::init();
+    \CouncilDebtCounters\License_Manager::init();
 } );
 
 /**

--- a/includes/class-license-manager.php
+++ b/includes/class-license-manager.php
@@ -8,6 +8,15 @@ if ( ! defined( 'ABSPATH' ) ) {
 class License_Manager {
     const OPTION_KEY = 'cdc_license_key';
     const OPTION_VALID = 'cdc_license_valid';
+    const API_ENDPOINT = 'https://mikerouse.co.uk/wp-json/wcls/v1/check';
+
+    /**
+     * Register hooks for AJAX and assets.
+     */
+    public static function init() {
+        add_action( 'admin_enqueue_scripts', [ __CLASS__, 'enqueue_assets' ] );
+        add_action( 'wp_ajax_cdc_check_license', [ __CLASS__, 'ajax_check_license' ] );
+    }
 
     /**
      * Determine if the installed license is valid.
@@ -22,5 +31,72 @@ class License_Manager {
      */
     public static function get_license_key() {
         return get_option( self::OPTION_KEY, '' );
+    }
+
+    /**
+     * Enqueue JS for license checking.
+     */
+    public static function enqueue_assets( $hook ) {
+        if ( $hook !== 'toplevel_page_council-debt-counters' ) {
+            return;
+        }
+        wp_enqueue_script(
+            'cdc-license-check',
+            plugins_url( 'admin/js/license-check.js', dirname( __DIR__ ) . '/council-debt-counters.php' ),
+            [],
+            '0.1.0',
+            true
+        );
+        wp_localize_script( 'cdc-license-check', 'CDC_LICENSE_CHECK', [
+            'nonce' => wp_create_nonce( 'cdc_check_license' ),
+        ] );
+    }
+
+    /**
+     * Validate a license key with the remote API.
+     */
+    public static function validate_key( string $key ) {
+        $args = [
+            'headers' => [ 'Content-Type' => 'application/json' ],
+            'body'    => wp_json_encode( [ 'licence_key' => $key ] ),
+            'timeout' => 20,
+        ];
+
+        $response = wp_remote_post( self::API_ENDPOINT, $args );
+        if ( is_wp_error( $response ) ) {
+            Error_Logger::log( 'License check failed: ' . $response->get_error_message() );
+            return $response;
+        }
+
+        $body = wp_remote_retrieve_body( $response );
+        $data = json_decode( $body, true );
+
+        if ( isset( $data['valid'] ) && $data['valid'] && empty( $data['expired'] ) ) {
+            return true;
+        }
+
+        return new \WP_Error( 'invalid_license', __( 'License key is invalid or expired.', 'council-debt-counters' ) );
+    }
+
+    /**
+     * AJAX callback to verify and store the license key.
+     */
+    public static function ajax_check_license() {
+        check_ajax_referer( 'cdc_check_license', 'nonce' );
+        $key = isset( $_POST['key'] ) ? sanitize_text_field( wp_unslash( $_POST['key'] ) ) : '';
+        if ( empty( $key ) ) {
+            wp_send_json_error( [ 'message' => __( 'License key missing.', 'council-debt-counters' ) ] );
+        }
+
+        $result = self::validate_key( $key );
+        update_option( self::OPTION_KEY, $key );
+        if ( true === $result ) {
+            update_option( self::OPTION_VALID, 1 );
+            wp_send_json_success( [ 'message' => __( 'License confirmed.', 'council-debt-counters' ) ] );
+        } else {
+            update_option( self::OPTION_VALID, 0 );
+            $msg = is_wp_error( $result ) ? $result->get_error_message() : __( 'License invalid.', 'council-debt-counters' );
+            wp_send_json_error( [ 'message' => $msg ] );
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add `License_Manager::init()` and hooks for checking license status via AJAX
- enqueue new license check script on the settings page
- add Check License button to the plugin instructions page
- call `License_Manager::init()` on plugin load

## Testing
- `php -l includes/class-license-manager.php`
- `php -l admin/views/instructions-page.php`
- `php -l council-debt-counters.php`
- `vendor/bin/phpunit` *(fails: Test directory not found)*

------
https://chatgpt.com/codex/tasks/task_e_684816bf7b708331837a356b415fd521