### PR TITLE
Allow negative growth in counter

### DIFF
--- a/public/js/counter.js
+++ b/public/js/counter.js
@@ -12,8 +12,8 @@
             if (current >= target) {
                 current = target;
                 clearInterval(int);
-                // If growth rate is set, start real-time increment
-                if (growth > 0) {
+                // If growth rate is set (positive or negative), start real-time update
+                if (growth !== 0) {
                     setInterval(function() {
                         current += growth;
                         el.textContent = current.toLocaleString('en-GB', {


### PR DESCRIPTION
## Summary
- enable realtime interval when growth is negative

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68483368f1a483319edb6790e8049996