### PR TITLE
Update debt formula

### DIFF
--- a/admin/js/council-form.js
+++ b/admin/js/council-form.js
@@ -28,7 +28,10 @@
             }
         });
 
-        var extField = document.querySelector('input[name="acf[field_cdc_total_external_borrowing]"]');
+        var extField = document.querySelector('input[name="acf[field_cdc_total_external_borrowing]"]'); // legacy
+        var shortField = document.querySelector('input[name="acf[field_cdc_short_term_borrowing]"]');
+        var longField = document.querySelector('input[name="acf[field_cdc_long_term_borrowing]"]');
+        var leaseField = document.querySelector('input[name="acf[field_cdc_finance_lease_pfi_liabilities]"]');
         var manualField = document.querySelector('input[name="acf[field_cdc_manual_debt_entry]"]');
         var adjustmentsField = document.querySelector('input[name="acf[field_cdc_debt_adjustments]"]');
         var interestField = document.querySelector('input[name="acf[field_cdc_interest_paid]"]');
@@ -39,7 +42,9 @@
         var ratesOutput = document.createElement('div');
         ratesOutput.id = 'cdc-debt-rates';
         ratesOutput.className = 'mt-2 alert alert-info';
-        if (extField) {
+        if (shortField) {
+            shortField.parentElement.appendChild(ratesOutput);
+        } else if (extField) {
             extField.parentElement.appendChild(ratesOutput);
         }
 
@@ -67,13 +72,15 @@
         setInterval(tick, 1000);
 
         function updateAll() {
-            var external = parseFloat(extField ? extField.value : 0) || 0;
+            var shortVal = parseFloat(shortField ? shortField.value : 0) || 0;
+            var longVal = parseFloat(longField ? longField.value : 0) || 0;
+            var leaseVal = parseFloat(leaseField ? leaseField.value : 0) || 0;
             var manual = parseFloat(manualField ? manualField.value : 0) || 0;
             var adjustments = parseFloat(adjustmentsField ? adjustmentsField.value : 0) || 0;
             var interest = parseFloat(interestField ? interestField.value : 0) || 0;
             var mrp = parseFloat(mrpField ? mrpField.value : 0) || 0;
-            // Only use external + manual + adjustments for total debt
-            var total = external + manual + adjustments;
+            // Total debt is short term + long term + lease/PFI + manual + adjustments
+            var total = shortVal + longVal + leaseVal + manual + adjustments;
             if (totalField) {
                 totalField.value = total.toFixed(2);
                 totalField.dispatchEvent(new Event('input'));
@@ -89,7 +96,10 @@
             rateDisplay.textContent = 'Growth per second: £' + growthPerSecond.toFixed(6);
         }
 
-        if (extField) extField.addEventListener('input', updateAll);
+        if (shortField) shortField.addEventListener('input', updateAll);
+        if (longField) longField.addEventListener('input', updateAll);
+        if (leaseField) leaseField.addEventListener('input', updateAll);
+        if (extField) extField.addEventListener('input', updateAll); // legacy
         if (interestField) interestField.addEventListener('input', updateAll);
         if (mrpField) mrpField.addEventListener('input', updateAll);
         if (pwlbField) pwlbField.addEventListener('input', updateAll);
@@ -98,7 +108,7 @@
         // Add explainer for calculation
         var explainer = document.createElement('div');
         explainer.className = 'alert alert-warning mt-2';
-        explainer.innerHTML = 'Total debt is calculated as: <strong>Total External Borrowing + Adjustments + Manual Entry (if any)</strong>. PWLB and CFR are shown for reference only. Interest is not added to the debt figure.';
+        explainer.innerHTML = 'Total debt is calculated as: <strong>Short-Term Borrowing + Long-Term Borrowing + Finance Lease/PFI Liabilities + Adjustments + Manual Entry (if any)</strong>. PWLB and CFR are shown for reference only. Interest is not added to the debt figure.';
         sidebar.querySelector('.card-body').appendChild(explainer);
     });
 })();

--- a/includes/class-council-post-type.php
+++ b/includes/class-council-post-type.php
@@ -14,6 +14,7 @@ class Council_Post_Type {
         add_action( 'load-post-new.php', [ __CLASS__, 'enforce_limit' ] );
         add_action( 'acf/save_post', [ __CLASS__, 'sync_title_from_acf' ], 20 );
         add_action( 'acf/save_post', [ __CLASS__, 'calculate_total_debt' ], 20 );
+        add_action( 'save_post_council', [ __CLASS__, 'calculate_total_debt' ], 20, 1 );
     }
 
     /**
@@ -76,8 +77,10 @@ class Council_Post_Type {
             return;
         }
         // Get all relevant fields
-        $external = (float) get_field( 'total_external_borrowing', $post_id );
-        $manual   = (float) get_field( 'manual_debt_entry', $post_id ); // If you have a manual field
+        $short_term = (float) get_field( 'short_term_borrowing', $post_id );
+        $long_term  = (float) get_field( 'long_term_borrowing', $post_id );
+        $lease_pfi  = (float) get_field( 'finance_lease_pfi_liabilities', $post_id );
+        $manual     = (float) get_field( 'manual_debt_entry', $post_id ); // If you have a manual field
         $adjust   = 0;
         $entries  = get_post_meta( $post_id, 'cdc_debt_adjustments', true );
         if ( is_array( $entries ) ) {
@@ -85,8 +88,8 @@ class Council_Post_Type {
                 $adjust += (float) $e['amount'];
             }
         }
-        // Total debt is just external borrowing + manual + adjustments
-        $total = $external + $manual + $adjust;
+        // Total debt is short term + long term + lease/PFI + manual + adjustments
+        $total = $short_term + $long_term + $lease_pfi + $manual + $adjust;
         update_field( 'total_debt', $total, $post_id );
     }
 }

--- a/includes/class-shortcode-renderer.php
+++ b/includes/class-shortcode-renderer.php
@@ -147,7 +147,7 @@ class Shortcode_Renderer {
                 </div>
                 <?php endif; ?>
                 <div class="alert alert-warning mt-2">
-                    <?php esc_html_e( 'Total debt is calculated as: Total External Borrowing + Adjustments + Manual Entry (if any). PWLB and CFR are shown for reference only. Interest is not added to the debt figure. This counter is an estimate. It assumes the council will pay the same amount of interest on its debt as last year, spread evenly over the year. In reality, the council could pay off debt faster or slower, refinance at a different rate, or borrow more. The actual interest paid will only be known when the next set of financial statements is published. This is just a live estimate, not an official figure.', 'council-debt-counters' ); ?>
+                    <?php esc_html_e( 'Total debt is calculated as: Short-Term Borrowing + Long-Term Borrowing + Finance Lease/PFI Liabilities + Adjustments + Manual Entry (if any). PWLB and CFR are shown for reference only. Interest is not added to the debt figure. This counter is an estimate. It assumes the council will pay the same amount of interest on its debt as last year, spread evenly over the year. In reality, the council could pay off debt faster or slower, refinance at a different rate, or borrow more. The actual interest paid will only be known when the next set of financial statements is published. This is just a live estimate, not an official figure.', 'council-debt-counters' ); ?>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- recalc total debt after each `save_post_council`
- compute debt from short/long term borrowing and finance lease/PFI liabilities
- show new debt formula in admin form and shortcode output

## Testing
- `composer install`
- `vendor/bin/phpunit` *(fails: Test directory not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848334c204c8331b69fce71d8cae0e5