### PR TITLE
Add borrowing fields

### DIFF
--- a/includes/class-acf-manager.php
+++ b/includes/class-acf-manager.php
@@ -112,6 +112,27 @@ class ACF_Manager {
                     'required' => 1,
                 ],
                 [
+                    'key' => 'field_cdc_short_term_borrowing',
+                    'label' => __( 'Short-term Borrowing', 'council-debt-counters' ),
+                    'name' => 'short_term_borrowing',
+                    'type' => 'number',
+                    'instructions' => __( 'Refer to the council\'s Statement of Accounts.', 'council-debt-counters' ),
+                ],
+                [
+                    'key' => 'field_cdc_long_term_borrowing',
+                    'label' => __( 'Long-term Borrowing', 'council-debt-counters' ),
+                    'name' => 'long_term_borrowing',
+                    'type' => 'number',
+                    'instructions' => __( 'Refer to the council\'s Statement of Accounts.', 'council-debt-counters' ),
+                ],
+                [
+                    'key' => 'field_cdc_pfi_lease_liabilities',
+                    'label' => __( 'PFI or Finance Lease Liabilities', 'council-debt-counters' ),
+                    'name' => 'pfi_or_finance_lease_liabilities',
+                    'type' => 'number',
+                    'instructions' => __( 'Refer to the council\'s Statement of Accounts.', 'council-debt-counters' ),
+                ],
+                [
                     'key' => 'field_cdc_interest_paid',
                     'label' => __( 'Interest Paid on Debt', 'council-debt-counters' ),
                     'name' => 'interest_paid_on_debt',


### PR DESCRIPTION
## Summary
- register short/long term borrowing and finance lease ACF fields
- include instructions pointing admins to councils' Statement of Accounts

## Testing
- `vendor/bin/phpunit`
- `composer validate`

------
https://chatgpt.com/codex/tasks/task_e_6848335d73108331aaeac8402b3d4e6d