### PR TITLE
Add nonce check for debt adjustments

### DIFF
--- a/admin/views/debt-adjustments-page.php
+++ b/admin/views/debt-adjustments-page.php
@@ -10,13 +10,18 @@ $councils = get_posts([
 ]);
 
 $success = '';
+$error   = '';
 
 if ( isset( $_POST['cdc_add_adjustment'] ) && isset( $_POST['cdc_council_id'] ) ) {
-    $cid    = intval( $_POST['cdc_council_id'] );
-    $amount = floatval( $_POST['cdc_amount'] );
-    $note   = sanitize_text_field( $_POST['cdc_note'] );
-    Debt_Adjustments_Page::add_adjustment( $cid, $amount, $note );
-    $success = __( 'Adjustment saved.', 'council-debt-counters' );
+    if ( ! check_admin_referer( 'cdc_add_adjustment', 'cdc_adjust_nonce', false ) ) {
+        $error = __( 'Security check failed.', 'council-debt-counters' );
+    } else {
+        $cid    = intval( $_POST['cdc_council_id'] );
+        $amount = floatval( $_POST['cdc_amount'] );
+        $note   = sanitize_text_field( $_POST['cdc_note'] );
+        Debt_Adjustments_Page::add_adjustment( $cid, $amount, $note );
+        $success = __( 'Adjustment saved.', 'council-debt-counters' );
+    }
 }
 ?>
 <div class="wrap">
@@ -24,7 +29,11 @@ if ( isset( $_POST['cdc_add_adjustment'] ) && isset( $_POST['cdc_council_id'] ) 
     <?php if ( $success ) : ?>
         <div class="notice notice-success"><p><?php echo esc_html( $success ); ?></p></div>
     <?php endif; ?>
+    <?php if ( $error ) : ?>
+        <div class="notice notice-error"><p><?php echo esc_html( $error ); ?></p></div>
+    <?php endif; ?>
     <form method="post" class="mb-4">
+        <?php wp_nonce_field( 'cdc_add_adjustment', 'cdc_adjust_nonce' ); ?>
         <table class="form-table">
             <tr>
                 <th scope="row"><label for="cdc_council_id"><?php esc_html_e( 'Council', 'council-debt-counters' ); ?></label></th>


### PR DESCRIPTION
## Summary
- secure Debt Adjustments admin form with a nonce

## Testing
- `php -l admin/views/debt-adjustments-page.php`
- `vendor/bin/phpunit -c phpunit.xml` *(fails: Test directory not found)*

------
https://chatgpt.com/codex/tasks/task_e_68483371d2808331ae75eaa559692600