### PR TITLE
Improve counter accessibility

### DIFF
--- a/admin/js/council-form.js
+++ b/admin/js/council-form.js
@@ -49,7 +49,7 @@
         sidebar.style.width = '18rem';
         sidebar.innerHTML = '<div class="card-body">' +
             '<h5 class="card-title">Live Counter</h5>' +
-            '<div id="cdc-counter-display" class="h3" aria-live="polite">£0</div>' +
+            '<div id="cdc-counter-display" class="h3" role="status" aria-live="polite">£0</div>' +
             '<p id="cdc-counter-rate" class="mb-0"></p>' +
             '</div>';
         document.body.appendChild(sidebar);

--- a/includes/class-shortcode-renderer.php
+++ b/includes/class-shortcode-renderer.php
@@ -111,7 +111,7 @@ class Shortcode_Renderer {
         ob_start();
         ?>
         <div class="cdc-counter-wrapper mb-3">
-            <div class="cdc-counter display-4 fw-bold" data-target="<?php echo esc_attr( $total + ($growth_per_second * $elapsed_seconds) ); ?>" data-growth="<?php echo esc_attr( $growth_per_second ); ?>" data-start="<?php echo esc_attr( $start_value ); ?>">
+            <div class="cdc-counter display-4 fw-bold" role="status" aria-live="polite" data-target="<?php echo esc_attr( $total + ($growth_per_second * $elapsed_seconds) ); ?>" data-growth="<?php echo esc_attr( $growth_per_second ); ?>" data-start="<?php echo esc_attr( $start_value ); ?>">
                 £0
             </div>
             <button class="btn btn-link p-0" type="button" data-bs-toggle="collapse" data-bs-target="#cdc-detail-<?php echo esc_attr( $id ); ?>" aria-expanded="false" aria-controls="cdc-detail-<?php echo esc_attr( $id ); ?>">


### PR DESCRIPTION
## Summary
- add `role="status"` to admin sidebar counter
- add `role="status"` to shortcode counter for frontend

## Testing
- `vendor/bin/phpunit` *(fails: Test directory not found)*

------
https://chatgpt.com/codex/tasks/task_e_68483373b1e08331a93727b1fc0dd64c