### PR TITLE
Remove PWLB field and references

### DIFF
--- a/admin/js/council-form.js
+++ b/admin/js/council-form.js
@@ -36,7 +36,6 @@
         var adjustmentsField = document.querySelector('input[name="acf[field_cdc_debt_adjustments]"]');
         var interestField = document.querySelector('input[name="acf[field_cdc_interest_paid]"]');
         var mrpField = document.querySelector('input[name="acf[field_cdc_mrp]"]');
-        var pwlbField = document.querySelector('input[name="acf[field_cdc_pwlb_borrowing]"]');
         var cfrField = document.querySelector('input[name="acf[field_cdc_cfr]"]');
         var totalField = document.querySelector('input[name="acf[field_cdc_total_debt]"]');
         var ratesOutput = document.createElement('div');
@@ -102,13 +101,12 @@
         if (extField) extField.addEventListener('input', updateAll); // legacy
         if (interestField) interestField.addEventListener('input', updateAll);
         if (mrpField) mrpField.addEventListener('input', updateAll);
-        if (pwlbField) pwlbField.addEventListener('input', updateAll);
         if (cfrField) cfrField.addEventListener('input', updateAll);
         updateAll();
         // Add explainer for calculation
         var explainer = document.createElement('div');
         explainer.className = 'alert alert-warning mt-2';
-        explainer.innerHTML = 'Total debt is calculated as: <strong>Short-Term Borrowing + Long-Term Borrowing + Finance Lease/PFI Liabilities + Adjustments + Manual Entry (if any)</strong>. PWLB and CFR are shown for reference only. Interest is not added to the debt figure.';
+        explainer.innerHTML = 'Total debt is calculated as: <strong>Short-Term Borrowing + Long-Term Borrowing + Finance Lease/PFI Liabilities + Adjustments + Manual Entry (if any)</strong>. CFR is shown for reference only. Interest is not added to the debt figure.';
         sidebar.querySelector('.card-body').appendChild(explainer);
     });
 })();

--- a/includes/class-acf-manager.php
+++ b/includes/class-acf-manager.php
@@ -105,13 +105,6 @@ class ACF_Manager {
                     'required' => 1,
                 ],
                 [
-                    'key' => 'field_cdc_pwlb_borrowing',
-                    'label' => __( 'Public Works Loan Board (PWLB) Borrowing', 'council-debt-counters' ),
-                    'name' => 'pwlb_borrowing',
-                    'type' => 'number',
-                    'required' => 1,
-                ],
-                [
                     'key' => 'field_cdc_short_term_borrowing',
                     'label' => __( 'Short-term Borrowing', 'council-debt-counters' ),
                     'name' => 'short_term_borrowing',

--- a/includes/class-shortcode-renderer.php
+++ b/includes/class-shortcode-renderer.php
@@ -54,7 +54,6 @@ class Shortcode_Renderer {
 
         $details  = [
             'external_borrowing' => get_field( 'total_external_borrowing', $id ),
-            'pwlb'               => get_field( 'pwlb_borrowing', $id ),
             'cfr'                => get_field( 'capital_financing_requirement', $id ),
             'interest'           => $interest,
             'mrp'                => $mrp,
@@ -120,7 +119,6 @@ class Shortcode_Renderer {
             <div class="collapse" id="cdc-detail-<?php echo esc_attr( $id ); ?>">
                 <ul class="mt-2 list-unstyled">
                     <li><?php esc_html_e( 'Total External Borrowing:', 'council-debt-counters' ); ?> £<?php echo number_format_i18n( (float) $details['external_borrowing'], 0 ); ?></li>
-                    <li><?php esc_html_e( 'PWLB Borrowing:', 'council-debt-counters' ); ?> £<?php echo number_format_i18n( (float) $details['pwlb'], 0 ); ?></li>
                     <li><?php esc_html_e( 'Capital Financing Requirement:', 'council-debt-counters' ); ?> £<?php echo number_format_i18n( (float) $details['cfr'], 0 ); ?></li>
                     <li><?php esc_html_e( 'Interest Paid on Debt (annual):', 'council-debt-counters' ); ?> £<?php echo number_format_i18n( (float) $details['interest'], 0 ); ?></li>
                     <li><?php esc_html_e( 'Minimum Revenue Provision (annual):', 'council-debt-counters' ); ?> £<?php echo number_format_i18n( (float) $details['mrp'], 0 ); ?></li>
@@ -147,7 +145,7 @@ class Shortcode_Renderer {
                 </div>
                 <?php endif; ?>
                 <div class="alert alert-warning mt-2">
-                    <?php esc_html_e( 'Total debt is calculated as: Short-Term Borrowing + Long-Term Borrowing + Finance Lease/PFI Liabilities + Adjustments + Manual Entry (if any). PWLB and CFR are shown for reference only. Interest is not added to the debt figure. This counter is an estimate. It assumes the council will pay the same amount of interest on its debt as last year, spread evenly over the year. In reality, the council could pay off debt faster or slower, refinance at a different rate, or borrow more. The actual interest paid will only be known when the next set of financial statements is published. This is just a live estimate, not an official figure.', 'council-debt-counters' ); ?>
+                    <?php esc_html_e( 'Total debt is calculated as: Short-Term Borrowing + Long-Term Borrowing + Finance Lease/PFI Liabilities + Adjustments + Manual Entry (if any). CFR is shown for reference only. Interest is not added to the debt figure. This counter is an estimate. It assumes the council will pay the same amount of interest on its debt as last year, spread evenly over the year. In reality, the council could pay off debt faster or slower, refinance at a different rate, or borrow more. The actual interest paid will only be known when the next set of financial statements is published. This is just a live estimate, not an official figure.', 'council-debt-counters' ); ?>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- drop `pwlb_borrowing` ACF field
- remove PWLB from shortcode details and info message
- strip PWLB handling from admin JS

## Testing
- `vendor/bin/phpunit -c phpunit.xml` *(fails: Test directory "././tests" not found)*

------
https://chatgpt.com/codex/tasks/task_e_684844cc9b28833197d5edfc77863719