### PR TITLE
Fix FY comment and remove obsolete note

### DIFF
--- a/includes/class-shortcode-renderer.php
+++ b/includes/class-shortcode-renderer.php
@@ -36,7 +36,8 @@ class Shortcode_Renderer {
         $net_growth_per_year = $interest - $mrp;
         $growth_per_second = $net_growth_per_year / (365 * 24 * 60 * 60);
 
-        // UK Financial Year Start Date is 1 April
+        // Council balance sheets cover the year ending 31 March.
+        // Calculations therefore start on 1 April.
         $year = date('Y');
         $now = time();
         $fy_start = strtotime("$year-04-01");
@@ -58,7 +59,7 @@ class Shortcode_Renderer {
             'cfr'                => get_field( 'capital_financing_requirement', $id ),
             'interest'           => $interest,
             'mrp'                => $mrp,
-            'counter_start_date' => null, // removed, always 6 April
+            'counter_start_date' => null, // removed
         ];
 
         // Get band property counts


### PR DESCRIPTION
## Summary
- update FY comment to mention balance sheets up to 31 March
- drop 'always 6 April' note from `$details`

## Testing
- `composer install`
- `./vendor/bin/phpunit` *(fails: Test directory not found)*

------
https://chatgpt.com/codex/tasks/task_e_684844f339d883319f5690e830d75f4e