### PR TITLE
Remove unused council fields

### DIFF
--- a/admin/js/council-form.js
+++ b/admin/js/council-form.js
@@ -22,13 +22,11 @@
             var name = field.getAttribute('name') || '';
             var isBand = /acf\[field_cdc_band_[a-h]_props?\]/i.test(name);
             var isPopulation = name === 'acf[field_cdc_population]';
-            var isMembers = name === 'acf[field_cdc_elected_members]';
-            if (!isBand && !isPopulation && !isMembers) {
+            if (!isBand && !isPopulation) {
                 addHelper(field);
             }
         });
 
-        var extField = document.querySelector('input[name="acf[field_cdc_total_external_borrowing]"]'); // legacy
         var shortField = document.querySelector('input[name="acf[field_cdc_current_liabilities]"]');
         var longField = document.querySelector('input[name="acf[field_cdc_long_term_liabilities]"]');
         var leaseField = document.querySelector('input[name="acf[field_cdc_finance_lease_pfi_liabilities]"]');
@@ -36,15 +34,12 @@
         var adjustmentsField = document.querySelector('input[name="acf[field_cdc_debt_adjustments]"]');
         var interestField = document.querySelector('input[name="acf[field_cdc_interest_paid]"]');
         var mrpField = document.querySelector('input[name="acf[field_cdc_mrp]"]');
-        var cfrField = document.querySelector('input[name="acf[field_cdc_cfr]"]');
         var totalField = document.querySelector('input[name="acf[field_cdc_total_debt]"]');
         var ratesOutput = document.createElement('div');
         ratesOutput.id = 'cdc-debt-rates';
         ratesOutput.className = 'mt-2 alert alert-info';
         if (shortField) {
             shortField.parentElement.appendChild(ratesOutput);
-        } else if (extField) {
-            extField.parentElement.appendChild(ratesOutput);
         }
 
         var sidebar = document.createElement('div');
@@ -98,10 +93,8 @@
         if (shortField) shortField.addEventListener('input', updateAll);
         if (longField) longField.addEventListener('input', updateAll);
         if (leaseField) leaseField.addEventListener('input', updateAll);
-        if (extField) extField.addEventListener('input', updateAll); // legacy
         if (interestField) interestField.addEventListener('input', updateAll);
         if (mrpField) mrpField.addEventListener('input', updateAll);
-        if (cfrField) cfrField.addEventListener('input', updateAll);
         updateAll();
         // Add explainer for calculation
         var explainer = document.createElement('div');

--- a/includes/class-acf-manager.php
+++ b/includes/class-acf-manager.php
@@ -79,18 +79,6 @@ class ACF_Manager {
                     'type' => 'number',
                 ],
                 [
-                    'key' => 'field_cdc_elected_members',
-                    'label' => __( 'Elected Members', 'council-debt-counters' ),
-                    'name' => 'elected_members',
-                    'type' => 'number',
-                ],
-                [
-                    'key' => 'field_cdc_council_tax_revenue',
-                    'label' => __( 'Annual Council Tax Revenue', 'council-debt-counters' ),
-                    'name' => 'council_tax_revenue',
-                    'type' => 'number',
-                ],
-                [
                     'key' => 'field_cdc_total_debt',
                     'label' => __( 'Total Debt', 'council-debt-counters' ),
                     'name' => 'total_debt',
@@ -98,16 +86,10 @@ class ACF_Manager {
                     'readonly' => 1,
                 ],
                 [
-                    'key' => 'field_cdc_total_external_borrowing',
-                    'label' => __( 'Total External Borrowing (Loans Outstanding)', 'council-debt-counters' ),
-                    'name' => 'total_external_borrowing',
-                    'type' => 'number',
-                    'required' => 1,
-                ],
-                [
                     'key' => 'field_cdc_current_liabilities',
                     'label' => __( 'Current Liabilities', 'council-debt-counters' ),
                     'name' => 'current_liabilities',
+                    'type' => 'number',
                 ],
                 [
                     'key' => 'field_cdc_short_term_borrowing',
@@ -134,13 +116,6 @@ class ACF_Manager {
                     'key' => 'field_cdc_interest_paid',
                     'label' => __( 'Interest Paid on Debt', 'council-debt-counters' ),
                     'name' => 'interest_paid_on_debt',
-                    'type' => 'number',
-                    'required' => 1,
-                ],
-                [
-                    'key' => 'field_cdc_cfr',
-                    'label' => __( 'Capital Financing Requirement (CFR)', 'council-debt-counters' ),
-                    'name' => 'capital_financing_requirement',
                     'type' => 'number',
                     'required' => 1,
                 ],

--- a/includes/class-shortcode-renderer.php
+++ b/includes/class-shortcode-renderer.php
@@ -54,8 +54,6 @@ class Shortcode_Renderer {
         wp_enqueue_script( 'cdc-counter' );
 
         $details  = [
-            'external_borrowing' => get_field( 'total_external_borrowing', $id ),
-            'cfr'                => get_field( 'capital_financing_requirement', $id ),
             'interest'           => $interest,
             'mrp'                => $mrp,
             'counter_start_date' => null, // removed
@@ -119,8 +117,6 @@ class Shortcode_Renderer {
             </button>
             <div class="collapse" id="cdc-detail-<?php echo esc_attr( $id ); ?>">
                 <ul class="mt-2 list-unstyled">
-                    <li><?php esc_html_e( 'Total External Borrowing:', 'council-debt-counters' ); ?> £<?php echo number_format_i18n( (float) $details['external_borrowing'], 0 ); ?></li>
-                    <li><?php esc_html_e( 'Capital Financing Requirement:', 'council-debt-counters' ); ?> £<?php echo number_format_i18n( (float) $details['cfr'], 0 ); ?></li>
                     <li><?php esc_html_e( 'Interest Paid on Debt (annual):', 'council-debt-counters' ); ?> £<?php echo number_format_i18n( (float) $details['interest'], 0 ); ?></li>
                     <li><?php esc_html_e( 'Minimum Revenue Provision (annual):', 'council-debt-counters' ); ?> £<?php echo number_format_i18n( (float) $details['mrp'], 0 ); ?></li>
                     <li><?php esc_html_e( 'Net growth/reduction per second:', 'council-debt-counters' ); ?> £<?php echo number_format_i18n( $growth_per_second, 6 ); ?></li>


### PR DESCRIPTION
## Summary
- drop unused external borrowing, CFR, council tax revenue and elected members fields
- add missing type attribute to Current Liabilities
- update admin JS helpers
- trim shortcode detail output

## Testing
- `vendor/bin/phpunit` *(fails: Test directory not found)*

------
https://chatgpt.com/codex/tasks/task_e_68485006b0488331bbf51bfe1808ec9e