### PR TITLE
Implement security and formatting updates

### DIFF
--- a/admin/js/license-check.js
+++ b/admin/js/license-check.js
@@ -7,7 +7,7 @@
         btn.addEventListener('click', function(e){
             e.preventDefault();
             if(!input) return;
-            result.textContent = 'Checking...';
+            result.textContent = CDC_LICENSE_CHECK.checkingText;
             fetch(ajaxurl, {
                 method: 'POST',
                 headers: {'Content-Type':'application/x-www-form-urlencoded; charset=UTF-8'},
@@ -22,10 +22,10 @@
                 if(data.success){
                     result.textContent = data.data.message;
                 } else {
-                    result.textContent = data.data && data.data.message ? data.data.message : 'Error validating license.';
+                    result.textContent = data.data && data.data.message ? data.data.message : CDC_LICENSE_CHECK.errorText;
                 }
             }).catch(function(){
-                result.textContent = 'Error validating license.';
+                result.textContent = CDC_LICENSE_CHECK.errorText;
             });
         });
     });

--- a/admin/views/docs-manager-page.php
+++ b/admin/views/docs-manager-page.php
@@ -9,7 +9,7 @@ $can_upload = Docs_Manager::can_upload();
 $is_pro = License_Manager::is_valid();
 $upload_error = '';
 
-if ( isset( $_POST['cdc_delete_doc'] ) && isset( $_POST['cdc_doc_name'] ) ) {
+if ( isset( $_POST['cdc_delete_doc'], $_POST['cdc_doc_name'], $_POST['cdc_delete_doc_nonce'] ) && wp_verify_nonce( $_POST['cdc_delete_doc_nonce'], 'cdc_delete_doc' ) ) {
     Docs_Manager::delete_document( sanitize_file_name( $_POST['cdc_doc_name'] ) );
     echo '<div class="notice notice-success"><p>' . esc_html__( 'Document deleted.', 'council-debt-counters' ) . '</p></div>';
     $docs = Docs_Manager::list_documents();
@@ -58,6 +58,7 @@ if ( isset( $_FILES['cdc_upload_doc'] ) && $_FILES['cdc_upload_doc']['size'] > 0
                     <td>
                         <form method="post" style="display:inline;">
                             <input type="hidden" name="cdc_doc_name" value="<?php echo esc_attr( $doc ); ?>" />
+                            <?php wp_nonce_field( 'cdc_delete_doc', 'cdc_delete_doc_nonce' ); ?>
                             <button type="submit" name="cdc_delete_doc" class="button button-secondary" onclick="return confirm('<?php esc_attr_e( 'Are you sure you want to delete this document?', 'council-debt-counters' ); ?>');"><?php esc_html_e( 'Delete', 'council-debt-counters' ); ?></button>
                         </form>
                         <a href="<?php echo esc_url( plugins_url( 'docs/' . $doc, dirname( __DIR__, 2 ) . '/council-debt-counters.php' ) ); ?>" target="_blank" rel="noopener noreferrer" class="button">View</a>

--- a/includes/class-license-manager.php
+++ b/includes/class-license-manager.php
@@ -48,7 +48,9 @@ class License_Manager {
             true
         );
         wp_localize_script( 'cdc-license-check', 'CDC_LICENSE_CHECK', [
-            'nonce' => wp_create_nonce( 'cdc_check_license' ),
+            'nonce'        => wp_create_nonce( 'cdc_check_license' ),
+            'checkingText' => __( 'Checking...', 'council-debt-counters' ),
+            'errorText'    => __( 'Error validating license.', 'council-debt-counters' ),
         ] );
     }
 

--- a/includes/class-shortcode-renderer.php
+++ b/includes/class-shortcode-renderer.php
@@ -110,7 +110,7 @@ class Shortcode_Renderer {
         ?>
         <div class="cdc-counter-wrapper mb-3">
             <div class="cdc-counter display-4 fw-bold" role="status" aria-live="polite" data-target="<?php echo esc_attr( $total + ($growth_per_second * $elapsed_seconds) ); ?>" data-growth="<?php echo esc_attr( $growth_per_second ); ?>" data-start="<?php echo esc_attr( $start_value ); ?>">
-                £0
+                £0.00
             </div>
             <button class="btn btn-link p-0" type="button" data-bs-toggle="collapse" data-bs-target="#cdc-detail-<?php echo esc_attr( $id ); ?>" aria-expanded="false" aria-controls="cdc-detail-<?php echo esc_attr( $id ); ?>">
                 <?php esc_html_e( 'View details', 'council-debt-counters' ); ?>
@@ -121,15 +121,17 @@ class Shortcode_Renderer {
                     <li><?php esc_html_e( 'Minimum Revenue Provision (annual):', 'council-debt-counters' ); ?> £<?php echo number_format_i18n( (float) $details['mrp'], 0 ); ?></li>
                     <li><?php esc_html_e( 'Net growth/reduction per second:', 'council-debt-counters' ); ?> £<?php echo number_format_i18n( $growth_per_second, 6 ); ?></li>
                 </ul>
-                <h5><?php esc_html_e( 'Debt per property by Council Tax Band:', 'council-debt-counters' ); ?></h5>
-                <ul class="mt-2 list-unstyled">
-                <?php foreach ( $bands as $band => $count ) :
-                    if ( $count > 0 ) :
-                        $debt_per_property = $total / $count;
-                ?>
-                    <li><?php echo esc_html( sprintf( 'Band %s: £%s per property', $band, number_format_i18n( $debt_per_property, 0 ) ) ); ?></li>
-                <?php endif; endforeach; ?>
-                </ul>
+                <?php if ( array_sum( $bands ) > 0 ) : ?>
+                    <h5><?php esc_html_e( 'Debt per property by Council Tax Band:', 'council-debt-counters' ); ?></h5>
+                    <ul class="mt-2 list-unstyled">
+                    <?php foreach ( $bands as $band => $count ) :
+                        if ( $count > 0 ) :
+                            $debt_per_property = $total / $count;
+                    ?>
+                        <li><?php echo esc_html( sprintf( 'Band %s: £%s per property', $band, number_format_i18n( $debt_per_property, 0 ) ) ); ?></li>
+                    <?php endif; endforeach; ?>
+                    </ul>
+                <?php endif; ?>
                 <?php if ( $population > 0 ) : ?>
                 <h5><?php esc_html_e( 'Debt per person:', 'council-debt-counters' ); ?></h5>
                 <ul class="mt-2 list-unstyled">

--- a/public/js/counter.js
+++ b/public/js/counter.js
@@ -19,7 +19,8 @@
                         el.textContent = current.toLocaleString('en-GB', {
                             style: 'currency',
                             currency: 'GBP',
-                            maximumFractionDigits: 0
+                            minimumFractionDigits: 2,
+                            maximumFractionDigits: 2
                         });
                     }, 1000);
                 }
@@ -27,7 +28,8 @@
             el.textContent = current.toLocaleString('en-GB', {
                 style: 'currency',
                 currency: 'GBP',
-                maximumFractionDigits: 0
+                minimumFractionDigits: 2,
+                maximumFractionDigits: 2
             });
         }, 50);
     }


### PR DESCRIPTION
## Summary
- ensure counter shows pennies
- hide header when no council tax band data exists
- protect document deletion with nonce
- localize license check status text

## Testing
- `composer install`
- `vendor/bin/phpunit` *(fails: Test directory not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b480a898883318a2d971687ae9b6d