### PR TITLE
Add Statement of Accounts upload field

### DIFF
--- a/admin/views/councils-page.php
+++ b/admin/views/councils-page.php
@@ -27,6 +27,29 @@ if ( $action === 'edit' ) {
                 $required = $field->required ? 'required' : '';
                 $readonly = in_array( $field->name, \CouncilDebtCounters\Custom_Fields::READONLY_FIELDS, true );
             ?>
+            <?php if ( $field->name === 'statement_of_accounts' ) : ?>
+            <tr>
+                <th scope="row"><label for="cdc-soa"><?php echo esc_html( $field->label ); ?></label></th>
+                <td>
+                    <?php if ( $val ) : ?>
+                        <p><a href="<?php echo esc_url( plugins_url( 'docs/' . $val, dirname( __DIR__, 2 ) . '/council-debt-counters.php' ) ); ?>" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'View current document', 'council-debt-counters' ); ?></a></p>
+                    <?php endif; ?>
+                    <input type="file" id="cdc-soa" name="statement_of_accounts_file" accept="application/pdf">
+                    <p class="description"><?php esc_html_e( 'or import from URL', 'council-debt-counters' ); ?></p>
+                    <input type="url" name="statement_of_accounts_url" class="regular-text" placeholder="https://example.com/file.pdf">
+                    <?php $orphans = \CouncilDebtCounters\Docs_Manager::list_orphan_documents(); ?>
+                    <?php if ( ! empty( $orphans ) ) : ?>
+                        <p class="description mt-2"><?php esc_html_e( 'Or attach an existing document', 'council-debt-counters' ); ?></p>
+                        <select name="statement_of_accounts_existing">
+                            <option value=""><?php esc_html_e( 'Select document', 'council-debt-counters' ); ?></option>
+                            <?php foreach ( $orphans as $doc ) : ?>
+                                <option value="<?php echo esc_attr( $doc->filename ); ?>"><?php echo esc_html( $doc->filename ); ?></option>
+                            <?php endforeach; ?>
+                        </select>
+                    <?php endif; ?>
+                </td>
+            </tr>
+            <?php else : ?>
             <tr>
                 <th scope="row"><label for="cdc-field-<?php echo esc_attr( $field->id ); ?>"><?php echo esc_html( $field->label ); ?><?php if ( $field->required ) echo ' *'; ?></label></th>
                 <td>
@@ -40,6 +63,7 @@ if ( $action === 'edit' ) {
                     <?php endif; ?>
                 </td>
             </tr>
+            <?php endif; ?>
             <?php endforeach; ?>
         </table>
         <?php submit_button( __( 'Save Council', 'council-debt-counters' ) ); ?>

--- a/admin/views/docs-manager-page.php
+++ b/admin/views/docs-manager-page.php
@@ -9,6 +9,18 @@ $can_upload = Docs_Manager::can_upload();
 $is_pro = License_Manager::is_valid();
 $upload_error = '';
 
+if ( isset( $_POST['cdc_assign_doc'], $_POST['cdc_doc_name'], $_POST['cdc_council'], $_POST['cdc_doc_type'], $_POST['cdc_assign_nonce'] ) && wp_verify_nonce( $_POST['cdc_assign_nonce'], 'cdc_assign_doc' ) ) {
+    $file = sanitize_file_name( $_POST['cdc_doc_name'] );
+    $council = intval( $_POST['cdc_council'] );
+    $type = sanitize_key( $_POST['cdc_doc_type'] );
+    Docs_Manager::assign_document( $file, $council, $type );
+    if ( $type === 'statement_of_accounts' ) {
+        \CouncilDebtCounters\Custom_Fields::update_value( $council, 'statement_of_accounts', $file );
+    }
+    echo '<div class="notice notice-success"><p>' . esc_html__( 'Document assigned.', 'council-debt-counters' ) . '</p></div>';
+    $docs = Docs_Manager::list_documents();
+}
+
 if ( isset( $_POST['cdc_delete_doc'], $_POST['cdc_doc_name'], $_POST['cdc_delete_doc_nonce'] ) && wp_verify_nonce( $_POST['cdc_delete_doc_nonce'], 'cdc_delete_doc' ) ) {
     Docs_Manager::delete_document( sanitize_file_name( $_POST['cdc_doc_name'] ) );
     echo '<div class="notice notice-success"><p>' . esc_html__( 'Document deleted.', 'council-debt-counters' ) . '</p></div>';
@@ -46,22 +58,43 @@ if ( isset( $_FILES['cdc_upload_doc'] ) && $_FILES['cdc_upload_doc']['size'] > 0
         <thead>
             <tr>
                 <th><?php esc_html_e( 'File Name', 'council-debt-counters' ); ?></th>
+                <th><?php esc_html_e( 'Council', 'council-debt-counters' ); ?></th>
+                <th><?php esc_html_e( 'Type', 'council-debt-counters' ); ?></th>
                 <th><?php esc_html_e( 'Actions', 'council-debt-counters' ); ?></th>
             </tr>
         </thead>
         <tbody>
             <?php if ( empty( $docs ) ) : ?>
-                <tr><td colspan="2"><?php esc_html_e( 'No documents uploaded.', 'council-debt-counters' ); ?></td></tr>
+                <tr><td colspan="4"><?php esc_html_e( 'No documents uploaded.', 'council-debt-counters' ); ?></td></tr>
             <?php else : foreach ( $docs as $doc ) : ?>
                 <tr>
-                    <td><?php echo esc_html( $doc ); ?></td>
+                    <td><?php echo esc_html( $doc->filename ); ?></td>
+                    <td>
+                        <?php echo $doc->council_id ? esc_html( get_the_title( $doc->council_id ) ) : esc_html__( 'Unassigned', 'council-debt-counters' ); ?>
+                    </td>
+                    <td><?php echo esc_html( $doc->doc_type ); ?></td>
                     <td>
                         <form method="post" style="display:inline;">
-                            <input type="hidden" name="cdc_doc_name" value="<?php echo esc_attr( $doc ); ?>" />
+                            <input type="hidden" name="cdc_doc_name" value="<?php echo esc_attr( $doc->filename ); ?>" />
                             <?php wp_nonce_field( 'cdc_delete_doc', 'cdc_delete_doc_nonce' ); ?>
                             <button type="submit" name="cdc_delete_doc" class="button button-secondary" onclick="return confirm('<?php esc_attr_e( 'Are you sure you want to delete this document?', 'council-debt-counters' ); ?>');"><?php esc_html_e( 'Delete', 'council-debt-counters' ); ?></button>
                         </form>
-                        <a href="<?php echo esc_url( plugins_url( 'docs/' . $doc, dirname( __DIR__, 2 ) . '/council-debt-counters.php' ) ); ?>" target="_blank" rel="noopener noreferrer" class="button">View</a>
+                        <a href="<?php echo esc_url( plugins_url( 'docs/' . $doc->filename, dirname( __DIR__, 2 ) . '/council-debt-counters.php' ) ); ?>" target="_blank" rel="noopener noreferrer" class="button">View</a>
+                        <?php if ( $doc->council_id == 0 ) : ?>
+                            <form method="post" style="display:inline; margin-left:10px;">
+                                <?php wp_nonce_field( 'cdc_assign_doc', 'cdc_assign_nonce' ); ?>
+                                <input type="hidden" name="cdc_doc_name" value="<?php echo esc_attr( $doc->filename ); ?>" />
+                                <select name="cdc_council">
+                                    <?php foreach ( get_posts( [ 'post_type' => 'council', 'numberposts' => -1 ] ) as $c ) : ?>
+                                        <option value="<?php echo esc_attr( $c->ID ); ?>"><?php echo esc_html( $c->post_title ); ?></option>
+                                    <?php endforeach; ?>
+                                </select>
+                                <select name="cdc_doc_type">
+                                    <option value="statement_of_accounts"><?php esc_html_e( 'Statement of Accounts', 'council-debt-counters' ); ?></option>
+                                </select>
+                                <button type="submit" name="cdc_assign_doc" class="button button-primary"><?php esc_html_e( 'Assign', 'council-debt-counters' ); ?></button>
+                            </form>
+                        <?php endif; ?>
                     </td>
                 </tr>
             <?php endforeach; endif; ?>

--- a/council-debt-counters.php
+++ b/council-debt-counters.php
@@ -28,7 +28,10 @@ require_once plugin_dir_path( __FILE__ ) . 'includes/class-debt-adjustments-page
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-whistleblower-form.php';
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-admin-dashboard-widget.php';
 
-register_activation_hook( __FILE__, [ '\\CouncilDebtCounters\\Custom_Fields', 'install' ] );
+register_activation_hook( __FILE__, function() {
+    \CouncilDebtCounters\Custom_Fields::install();
+    \CouncilDebtCounters\Docs_Manager::install();
+} );
 
 add_action( 'plugins_loaded', function() {
     \CouncilDebtCounters\Error_Logger::init();
@@ -36,6 +39,7 @@ add_action( 'plugins_loaded', function() {
     \CouncilDebtCounters\Council_Post_Type::init();
     \CouncilDebtCounters\Council_Admin_Page::init();
     \CouncilDebtCounters\Custom_Fields::init();
+    \CouncilDebtCounters\Docs_Manager::init();
     \CouncilDebtCounters\Shortcode_Renderer::init();
     \CouncilDebtCounters\Debt_Adjustments_Page::init();
     \CouncilDebtCounters\Data_Loader::init();

--- a/includes/class-custom-fields.php
+++ b/includes/class-custom-fields.php
@@ -30,6 +30,7 @@ class Custom_Fields {
         ['name' => 'usable_reserves', 'label' => 'Usable Reserves', 'type' => 'money', 'required' => 0],
         ['name' => 'consultancy_spend', 'label' => 'Consultancy Spend', 'type' => 'money', 'required' => 0],
         ['name' => 'waste_report_count', 'label' => 'Waste Report Count', 'type' => 'number', 'required' => 0],
+        ['name' => 'statement_of_accounts', 'label' => 'Statement of Accounts (PDF)', 'type' => 'text', 'required' => 0],
     ];
 
     /**
@@ -40,6 +41,7 @@ class Custom_Fields {
         'council_name',
         'current_liabilities',
         'long_term_liabilities',
+        'statement_of_accounts',
     ];
 
     /**

--- a/includes/class-docs-manager.php
+++ b/includes/class-docs-manager.php
@@ -10,21 +10,54 @@ class Docs_Manager {
     const ALLOWED_EXTENSIONS = ['csv', 'pdf', 'xlsx'];
     const FREE_LIMIT = 10;
 
+    const TABLE = 'cdc_documents';
+    const DOC_TYPES = ['statement_of_accounts'];
+
+    public static function init() {
+        add_action( 'init', [ __CLASS__, 'maybe_install' ] );
+    }
+
+    public static function install() {
+        global $wpdb;
+        $table = $wpdb->prefix . self::TABLE;
+        $charset_collate = $wpdb->get_charset_collate();
+        $sql = "CREATE TABLE $table (
+            id bigint(20) NOT NULL AUTO_INCREMENT,
+            filename varchar(255) NOT NULL,
+            doc_type varchar(100) NOT NULL,
+            council_id bigint(20) NOT NULL DEFAULT 0,
+            PRIMARY KEY  (id),
+            UNIQUE KEY filename (filename)
+        ) $charset_collate;";
+        require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+        dbDelta( $sql );
+    }
+
+    public static function maybe_install() {
+        global $wpdb;
+        $table = $wpdb->prefix . self::TABLE;
+        if ( $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table ) ) !== $table ) {
+            self::install();
+        }
+    }
+
     public static function get_docs_path() {
         return plugin_dir_path( dirname( __FILE__ ) ) . self::DOCS_DIR . '/';
     }
 
-    public static function list_documents() {
-        $files = [];
-        $dir = self::get_docs_path();
-        if ( is_dir( $dir ) ) {
-            foreach ( scandir( $dir ) as $file ) {
-                if ( in_array( strtolower( pathinfo( $file, PATHINFO_EXTENSION ) ), self::ALLOWED_EXTENSIONS ) ) {
-                    $files[] = $file;
-                }
-            }
+    public static function list_documents( int $council_id = 0 ) {
+        global $wpdb;
+        $table = $wpdb->prefix . self::TABLE;
+        if ( $council_id > 0 ) {
+            return $wpdb->get_results( $wpdb->prepare( "SELECT * FROM $table WHERE council_id = %d", $council_id ) );
         }
-        return $files;
+        return $wpdb->get_results( "SELECT * FROM $table" );
+    }
+
+    public static function list_orphan_documents() {
+        global $wpdb;
+        $table = $wpdb->prefix . self::TABLE;
+        return $wpdb->get_results( "SELECT * FROM $table WHERE council_id = 0" );
     }
 
     public static function can_upload() {
@@ -33,7 +66,7 @@ class Docs_Manager {
         return count( self::list_documents() ) < self::FREE_LIMIT;
     }
 
-    public static function upload_document( $file ) {
+    public static function upload_document( $file, string $doc_type = '', int $council_id = 0 ) {
         $ext = strtolower( pathinfo( $file['name'], PATHINFO_EXTENSION ) );
         if ( ! in_array( $ext, self::ALLOWED_EXTENSIONS ) ) {
             Error_Logger::log( 'Attempted upload of invalid file type: ' . $file['name'] );
@@ -43,8 +76,10 @@ class Docs_Manager {
             Error_Logger::log( 'Document upload blocked - free limit reached' );
             return __( 'Free version limit reached. Upgrade to Pro for unlimited documents.', 'council-debt-counters' );
         }
-        $target = self::get_docs_path() . basename( $file['name'] );
+        $filename = basename( $file['name'] );
+        $target   = self::get_docs_path() . $filename;
         if ( move_uploaded_file( $file['tmp_name'], $target ) ) {
+            self::add_document( $filename, $doc_type, $council_id );
             return true;
         }
         Error_Logger::log( 'Failed to move uploaded document: ' . $file['name'] );
@@ -55,8 +90,82 @@ class Docs_Manager {
         $file = self::get_docs_path() . $filename;
         if ( file_exists( $file ) ) {
             unlink( $file );
+            global $wpdb;
+            $wpdb->delete( $wpdb->prefix . self::TABLE, [ 'filename' => $filename ], [ '%s' ] );
             return true;
         }
         return false;
+    }
+
+    /**
+     * Download a PDF from a remote URL into the docs directory.
+     *
+     * @param string $url Remote file URL.
+     * @return true|string True on success or error message.
+     */
+    public static function import_from_url( string $url, string $doc_type = '', int $council_id = 0 ) {
+        $path = parse_url( $url, PHP_URL_PATH );
+        $ext  = strtolower( pathinfo( $path, PATHINFO_EXTENSION ) );
+        if ( ! in_array( $ext, self::ALLOWED_EXTENSIONS ) ) {
+            Error_Logger::log( 'Invalid import file type: ' . $url );
+            return __( 'Invalid file type. Only XLSX, CSV, and PDF are allowed.', 'council-debt-counters' );
+        }
+
+        if ( ! self::can_upload() ) {
+            Error_Logger::log( 'Document import blocked - free limit reached' );
+            return __( 'Free version limit reached. Upgrade to Pro for unlimited documents.', 'council-debt-counters' );
+        }
+
+        if ( ! function_exists( 'download_url' ) ) {
+            require_once ABSPATH . 'wp-admin/includes/file.php';
+        }
+
+        $tmp = download_url( $url );
+        if ( is_wp_error( $tmp ) ) {
+            Error_Logger::log( 'Failed to download document: ' . $url . ' - ' . $tmp->get_error_message() );
+            return __( 'Download failed.', 'council-debt-counters' );
+        }
+
+        $filename = basename( $path );
+        $target   = self::get_docs_path() . $filename;
+        if ( ! copy( $tmp, $target ) ) {
+            unlink( $tmp );
+            Error_Logger::log( 'Failed to copy imported document to docs: ' . $filename );
+            return __( 'Import failed.', 'council-debt-counters' );
+        }
+        unlink( $tmp );
+        self::add_document( $filename, $doc_type, $council_id );
+        return true;
+    }
+
+    public static function get_document( string $filename ) {
+        global $wpdb;
+        return $wpdb->get_row( $wpdb->prepare( "SELECT * FROM {$wpdb->prefix}" . self::TABLE . " WHERE filename = %s", $filename ) );
+    }
+
+    public static function add_document( string $filename, string $doc_type = '', int $council_id = 0 ) {
+        global $wpdb;
+        $wpdb->insert( $wpdb->prefix . self::TABLE, [
+            'filename'   => $filename,
+            'doc_type'   => $doc_type,
+            'council_id' => $council_id,
+        ], [ '%s', '%s', '%d' ] );
+    }
+
+    public static function assign_document( string $filename, int $council_id, string $doc_type ) {
+        if ( ! in_array( $doc_type, self::DOC_TYPES, true ) ) {
+            return false;
+        }
+        global $wpdb;
+        $doc = self::get_document( $filename );
+        if ( $doc ) {
+            $wpdb->update( $wpdb->prefix . self::TABLE, [
+                'council_id' => $council_id,
+                'doc_type'   => $doc_type,
+            ], [ 'id' => $doc->id ], [ '%d', '%s' ], [ '%d' ] );
+        } else {
+            self::add_document( $filename, $doc_type, $council_id );
+        }
+        return true;
     }
 }


### PR DESCRIPTION
## Summary
- add database table for council documents
- register Docs Manager during activation
- allow upload/import/assignment of Statement of Accounts files
- show orphan PDF dropdown on council edit form
- support assigning orphan documents from Manage Documents screen

## Testing
- `../vendor/bin/phpunit -c ../phpunit.xml` *(fails: Test directory not found)*
- `php -l includes/class-docs-manager.php`
- `php -l includes/class-council-admin-page.php`
- `php -l admin/views/councils-page.php`
- `php -l admin/views/docs-manager-page.php`
- `php -l council-debt-counters.php`


------
https://chatgpt.com/codex/tasks/task_e_68532d248b008331aab2b9aed2175ffe