### PR TITLE
Add shortcode playground and financial year support

### DIFF
--- a/admin/js/council-form.js
+++ b/admin/js/council-form.js
@@ -47,28 +47,7 @@
             shortField.parentElement.appendChild(ratesOutput);
         }
 
-        var sidebar = document.createElement('div');
-        sidebar.id = 'cdc-counter-sidebar';
-        sidebar.className = 'card mb-3 ms-3';
-        sidebar.style.width = '18rem';
-        sidebar.innerHTML = '<div class="card-body">' +
-            '<h5 class="card-title">Live Counter</h5>' +
-            '<div id="cdc-counter-display" class="h3" role="status" aria-live="polite">£0</div>' +
-            '<p id="cdc-counter-rate" class="mb-0"></p>' +
-            '</div>';
-        form.parentElement.appendChild(sidebar);
-        var counterDisplay = sidebar.querySelector('#cdc-counter-display');
-        var rateDisplay = sidebar.querySelector('#cdc-counter-rate');
-        var baseTotal = 0;
-        var startTime = Date.now();
         var growthPerSecond = 0;
-
-        function tick() {
-            var elapsed = (Date.now() - startTime) / 1000;
-            var current = baseTotal + elapsed * growthPerSecond;
-            counterDisplay.textContent = current.toLocaleString('en-GB', { style: 'currency', currency: 'GBP', maximumFractionDigits: 2 });
-        }
-        setInterval(tick, 1000);
 
         function updateAll() {
             var shortVal = parseFloat(shortField ? shortField.value : 0) || 0;
@@ -90,9 +69,6 @@
             ratesOutput.textContent = 'Debt per day: £' + perDay.toFixed(2) + ', per hour: £' + perHour.toFixed(2) + ', per second: £' + perSecond.toFixed(2);
 
             growthPerSecond = (interest - mrp) / (365 * 24 * 60 * 60);
-            baseTotal = total;
-            startTime = Date.now();
-            rateDisplay.textContent = 'Growth per second: £' + growthPerSecond.toFixed(6);
         }
 
         if (shortField) shortField.addEventListener('input', updateAll);
@@ -101,10 +77,5 @@
         if (interestField) interestField.addEventListener('input', updateAll);
         if (mrpField) mrpField.addEventListener('input', updateAll);
         updateAll();
-        // Add explainer for calculation
-        var explainer = document.createElement('div');
-        explainer.className = 'alert alert-warning mt-2';
-        explainer.innerHTML = 'Total debt = <strong>Current Liabilities + Long Term Liabilities + Finance Lease/PFI Liabilities + Adjustments</strong>. The growth or shrinkage estimate uses interest from the last statement of accounts.';
-        sidebar.querySelector('.card-body').appendChild(explainer);
     });
 })();

--- a/admin/js/playground.js
+++ b/admin/js/playground.js
@@ -1,0 +1,43 @@
+document.addEventListener('DOMContentLoaded', function() {
+    var council = document.getElementById('cdc-play-council');
+    var type = document.getElementById('cdc-play-type');
+    var code = document.getElementById('cdc-play-shortcode');
+    var preview = document.getElementById('cdc-play-preview');
+
+    function buildShortcode() {
+        var c = council.value;
+        var t = type.value;
+        switch (t) {
+            case 'debt':
+                return '[council_counter id="' + c + '"]';
+            case 'spending':
+                return '[spending_counter id="' + c + '"]';
+            case 'income':
+                return '[revenue_counter id="' + c + '"]';
+            case 'deficit':
+                return '[deficit_counter id="' + c + '"]';
+            case 'interest':
+                return '[interest_counter id="' + c + '"]';
+            default:
+                return '[custom_counter id="' + c + '" type="' + t + '"]';
+        }
+    }
+
+    function update() {
+        var sc = buildShortcode();
+        code.value = sc;
+        fetch(cdcPlay.ajaxUrl, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+            body: 'action=cdc_preview_shortcode&shortcode=' + encodeURIComponent(sc)
+        }).then(function(r){ return r.text(); }).then(function(html){
+            preview.innerHTML = html;
+        });
+    }
+
+    if (council && type) {
+        council.addEventListener('change', update);
+        type.addEventListener('change', update);
+        update();
+    }
+});

--- a/admin/views/docs-manager-page.php
+++ b/admin/views/docs-manager-page.php
@@ -13,7 +13,8 @@ if ( isset( $_POST['cdc_assign_doc'], $_POST['cdc_doc_name'], $_POST['cdc_counci
     $file = sanitize_file_name( $_POST['cdc_doc_name'] );
     $council = intval( $_POST['cdc_council'] );
     $type = sanitize_key( $_POST['cdc_doc_type'] );
-    Docs_Manager::assign_document( $file, $council, $type );
+    $year = sanitize_text_field( $_POST['cdc_doc_year'] );
+    Docs_Manager::assign_document( $file, $council, $type, $year );
     if ( $type === 'statement_of_accounts' ) {
         \CouncilDebtCounters\Custom_Fields::update_value( $council, 'statement_of_accounts', $file );
     }
@@ -28,7 +29,8 @@ if ( isset( $_POST['cdc_delete_doc'], $_POST['cdc_doc_name'], $_POST['cdc_delete
 }
 
 if ( isset( $_FILES['cdc_upload_doc'] ) && $_FILES['cdc_upload_doc']['size'] > 0 ) {
-    $result = Docs_Manager::upload_document( $_FILES['cdc_upload_doc'] );
+    $year = sanitize_text_field( $_POST['cdc_upload_year'] ?? Docs_Manager::current_financial_year() );
+    $result = Docs_Manager::upload_document( $_FILES['cdc_upload_doc'], '', 0, $year );
     if ( $result === true ) {
         echo '<div class="notice notice-success"><p>' . esc_html__( 'Document uploaded.', 'council-debt-counters' ) . '</p></div>';
         $docs = Docs_Manager::list_documents();
@@ -48,6 +50,7 @@ if ( isset( $_FILES['cdc_upload_doc'] ) && $_FILES['cdc_upload_doc']['size'] > 0
     <?php endif; ?>
     <form method="post" enctype="multipart/form-data">
         <input type="file" name="cdc_upload_doc" accept=".csv,.pdf,.xlsx" <?php if ( ! $can_upload ) echo 'disabled'; ?> />
+        <input type="text" name="cdc_upload_year" value="<?php echo esc_attr( Docs_Manager::current_financial_year() ); ?>" class="regular-text" style="margin-left:10px;" />
         <button type="submit" class="button button-primary" <?php if ( ! $can_upload ) echo 'disabled'; ?>><?php esc_html_e( 'Upload', 'council-debt-counters' ); ?></button>
         <?php if ( ! $can_upload ) : ?>
             <p class="description" style="color:red;"><?php esc_html_e( 'Free version limit reached. Delete a document or upgrade to Pro.', 'council-debt-counters' ); ?></p>
@@ -59,6 +62,7 @@ if ( isset( $_FILES['cdc_upload_doc'] ) && $_FILES['cdc_upload_doc']['size'] > 0
             <tr>
                 <th><?php esc_html_e( 'File Name', 'council-debt-counters' ); ?></th>
                 <th><?php esc_html_e( 'Council', 'council-debt-counters' ); ?></th>
+                <th><?php esc_html_e( 'Year', 'council-debt-counters' ); ?></th>
                 <th><?php esc_html_e( 'Type', 'council-debt-counters' ); ?></th>
                 <th><?php esc_html_e( 'Actions', 'council-debt-counters' ); ?></th>
             </tr>
@@ -72,6 +76,7 @@ if ( isset( $_FILES['cdc_upload_doc'] ) && $_FILES['cdc_upload_doc']['size'] > 0
                     <td>
                         <?php echo $doc->council_id ? esc_html( get_the_title( $doc->council_id ) ) : esc_html__( 'Unassigned', 'council-debt-counters' ); ?>
                     </td>
+                    <td><?php echo esc_html( $doc->financial_year ); ?></td>
                     <td><?php echo esc_html( $doc->doc_type ); ?></td>
                     <td>
                         <form method="post" style="display:inline;">
@@ -92,6 +97,7 @@ if ( isset( $_FILES['cdc_upload_doc'] ) && $_FILES['cdc_upload_doc']['size'] > 0
                                 <select name="cdc_doc_type">
                                     <option value="statement_of_accounts"><?php esc_html_e( 'Statement of Accounts', 'council-debt-counters' ); ?></option>
                                 </select>
+                                <input type="text" name="cdc_doc_year" value="<?php echo esc_attr( Docs_Manager::current_financial_year() ); ?>" class="regular-text" />
                                 <button type="submit" name="cdc_assign_doc" class="button button-primary"><?php esc_html_e( 'Assign', 'council-debt-counters' ); ?></button>
                             </form>
                         <?php endif; ?>

--- a/admin/views/shortcode-playground-page.php
+++ b/admin/views/shortcode-playground-page.php
@@ -1,0 +1,33 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) exit;
+$councils = get_posts([
+    'post_type'   => 'council',
+    'numberposts' => -1,
+]);
+$enabled = (array) get_option( 'cdc_enabled_counters', [] );
+?>
+<div class="wrap">
+    <h1><?php esc_html_e( 'Shortcode Playground', 'council-debt-counters' ); ?></h1>
+    <p><?php esc_html_e( 'Build and preview shortcodes for your councils.', 'council-debt-counters' ); ?></p>
+    <div class="mb-3">
+        <label for="cdc-play-council" class="form-label"><?php esc_html_e( 'Council', 'council-debt-counters' ); ?></label>
+        <select id="cdc-play-council" class="form-select">
+            <?php foreach ( $councils as $c ) : ?>
+                <option value="<?php echo esc_attr( $c->ID ); ?>"><?php echo esc_html( $c->post_title ); ?></option>
+            <?php endforeach; ?>
+        </select>
+    </div>
+    <div class="mb-3">
+        <label for="cdc-play-type" class="form-label"><?php esc_html_e( 'Counter Type', 'council-debt-counters' ); ?></label>
+        <select id="cdc-play-type" class="form-select">
+            <?php foreach ( $enabled as $type ) : ?>
+                <option value="<?php echo esc_attr( $type ); ?>"><?php echo esc_html( ucfirst( $type ) ); ?></option>
+            <?php endforeach; ?>
+        </select>
+    </div>
+    <div class="mb-3">
+        <label for="cdc-play-shortcode" class="form-label"><?php esc_html_e( 'Shortcode', 'council-debt-counters' ); ?></label>
+        <input type="text" id="cdc-play-shortcode" class="form-control" readonly>
+    </div>
+    <div id="cdc-play-preview" class="mt-4"></div>
+</div>

--- a/council-debt-counters.php
+++ b/council-debt-counters.php
@@ -24,9 +24,11 @@ require_once plugin_dir_path( __FILE__ ) . 'includes/class-council-post-type.php
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-council-admin-page.php';
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-custom-fields.php';
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-openai-helper.php';
+require_once plugin_dir_path( __FILE__ ) . 'includes/class-ai-extractor.php';
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-debt-adjustments-page.php';
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-whistleblower-form.php';
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-admin-dashboard-widget.php';
+require_once plugin_dir_path( __FILE__ ) . 'includes/class-shortcode-playground.php';
 
 register_activation_hook( __FILE__, function() {
     \CouncilDebtCounters\Custom_Fields::install();
@@ -46,6 +48,7 @@ add_action( 'plugins_loaded', function() {
     \CouncilDebtCounters\License_Manager::init();
     \CouncilDebtCounters\Whistleblower_Form::init();
     \CouncilDebtCounters\Admin_Dashboard_Widget::init();
+    \CouncilDebtCounters\Shortcode_Playground::init();
 } );
 
 /**

--- a/includes/class-ai-extractor.php
+++ b/includes/class-ai-extractor.php
@@ -1,0 +1,27 @@
+<?php
+namespace CouncilDebtCounters;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class AI_Extractor {
+    /**
+     * Ask OpenAI to extract key figures from a statement of accounts text.
+     *
+     * @param string $text Raw text from the statement of accounts.
+     * @return mixed WP_Error on failure or array of extracted values.
+     */
+    public static function extract_key_figures( string $text ) {
+        $prompt = 'Extract the Current Liabilities, Long Term Liabilities and any other useful financial figures from the following statement of accounts. Respond in JSON.' . "\n" . $text;
+        $response = OpenAI_Helper::query( $prompt );
+        if ( is_wp_error( $response ) ) {
+            return $response;
+        }
+        $data = json_decode( $response, true );
+        if ( is_array( $data ) ) {
+            return $data;
+        }
+        return new \WP_Error( 'invalid_ai_response', __( 'Failed to parse AI response.', 'council-debt-counters' ) );
+    }
+}

--- a/includes/class-council-admin-page.php
+++ b/includes/class-council-admin-page.php
@@ -80,21 +80,22 @@ class Council_Admin_Page {
         }
 
         $soa_value = Custom_Fields::get_value( $post_id, 'statement_of_accounts' );
+        $soa_year  = sanitize_text_field( $_POST['statement_of_accounts_year'] ?? Docs_Manager::current_financial_year() );
 
         if ( ! empty( $_FILES['statement_of_accounts_file']['name'] ) ) {
-            $result = Docs_Manager::upload_document( $_FILES['statement_of_accounts_file'], 'statement_of_accounts', $post_id );
+            $result = Docs_Manager::upload_document( $_FILES['statement_of_accounts_file'], 'statement_of_accounts', $post_id, $soa_year );
             if ( $result === true ) {
                 $soa_value = sanitize_file_name( $_FILES['statement_of_accounts_file']['name'] );
             }
         } elseif ( ! empty( $_POST['statement_of_accounts_url'] ) ) {
             $url = esc_url_raw( $_POST['statement_of_accounts_url'] );
-            $result = Docs_Manager::import_from_url( $url, 'statement_of_accounts', $post_id );
+            $result = Docs_Manager::import_from_url( $url, 'statement_of_accounts', $post_id, $soa_year );
             if ( $result === true ) {
                 $soa_value = sanitize_file_name( basename( parse_url( $url, PHP_URL_PATH ) ) );
             }
         } elseif ( ! empty( $_POST['statement_of_accounts_existing'] ) ) {
             $existing = sanitize_file_name( $_POST['statement_of_accounts_existing'] );
-            Docs_Manager::assign_document( $existing, $post_id, 'statement_of_accounts' );
+            Docs_Manager::assign_document( $existing, $post_id, 'statement_of_accounts', $soa_year );
             $soa_value = $existing;
         }
 

--- a/includes/class-shortcode-playground.php
+++ b/includes/class-shortcode-playground.php
@@ -1,0 +1,56 @@
+<?php
+namespace CouncilDebtCounters;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class Shortcode_Playground {
+    const SLUG = 'cdc-playground';
+
+    public static function init() {
+        add_action( 'admin_menu', [ __CLASS__, 'add_menu' ] );
+        add_action( 'admin_enqueue_scripts', [ __CLASS__, 'enqueue_assets' ] );
+        add_action( 'wp_ajax_cdc_preview_shortcode', [ __CLASS__, 'ajax_preview' ] );
+    }
+
+    public static function add_menu() {
+        add_submenu_page(
+            'council-debt-counters',
+            __( 'Shortcode Playground', 'council-debt-counters' ),
+            __( 'Shortcode Playground', 'council-debt-counters' ),
+            'manage_options',
+            self::SLUG,
+            [ __CLASS__, 'render' ]
+        );
+    }
+
+    public static function enqueue_assets( $hook ) {
+        if ( $hook !== 'debt-counters_page_' . self::SLUG ) {
+            return;
+        }
+        wp_enqueue_style( 'bootstrap-5', 'https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/css/bootstrap.min.css', [], '5.3.1' );
+        wp_enqueue_script( 'bootstrap-5', 'https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/js/bootstrap.bundle.min.js', [], '5.3.1', true );
+        wp_enqueue_script(
+            'cdc-playground',
+            plugins_url( 'admin/js/playground.js', dirname( __DIR__ ) . '/council-debt-counters.php' ),
+            [ 'jquery' ],
+            '0.1.0',
+            true
+        );
+        wp_localize_script( 'cdc-playground', 'cdcPlay', [ 'ajaxUrl' => admin_url( 'admin-ajax.php' ) ] );
+    }
+
+    public static function render() {
+        include plugin_dir_path( __DIR__ ) . 'admin/views/shortcode-playground-page.php';
+    }
+
+    public static function ajax_preview() {
+        if ( ! current_user_can( 'manage_options' ) ) {
+            wp_die();
+        }
+        $shortcode = wp_unslash( $_POST['shortcode'] ?? '' );
+        echo do_shortcode( $shortcode );
+        wp_die();
+    }
+}


### PR DESCRIPTION
## Summary
- remove live counter sidebar helper
- add `Shortcode_Playground` admin page with dynamic preview
- introduce AI extractor skeleton
- manage statement of accounts by financial year
- reorganise council edit screen with Bootstrap tabs

## Testing
- `vendor/bin/phpunit` *(fails: Test directory not found)*
- `php -l council-debt-counters.php`
- `php -l includes/class-shortcode-playground.php`
- `php -l includes/class-ai-extractor.php`
- `php -l includes/class-docs-manager.php`
- `php -l includes/class-council-admin-page.php`

------
https://chatgpt.com/codex/tasks/task_e_6853351733088331a9baa6981496fbf6