### PR TITLE
Add document editing and admin pages

### DIFF
--- a/admin/views/councils-page.php
+++ b/admin/views/councils-page.php
@@ -82,6 +82,7 @@ if ( $action === 'edit' ) {
             </div>
             <?php foreach ( $enabled as $tab ) : if ( empty( $groups[ $tab ] ) ) continue; ?>
             <div class="tab-pane fade" id="tab-<?php echo esc_attr( $tab ); ?>" role="tabpanel">
+                <p class="description"><code>[council_counter id="<?php echo esc_attr( $post_id ); ?>" type="<?php echo esc_attr( $tab ); ?>"]</code></p>
                 <table class="form-table" role="presentation">
                 <?php foreach ( $groups[ $tab ] as $field ) :
                     $val = $post_id ? \CouncilDebtCounters\Custom_Fields::get_value( $post_id, $field->name ) : '';
@@ -120,7 +121,11 @@ if ( $action === 'edit' ) {
                             <input type="url" name="statement_of_accounts_url" class="regular-text" placeholder="https://example.com/file.pdf">
                             <p class="description mt-2">
                                 <label for="cdc-soa-year" class="form-label"><?php esc_html_e( 'Financial Year', 'council-debt-counters' ); ?></label>
-                                <input type="text" id="cdc-soa-year" name="statement_of_accounts_year" value="<?php echo esc_attr( \CouncilDebtCounters\Docs_Manager::current_financial_year() ); ?>" class="regular-text">
+                                <select id="cdc-soa-year" name="statement_of_accounts_year">
+                                    <?php foreach ( \CouncilDebtCounters\Docs_Manager::financial_years() as $y ) : ?>
+                                        <option value="<?php echo esc_attr( $y ); ?>" <?php selected( \CouncilDebtCounters\Docs_Manager::current_financial_year(), $y ); ?>><?php echo esc_html( $y ); ?></option>
+                                    <?php endforeach; ?>
+                                </select>
                             </p>
                             <?php $orphans = \CouncilDebtCounters\Docs_Manager::list_orphan_documents(); ?>
                             <?php if ( ! empty( $orphans ) ) : ?>
@@ -138,10 +143,35 @@ if ( $action === 'edit' ) {
                 <?php if ( ! empty( $docs ) ) : ?>
                 <h2><?php esc_html_e( 'Existing Documents', 'council-debt-counters' ); ?></h2>
                 <table class="widefat">
-                    <thead><tr><th><?php esc_html_e( 'File', 'council-debt-counters' ); ?></th><th><?php esc_html_e( 'Year', 'council-debt-counters' ); ?></th></tr></thead>
+                    <thead>
+                        <tr>
+                            <th><?php esc_html_e( 'File', 'council-debt-counters' ); ?></th>
+                            <th><?php esc_html_e( 'Year', 'council-debt-counters' ); ?></th>
+                            <th><?php esc_html_e( 'Type', 'council-debt-counters' ); ?></th>
+                            <th><?php esc_html_e( 'Actions', 'council-debt-counters' ); ?></th>
+                        </tr>
+                    </thead>
                     <tbody>
                     <?php foreach ( $docs as $d ) : ?>
-                        <tr><td><?php echo esc_html( $d->filename ); ?></td><td><?php echo esc_html( $d->financial_year ); ?></td></tr>
+                        <tr>
+                            <td><?php echo esc_html( $d->filename ); ?></td>
+                            <td>
+                                <select name="docs[<?php echo esc_attr( $d->id ); ?>][financial_year]">
+                                    <?php foreach ( \CouncilDebtCounters\Docs_Manager::financial_years() as $y ) : ?>
+                                        <option value="<?php echo esc_attr( $y ); ?>" <?php selected( $d->financial_year, $y ); ?>><?php echo esc_html( $y ); ?></option>
+                                    <?php endforeach; ?>
+                                </select>
+                            </td>
+                            <td>
+                                <select name="docs[<?php echo esc_attr( $d->id ); ?>][doc_type]">
+                                    <option value="statement_of_accounts" <?php selected( $d->doc_type, 'statement_of_accounts' ); ?>><?php esc_html_e( 'Statement of Accounts', 'council-debt-counters' ); ?></option>
+                                </select>
+                            </td>
+                            <td>
+                                <button type="submit" name="update_doc" value="<?php echo esc_attr( $d->id ); ?>" class="button button-secondary"><?php esc_html_e( 'Update', 'council-debt-counters' ); ?></button>
+                                <button type="submit" name="delete_doc" value="<?php echo esc_attr( $d->id ); ?>" class="button button-link-delete" onclick="return confirm('<?php esc_attr_e( 'Delete this document?', 'council-debt-counters' ); ?>');"><?php esc_html_e( 'Delete', 'council-debt-counters' ); ?></button>
+                            </td>
+                        </tr>
                     <?php endforeach; ?>
                     </tbody>
                 </table>

--- a/admin/views/docs-manager-page.php
+++ b/admin/views/docs-manager-page.php
@@ -50,7 +50,11 @@ if ( isset( $_FILES['cdc_upload_doc'] ) && $_FILES['cdc_upload_doc']['size'] > 0
     <?php endif; ?>
     <form method="post" enctype="multipart/form-data">
         <input type="file" name="cdc_upload_doc" accept=".csv,.pdf,.xlsx" <?php if ( ! $can_upload ) echo 'disabled'; ?> />
-        <input type="text" name="cdc_upload_year" value="<?php echo esc_attr( Docs_Manager::current_financial_year() ); ?>" class="regular-text" style="margin-left:10px;" />
+        <select name="cdc_upload_year" style="margin-left:10px;">
+            <?php foreach ( Docs_Manager::financial_years() as $y ) : ?>
+                <option value="<?php echo esc_attr( $y ); ?>" <?php selected( Docs_Manager::current_financial_year(), $y ); ?>><?php echo esc_html( $y ); ?></option>
+            <?php endforeach; ?>
+        </select>
         <button type="submit" class="button button-primary" <?php if ( ! $can_upload ) echo 'disabled'; ?>><?php esc_html_e( 'Upload', 'council-debt-counters' ); ?></button>
         <?php if ( ! $can_upload ) : ?>
             <p class="description" style="color:red;"><?php esc_html_e( 'Free version limit reached. Delete a document or upgrade to Pro.', 'council-debt-counters' ); ?></p>
@@ -97,7 +101,11 @@ if ( isset( $_FILES['cdc_upload_doc'] ) && $_FILES['cdc_upload_doc']['size'] > 0
                                 <select name="cdc_doc_type">
                                     <option value="statement_of_accounts"><?php esc_html_e( 'Statement of Accounts', 'council-debt-counters' ); ?></option>
                                 </select>
-                                <input type="text" name="cdc_doc_year" value="<?php echo esc_attr( Docs_Manager::current_financial_year() ); ?>" class="regular-text" />
+                                <select name="cdc_doc_year">
+                                    <?php foreach ( Docs_Manager::financial_years() as $y ) : ?>
+                                        <option value="<?php echo esc_attr( $y ); ?>" <?php selected( Docs_Manager::current_financial_year(), $y ); ?>><?php echo esc_html( $y ); ?></option>
+                                    <?php endforeach; ?>
+                                </select>
                                 <button type="submit" name="cdc_assign_doc" class="button button-primary"><?php esc_html_e( 'Assign', 'council-debt-counters' ); ?></button>
                             </form>
                         <?php endif; ?>

--- a/admin/views/import-export-page.php
+++ b/admin/views/import-export-page.php
@@ -1,0 +1,24 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) exit;
+?>
+<div class="wrap">
+    <h1><?php esc_html_e( 'Import & Export', 'council-debt-counters' ); ?></h1>
+    <h2><?php esc_html_e( 'Import Councils', 'council-debt-counters' ); ?></h2>
+    <form method="post" enctype="multipart/form-data">
+        <?php wp_nonce_field( 'cdc_load_csv', 'cdc_load_csv_nonce' ); ?>
+        <input type="file" name="cdc_csv_file" accept=".csv,.json" required />
+        <button type="submit" class="button"><?php esc_html_e( 'Import', 'council-debt-counters' ); ?></button>
+    </form>
+    <p class="description">
+        <?php esc_html_e( 'CSV/JSON must include a "council_name" column plus any custom field names.', 'council-debt-counters' ); ?>
+    </p>
+    <h2><?php esc_html_e( 'Export Councils', 'council-debt-counters' ); ?></h2>
+    <form method="post">
+        <?php wp_nonce_field( 'cdc_export', 'cdc_export_nonce' ); ?>
+        <select name="format">
+            <option value="csv">CSV</option>
+            <option value="json">JSON</option>
+        </select>
+        <button type="submit" name="cdc_export" class="button button-primary"><?php esc_html_e( 'Download', 'council-debt-counters' ); ?></button>
+    </form>
+</div>

--- a/admin/views/instructions-page.php
+++ b/admin/views/instructions-page.php
@@ -9,64 +9,7 @@ if ( ! defined( 'ABSPATH' ) ) exit;
     <p><?php esc_html_e( 'To get started, upload baseline debt figures or manually enter data for each council.', 'council-debt-counters' ); ?></p>
     <p><?php esc_html_e( 'Manage councils from the "Councils" submenu under Debt Counters.', 'council-debt-counters' ); ?></p>
 
-    <form method="post" action="options.php">
-        <?php
-        settings_fields( 'council-debt-counters' );
-        do_settings_sections( 'council-debt-counters' );
-        ?>
-        <table class="form-table" role="presentation">
-            <tr>
-                <th scope="row"><label for="<?php echo esc_attr( License_Manager::OPTION_KEY ); ?>"><?php esc_html_e( 'License Key', 'council-debt-counters' ); ?></label></th>
-                <td>
-                    <input name="<?php echo esc_attr( License_Manager::OPTION_KEY ); ?>" type="text" id="<?php echo esc_attr( License_Manager::OPTION_KEY ); ?>" value="<?php echo esc_attr( License_Manager::get_license_key() ); ?>" class="regular-text" />
-                    <button type="button" id="cdc-check-license" class="button" style="margin-left:10px;">
-                        <?php esc_html_e( 'Check License', 'council-debt-counters' ); ?>
-                    </button>
-                    <p id="cdc-license-result" class="description">
-                        <?php echo License_Manager::is_valid() ? esc_html__( 'License is valid.', 'council-debt-counters' ) : ''; ?>
-                    </p>
-                    <p class="description"><?php esc_html_e( 'Enter a valid license key to unlock unlimited councils.', 'council-debt-counters' ); ?></p>
-                </td>
-            </tr>
-            <tr>
-                <th scope="row"><label for="cdc_openai_api_key"><?php esc_html_e( 'OpenAI API Key', 'council-debt-counters' ); ?></label></th>
-                <td>
-                    <input name="cdc_openai_api_key" type="text" id="cdc_openai_api_key" value="<?php echo esc_attr( get_option( 'cdc_openai_api_key', '' ) ); ?>" class="regular-text" />
-                    <p class="description"><?php esc_html_e( 'Optional: provide an OpenAI API key to assist with generating council information.', 'council-debt-counters' ); ?></p>
-                </td>
-            </tr>
-            <tr>
-                <th scope="row"><?php esc_html_e( 'Enabled Counters', 'council-debt-counters' ); ?></th>
-                <td>
-                    <?php $enabled = (array) get_option( 'cdc_enabled_counters', [] ); ?>
-                    <?php
-                    $types = [
-                        'debt' => __( 'Debt', 'council-debt-counters' ),
-                        'spending' => __( 'Spending', 'council-debt-counters' ),
-                        'income' => __( 'Income', 'council-debt-counters' ),
-                        'deficit' => __( 'Deficit', 'council-debt-counters' ),
-                        'interest' => __( 'Interest', 'council-debt-counters' ),
-                        'reserves' => __( 'Reserves', 'council-debt-counters' ),
-                        'consultancy' => __( 'Consultancy', 'council-debt-counters' ),
-                    ];
-                    foreach ( $types as $key => $label ) : ?>
-                        <label style="display:block;margin-bottom:4px;">
-                            <input type="checkbox" name="cdc_enabled_counters[]" value="<?php echo esc_attr( $key ); ?>" <?php checked( in_array( $key, $enabled, true ) ); ?> />
-                            <?php echo esc_html( $label ); ?>
-                        </label>
-                    <?php endforeach; ?>
-                    <p class="description"><?php esc_html_e( 'Select which counters are available for shortcodes.', 'council-debt-counters' ); ?></p>
-                </td>
-            </tr>
-        </table>
-        <?php submit_button(); ?>
-    </form>
-    <h2><?php esc_html_e( "Import Councils from CSV", 'council-debt-counters' ); ?></h2>
-    <form method="post" enctype="multipart/form-data">
-        <?php wp_nonce_field( "cdc_load_csv", "cdc_load_csv_nonce" ); ?>
-        <input type="file" name="cdc_csv_file" accept=".csv" required />
-        <button type="submit" class="button"><?php esc_html_e( "Import CSV", 'council-debt-counters' ); ?></button>
-    </form>
+    <p><?php esc_html_e( 'Use the submenu pages to configure license keys, settings, and data import/export.', 'council-debt-counters' ); ?></p>
     <div class="notice notice-info" style="margin-top:20px;">
         <p><strong><?php esc_html_e( 'Legal notice', 'council-debt-counters' ); ?></strong></p>
         <p><?php esc_html_e( 'When publishing council data you must comply with the Copyright, Designs and Patents Act 1988, Section 11A of the Freedom of Information Act 2001, and the Re-Use of Public Sector Information Regulations 2005. Data must not be shown in a misleading context or for commercial gain, including behind paywalls. Always attribute the source council wherever the data is displayed, including when using a shortcode.', 'council-debt-counters' ); ?></p>

--- a/admin/views/license-page.php
+++ b/admin/views/license-page.php
@@ -1,0 +1,35 @@
+<?php
+use CouncilDebtCounters\License_Manager;
+if ( ! defined( 'ABSPATH' ) ) exit;
+?>
+<div class="wrap">
+    <h1><?php esc_html_e( 'Licence Keys and Addons', 'council-debt-counters' ); ?></h1>
+    <form method="post" action="options.php">
+        <?php
+        settings_fields( 'council-debt-counters' );
+        do_settings_sections( 'council-debt-counters' );
+        ?>
+        <table class="form-table" role="presentation">
+            <tr>
+                <th scope="row"><label for="<?php echo esc_attr( License_Manager::OPTION_KEY ); ?>"><?php esc_html_e( 'License Key', 'council-debt-counters' ); ?></label></th>
+                <td>
+                    <input name="<?php echo esc_attr( License_Manager::OPTION_KEY ); ?>" type="text" id="<?php echo esc_attr( License_Manager::OPTION_KEY ); ?>" value="<?php echo esc_attr( License_Manager::get_license_key() ); ?>" class="regular-text" />
+                    <button type="button" id="cdc-check-license" class="button" style="margin-left:10px;">
+                        <?php esc_html_e( 'Check License', 'council-debt-counters' ); ?>
+                    </button>
+                    <p id="cdc-license-result" class="description">
+                        <?php echo License_Manager::is_valid() ? esc_html__( 'License is valid.', 'council-debt-counters' ) : ''; ?>
+                    </p>
+                </td>
+            </tr>
+            <tr>
+                <th scope="row"><label for="cdc_openai_api_key"><?php esc_html_e( 'OpenAI API Key', 'council-debt-counters' ); ?></label></th>
+                <td>
+                    <input name="cdc_openai_api_key" type="text" id="cdc_openai_api_key" value="<?php echo esc_attr( get_option( 'cdc_openai_api_key', '' ) ); ?>" class="regular-text" />
+                    <p class="description"><?php esc_html_e( 'Optional: provide an OpenAI API key to assist with generating council information.', 'council-debt-counters' ); ?></p>
+                </td>
+            </tr>
+        </table>
+        <?php submit_button(); ?>
+    </form>
+</div>

--- a/admin/views/settings-page.php
+++ b/admin/views/settings-page.php
@@ -1,0 +1,33 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) exit;
+$enabled = (array) get_option( 'cdc_enabled_counters', [] );
+$types = [
+    'debt' => __( 'Debt', 'council-debt-counters' ),
+    'spending' => __( 'Spending', 'council-debt-counters' ),
+    'income' => __( 'Income', 'council-debt-counters' ),
+    'deficit' => __( 'Deficit', 'council-debt-counters' ),
+    'interest' => __( 'Interest', 'council-debt-counters' ),
+    'reserves' => __( 'Reserves', 'council-debt-counters' ),
+    'consultancy' => __( 'Consultancy', 'council-debt-counters' ),
+];
+?>
+<div class="wrap">
+    <h1><?php esc_html_e( 'Settings', 'council-debt-counters' ); ?></h1>
+    <form method="post" action="options.php">
+        <?php settings_fields( 'council-debt-counters' ); ?>
+        <table class="form-table" role="presentation">
+            <tr>
+                <th scope="row"><?php esc_html_e( 'Enabled Counters', 'council-debt-counters' ); ?></th>
+                <td>
+                    <?php foreach ( $types as $key => $label ) : ?>
+                        <label style="display:block;margin-bottom:4px;">
+                            <input type="checkbox" name="cdc_enabled_counters[]" value="<?php echo esc_attr( $key ); ?>" <?php checked( in_array( $key, $enabled, true ) ); ?> />
+                            <?php echo esc_html( $label ); ?>
+                        </label>
+                    <?php endforeach; ?>
+                </td>
+            </tr>
+        </table>
+        <?php submit_button(); ?>
+    </form>
+</div>

--- a/admin/views/troubleshooting-page.php
+++ b/admin/views/troubleshooting-page.php
@@ -11,7 +11,15 @@ $log = \CouncilDebtCounters\Error_Logger::get_log();
 if ( isset( $_POST['cdc_clear_log'] ) ) {
     \CouncilDebtCounters\Error_Logger::clear_log();
     $log = \CouncilDebtCounters\Error_Logger::get_log();
+    \CouncilDebtCounters\Error_Logger::log_info( 'Troubleshooting log cleared' );
     echo '<div class="notice notice-success"><p>' . esc_html__( 'Log cleared.', 'council-debt-counters' ) . '</p></div>';
+}
+
+if ( isset( $_POST['cdc_download_log'] ) ) {
+    header( 'Content-Type: text/plain' );
+    header( 'Content-Disposition: attachment; filename=troubleshooting.log' );
+    echo $log;
+    exit;
 }
 
 if ( isset( $_POST['cdc_migrate_acf_nonce'] ) && wp_verify_nonce( $_POST['cdc_migrate_acf_nonce'], 'cdc_migrate_acf' ) ) {
@@ -24,7 +32,10 @@ if ( isset( $_POST['cdc_migrate_acf_nonce'] ) && wp_verify_nonce( $_POST['cdc_mi
     <p><?php esc_html_e( 'View recent plugin errors for debugging purposes.', 'council-debt-counters' ); ?></p>
     <form method="post">
         <textarea readonly rows="20" style="width:100%;" aria-label="<?php echo esc_attr__( 'Error log', 'council-debt-counters' ); ?>"><?php echo esc_textarea( $log ); ?></textarea>
-        <p><button type="submit" name="cdc_clear_log" class="button"><?php esc_html_e( 'Clear Log', 'council-debt-counters' ); ?></button></p>
+        <p>
+            <button type="submit" name="cdc_clear_log" class="button"><?php esc_html_e( 'Clear Log', 'council-debt-counters' ); ?></button>
+            <button type="submit" name="cdc_download_log" class="button" style="margin-left:10px;"><?php esc_html_e( 'Download Log', 'council-debt-counters' ); ?></button>
+        </p>
     </form>
     <form method="post">
         <?php wp_nonce_field( 'cdc_migrate_acf', 'cdc_migrate_acf_nonce' ); ?>

--- a/council-debt-counters.php
+++ b/council-debt-counters.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Council Debt Counters
  * Description: Animated counters visualising council debt figures.
- * Version: 0.2.0
+ * Version: 0.2.1
  * Author: Mike Rouse using OpenAI Codex
  * Author URI: https://www.mikerouse.co.uk
  * Text Domain: council-debt-counters

--- a/includes/class-council-admin-page.php
+++ b/includes/class-council-admin-page.php
@@ -103,6 +103,24 @@ class Council_Admin_Page {
             Custom_Fields::update_value( $post_id, 'statement_of_accounts', $soa_value );
         }
 
+        // Document edits or deletions from the Documents tab
+        if ( isset( $_POST['update_doc'] ) && isset( $_POST['docs'][ $_POST['update_doc'] ] ) ) {
+            $doc_id = intval( $_POST['update_doc'] );
+            $info   = $_POST['docs'][ $doc_id ];
+            Docs_Manager::update_document( $doc_id, [
+                'doc_type'      => sanitize_key( $info['doc_type'] ?? '' ),
+                'financial_year'=> sanitize_text_field( $info['financial_year'] ?? '' ),
+            ] );
+        }
+
+        if ( isset( $_POST['delete_doc'] ) ) {
+            $doc_id = intval( $_POST['delete_doc'] );
+            $doc    = Docs_Manager::get_document_by_id( $doc_id );
+            if ( $doc ) {
+                Docs_Manager::delete_document( $doc->filename );
+            }
+        }
+
         wp_safe_redirect( admin_url( 'admin.php?page=' . self::PAGE_SLUG ) );
         exit;
     }

--- a/includes/class-settings-page.php
+++ b/includes/class-settings-page.php
@@ -25,6 +25,33 @@ class Settings_Page {
             'dashicons-chart-line'
         );
 
+        add_submenu_page(
+            'council-debt-counters',
+            __( 'Licence Keys and Addons', 'council-debt-counters' ),
+            __( 'Licence Keys and Addons', 'council-debt-counters' ),
+            'manage_options',
+            'cdc-license-keys',
+            [ __CLASS__, 'render_license_page' ]
+        );
+
+        add_submenu_page(
+            'council-debt-counters',
+            __( 'Settings', 'council-debt-counters' ),
+            __( 'Settings', 'council-debt-counters' ),
+            'manage_options',
+            'cdc-settings',
+            [ __CLASS__, 'render_settings_page' ]
+        );
+
+        add_submenu_page(
+            'council-debt-counters',
+            __( 'Import & Export', 'council-debt-counters' ),
+            __( 'Import & Export', 'council-debt-counters' ),
+            'manage_options',
+            'cdc-import-export',
+            [ __CLASS__, 'render_import_export_page' ]
+        );
+
         // Only add unique submenus here (do not duplicate "Councils")
         add_submenu_page(
             'council-debt-counters',
@@ -53,6 +80,18 @@ class Settings_Page {
 
     public static function render_page() {
         include plugin_dir_path( __DIR__ ) . 'admin/views/instructions-page.php';
+    }
+
+    public static function render_license_page() {
+        include plugin_dir_path( __DIR__ ) . 'admin/views/license-page.php';
+    }
+
+    public static function render_settings_page() {
+        include plugin_dir_path( __DIR__ ) . 'admin/views/settings-page.php';
+    }
+
+    public static function render_import_export_page() {
+        include plugin_dir_path( __DIR__ ) . 'admin/views/import-export-page.php';
     }
 
     public static function render_docs_page() {

--- a/includes/class-shortcode-renderer.php
+++ b/includes/class-shortcode-renderer.php
@@ -38,7 +38,9 @@ class Shortcode_Renderer {
         ?>
         <div class="card card-counter text-center mb-3">
             <div class="card-body">
-                <div class="cdc-counter display-6 fw-bold" role="status" aria-live="polite" data-target="<?php echo esc_attr( $current ); ?>" data-growth="<?php echo esc_attr( $rate ); ?>" data-start="0" data-prefix="£">£0</div>
+                <div class="cdc-counter display-6 fw-bold" role="status" aria-live="polite" data-target="<?php echo esc_attr( $current ); ?>" data-growth="<?php echo esc_attr( $rate ); ?>" data-start="<?php echo esc_attr( $current ); ?>" data-prefix="£">
+                    £<?php echo number_format_i18n( $current, 2 ); ?>
+                </div>
             </div>
         </div>
         <?php
@@ -159,7 +161,7 @@ class Shortcode_Renderer {
         <div class="card card-counter text-center mb-3">
             <div class="card-body">
                 <div class="cdc-counter display-4 fw-bold" role="status" aria-live="polite" data-target="<?php echo esc_attr( $total + ($growth_per_second * $elapsed_seconds) ); ?>" data-growth="<?php echo esc_attr( $growth_per_second ); ?>" data-start="<?php echo esc_attr( $start_value ); ?>" data-prefix="£">
-                    £0.00
+                    £<?php echo number_format_i18n( $start_value, 2 ); ?>
                 </div>
             </div>
             <button class="btn btn-link p-0" type="button" data-bs-toggle="collapse" data-bs-target="#cdc-detail-<?php echo esc_attr( $id ); ?>" aria-expanded="false" aria-controls="cdc-detail-<?php echo esc_attr( $id ); ?>">


### PR DESCRIPTION
## Summary
- allow editing and deleting council documents
- show shortcode per counter tab
- move options into new admin pages: Licence Keys, Settings, Import & Export
- add download and clear options for troubleshooting log
- improve logging and export functionality
- show initial counter values immediately

## Testing
- `php -l` on all PHP files
- `composer install`
- `./vendor/bin/phpunit -c phpunit.xml` *(fails: Test directory not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853d626fc54833195e60e26e94c4b6f