### PR TITLE
Fix shortcode type handling and missing data alerts

### DIFF
--- a/council-debt-counters.php
+++ b/council-debt-counters.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Council Debt Counters
  * Description: Animated counters visualising council debt figures.
- * Version: 0.2.1
+ * Version: 0.2.2
  * Author: Mike Rouse using OpenAI Codex
  * Author URI: https://www.mikerouse.co.uk
  * Text Domain: council-debt-counters


### PR DESCRIPTION
## Summary
- handle `type` attribute for `[council_counter]` shortcode and delegate to the custom counter handler
- warn when required figures for a counter are missing
- ensure collapse IDs are unique per counter type
- bump plugin version to 0.2.2

## Testing
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6853e0af5bfc83319b1fcff9ca341586