### PR TITLE
Add logging level controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Councils can be added, edited, and deleted from the **Debt Counters → Councils
 
 Currently the plugin includes an admin page with instructions for uploading starting debt figures via CSV. Additional functionality such as data uploading and counter rendering will be added in future versions.
 
+The **Troubleshooting** submenu lets you view error logs and choose how much JavaScript debugging information appears in the browser console. Available levels are **Verbose**, **Standard**, and **Quiet**.
+
 ## Installation
 1. Copy the plugin folder to your `wp-content/plugins` directory.
 2. Activate **Council Debt Counters** in the WordPress admin.

--- a/admin/views/troubleshooting-page.php
+++ b/admin/views/troubleshooting-page.php
@@ -8,6 +8,18 @@ if ( ! defined( 'ABSPATH' ) ) exit;
 
 $log = \CouncilDebtCounters\Error_Logger::get_log();
 
+$log_level = get_option( 'cdc_log_level', 'standard' );
+
+if ( isset( $_POST['cdc_save_log_level'] ) && check_admin_referer( 'cdc_save_log_level' ) ) {
+    $level = sanitize_key( $_POST['cdc_log_level'] ?? '' );
+    if ( ! in_array( $level, [ 'verbose', 'standard', 'quiet' ], true ) ) {
+        $level = 'standard';
+    }
+    update_option( 'cdc_log_level', $level );
+    $log_level = $level;
+    echo '<div class="notice notice-success"><p>' . esc_html__( 'Logging level saved.', 'council-debt-counters' ) . '</p></div>';
+}
+
 if ( isset( $_POST['cdc_clear_log'] ) ) {
     \CouncilDebtCounters\Error_Logger::clear_log();
     $log = \CouncilDebtCounters\Error_Logger::get_log();
@@ -40,5 +52,17 @@ if ( isset( $_POST['cdc_migrate_acf_nonce'] ) && wp_verify_nonce( $_POST['cdc_mi
     <form method="post">
         <?php wp_nonce_field( 'cdc_migrate_acf', 'cdc_migrate_acf_nonce' ); ?>
         <p><button type="submit" class="button button-primary"><?php esc_html_e( 'Migrate ACF Data', 'council-debt-counters' ); ?></button></p>
+    </form>
+
+    <form method="post" class="mt-4">
+        <?php wp_nonce_field( 'cdc_save_log_level' ); ?>
+        <h2><?php esc_html_e( 'JavaScript Logging Level', 'council-debt-counters' ); ?></h2>
+        <label for="cdc_log_level" class="screen-reader-text"><?php esc_html_e( 'Select logging level', 'council-debt-counters' ); ?></label>
+        <select name="cdc_log_level" id="cdc_log_level">
+            <option value="verbose" <?php selected( $log_level, 'verbose' ); ?>><?php esc_html_e( 'Verbose', 'council-debt-counters' ); ?></option>
+            <option value="standard" <?php selected( $log_level, 'standard' ); ?>><?php esc_html_e( 'Standard', 'council-debt-counters' ); ?></option>
+            <option value="quiet" <?php selected( $log_level, 'quiet' ); ?>><?php esc_html_e( 'Quiet', 'council-debt-counters' ); ?></option>
+        </select>
+        <?php submit_button( __( 'Save Logging Level', 'council-debt-counters' ), 'primary', 'cdc_save_log_level' ); ?>
     </form>
 </div>

--- a/includes/class-settings-page.php
+++ b/includes/class-settings-page.php
@@ -76,6 +76,20 @@ class Settings_Page {
         register_setting( 'council-debt-counters', License_Manager::OPTION_VALID );
         register_setting( 'council-debt-counters', 'cdc_openai_api_key' );
         register_setting( 'council-debt-counters', 'cdc_enabled_counters', [ 'type' => 'array', 'default' => [] ] );
+        register_setting(
+            'council-debt-counters',
+            'cdc_log_level',
+            [
+                'type'              => 'string',
+                'default'           => 'standard',
+                'sanitize_callback' => [ __CLASS__, 'sanitize_log_level' ],
+            ]
+        );
+    }
+
+    public static function sanitize_log_level( $value ) {
+        $value = sanitize_key( $value );
+        return in_array( $value, [ 'verbose', 'standard', 'quiet' ], true ) ? $value : 'standard';
     }
 
     public static function render_page() {

--- a/includes/class-shortcode-renderer.php
+++ b/includes/class-shortcode-renderer.php
@@ -87,6 +87,7 @@ class Shortcode_Renderer {
         wp_localize_script( 'cdc-counter-animations', 'CDC_LOGGER', [
             'ajaxUrl' => admin_url( 'admin-ajax.php' ),
             'nonce'   => wp_create_nonce( 'cdc_log_js' ),
+            'logLevel' => get_option( 'cdc_log_level', 'standard' ),
         ] );
     }
 

--- a/public/js/counter-animations.js
+++ b/public/js/counter-animations.js
@@ -1,11 +1,21 @@
 (function(){
     'use strict';
 
-    function debugLog(message, data){
-        if(window.CDC_DEBUG !== false){
+    const LOG_LEVELS = { quiet: 0, standard: 1, verbose: 2 };
+
+    function getCurrentLogLevel() {
+        if (window.CDC_LOGGER && window.CDC_LOGGER.logLevel) {
+            return window.CDC_LOGGER.logLevel;
+        }
+        return 'standard';
+    }
+
+    function debugLog(message, data, level = 'standard'){
+        const current = getCurrentLogLevel();
+        if (LOG_LEVELS[current] >= LOG_LEVELS[level]) {
             if(data !== undefined){
                 console.log('[CDC]', message, data);
-            }else{
+            } else {
                 console.log('[CDC]', message);
             }
         }
@@ -70,7 +80,7 @@
                 setInterval(() => {
                     start += growth;
                     counter.update(start);
-                    debugLog('Counter tick', {value: start});
+                    debugLog('Counter tick', {value: start}, 'verbose');
                 }, 1000);
             }
         });


### PR DESCRIPTION
## Summary
- allow admins to set JS logging level (Verbose, Standard, Quiet)
- localize selected log level for counter script
- respect log levels in counter-animations.js
- document the new troubleshooting option in the README

## Testing
- `php -l includes/class-settings-page.php`
- `php -l admin/views/troubleshooting-page.php`
- `php -l includes/class-shortcode-renderer.php`
- `node --check public/js/counter-animations.js`
- `vendor/bin/phpcs --standard=phpcs.xml.dist` *(fails: option `--show-sniff-names` not known)*

------
https://chatgpt.com/codex/tasks/task_e_685409318f308331b3fa0f68f04e8473