### PR TITLE
Remove redundant MRP retrieval

### DIFF
--- a/includes/class-shortcode-renderer.php
+++ b/includes/class-shortcode-renderer.php
@@ -153,7 +153,6 @@ class Shortcode_Renderer {
 
         $population = (int) Custom_Fields::get_value( $id, 'population' );
 
-        $mrp = (float) Custom_Fields::get_value( $id, 'minimum_revenue_provision' );
         $debt_repayment_explainer = '';
         if ( $mrp > 0 ) {
             $principal_repayment = $mrp - $interest;

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -17,5 +17,4 @@
 
     <!-- Show progress -->
     <arg name="colors"/>
-    <arg name="show-sniff-names"/>
 </ruleset>


### PR DESCRIPTION
## Summary
- clean up duplicate `minimum_revenue_provision` retrieval in `render_counter`
- update PHPCS config for compatibility

## Testing
- `vendor/bin/phpcs -q`

------
https://chatgpt.com/codex/tasks/task_e_68542283ff84833180023ce7666f99da