### PR TITLE
Handle cleanup of custom error handlers

### DIFF
--- a/council-debt-counters.php
+++ b/council-debt-counters.php
@@ -35,7 +35,15 @@ register_activation_hook( __FILE__, function() {
     \CouncilDebtCounters\Docs_Manager::install();
 } );
 
+// Ensure custom error handling does not persist after deactivation.
+register_deactivation_hook( __FILE__, function() {
+    \CouncilDebtCounters\Error_Logger::cleanup();
+} );
+
+
 add_action( 'plugins_loaded', function() {
+    // Initialise error logging; Error_Logger::cleanup() will restore
+    // the previous handlers on plugin deactivation.
     \CouncilDebtCounters\Error_Logger::init();
     \CouncilDebtCounters\Settings_Page::init();
     \CouncilDebtCounters\Council_Post_Type::init();

--- a/includes/class-error-logger.php
+++ b/includes/class-error-logger.php
@@ -6,15 +6,64 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class Error_Logger {
+    /**
+     * Name of the troubleshooting log file.
+     */
     const LOG_FILENAME = 'troubleshooting.log';
+
+    /**
+     * Previous PHP error handler before this class was initialised.
+     *
+     * @var callable|null
+     */
+    private static $previous_error_handler = null;
+
+    /**
+     * Previously registered shutdown handler, if any.
+     * PHP does not provide a way to remove shutdown handlers so we store
+     * the existing callback and re-register it when cleaning up.
+     *
+     * @var callable|null
+     */
+    private static $previous_shutdown_handler = null;
+
+    /**
+     * Flag for whether our handlers should run.
+     * Used when cleaning up on plugin deactivation.
+     *
+     * @var bool
+     */
+    private static $active = false;
 
     public static function log_info( string $message ) {
         self::log( 'INFO: ' . $message );
     }
 
     public static function init() {
-        set_error_handler( [ __CLASS__, 'handle_error' ] );
+        // Store existing handlers so they can be restored on deactivation.
+        self::$previous_error_handler    = set_error_handler( [ __CLASS__, 'handle_error' ] );
+        self::$previous_shutdown_handler = null; // PHP doesn't expose previously registered shutdown callbacks.
+
         register_shutdown_function( [ __CLASS__, 'handle_shutdown' ] );
+        self::$active = true;
+    }
+
+    /**
+     * Restore original handlers and disable logging.
+     * Called via plugin deactivation hook.
+     */
+    public static function cleanup() {
+        if ( null !== self::$previous_error_handler ) {
+            set_error_handler( self::$previous_error_handler );
+        } else {
+            restore_error_handler();
+        }
+
+        self::$active = false;
+
+        if ( null !== self::$previous_shutdown_handler ) {
+            register_shutdown_function( self::$previous_shutdown_handler );
+        }
     }
 
     public static function log( string $message ) {
@@ -24,14 +73,23 @@ class Error_Logger {
     }
 
     public static function handle_error( $errno, $errstr, $errfile, $errline ) {
+        if ( ! self::$active ) {
+            return false;
+        }
+
         if ( ! ( error_reporting() & $errno ) ) {
             return false;
         }
+
         self::log( "Error {$errno} at {$errfile}:{$errline} - {$errstr}" );
         return false; // Let default handler run as well
     }
 
     public static function handle_shutdown() {
+        if ( ! self::$active ) {
+            return;
+        }
+
         $error = error_get_last();
         if ( $error && in_array( $error['type'], [ E_ERROR, E_PARSE, E_CORE_ERROR, E_COMPILE_ERROR, E_USER_ERROR ] ) ) {
             self::log( "Fatal {$error['type']} at {$error['file']}:{$error['line']} - {$error['message']}" );


### PR DESCRIPTION
## Summary
- save previous PHP handlers in `Error_Logger`
- restore them via new `cleanup()` method and call this on plugin deactivation
- document new behaviour in code comments

## Testing
- `php -l includes/class-error-logger.php`
- `php -l council-debt-counters.php`
- `vendor/bin/phpcs` *(fails: option `--show-sniff-names` not known)*

------
https://chatgpt.com/codex/tasks/task_e_685422afb0c883318d80d71cf206d1bc