### PR TITLE
Add uninstall cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ The **Troubleshooting** submenu lets you view error logs and choose how much Jav
 2. Activate **Council Debt Counters** in the WordPress admin.
 3. Visit **Debt Counters** in the admin menu to enter your license key and start adding councils.
 
+## Uninstalling
+Deleting the plugin from the Plugins screen removes all data it created. This includes the custom `council` posts, uploaded documents, custom database tables and stored options like the licence key or OpenAI API key.
+
 ## Legal notice
 
 When displaying council data you must comply with the **Copyright, Designs and Patents Act 1988**, **Section 11A of the Freedom of Information Act 2001**, and the **Re-Use of Public Sector Information Regulations 2005**. Data must not be shown in a misleading context or used for commercial gain, including behind paywalls. Always attribute the data source to the relevant council whenever it is displayed, including when output via shortcodes.

--- a/uninstall.php
+++ b/uninstall.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * Uninstall script for Council Debt Counters.
+ *
+ * @package CouncilDebtCounters
+ */
+
+if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
+	exit;
+}
+
+// Options to remove.
+$option_names = array(
+	'cdc_license_key',
+	'cdc_license_valid',
+	'cdc_openai_api_key',
+	'cdc_enabled_counters',
+	'cdc_log_level',
+	'cdc_waste_report_count',
+);
+
+foreach ( $option_names as $option ) {
+	delete_option( $option );
+	delete_site_option( $option );
+}
+
+// Drop custom tables.
+global $wpdb;
+$tables = array(
+	$wpdb->prefix . 'cdc_fields',
+	$wpdb->prefix . 'cdc_field_values',
+	$wpdb->prefix . 'cdc_documents',
+);
+
+foreach ( $tables as $table ) {
+	$wpdb->query( "DROP TABLE IF EXISTS {$table}" ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQL.NotPrepared
+}
+
+// Delete custom post types.
+$council_posts = get_posts(
+	array(
+		'post_type'   => 'council',
+		'numberposts' => -1,
+		'post_status' => 'any',
+		'fields'      => 'ids',
+	)
+);
+
+foreach ( $council_posts as $council_id ) {
+	wp_delete_post( $council_id, true );
+}
+
+$waste_reports = get_posts(
+	array(
+		'post_type'   => 'waste_report',
+		'numberposts' => -1,
+		'post_status' => 'any',
+		'fields'      => 'ids',
+	)
+);
+
+foreach ( $waste_reports as $report_id ) {
+	wp_delete_post( $report_id, true );
+}
+
+// Remove uploaded documents and log file.
+$docs_dir = plugin_dir_path( __FILE__ ) . 'docs/';
+if ( file_exists( $docs_dir ) ) {
+	$files = new RecursiveIteratorIterator( new RecursiveDirectoryIterator( $docs_dir, RecursiveDirectoryIterator::SKIP_DOTS ), RecursiveIteratorIterator::CHILD_FIRST );
+	foreach ( $files as $file ) {
+		if ( $file->isDir() ) {
+			rmdir( $file->getRealPath() );
+		} else {
+			unlink( $file->getRealPath() );
+		}
+	}
+	rmdir( $docs_dir );
+}
+
+$log_file = plugin_dir_path( __FILE__ ) . 'troubleshooting.log';
+if ( file_exists( $log_file ) ) {
+	unlink( $log_file );
+}


### PR DESCRIPTION
## Summary
- add uninstall.php script to remove plugin data
- document uninstall behaviour in README

## Testing
- `./vendor/bin/phpcs --standard=WordPress uninstall.php -n -q`
- `./vendor/bin/phpcs --standard=WordPress README.md -n -q`
- `./vendor/bin/phpunit` *(fails: Test directory not found)*

------
https://chatgpt.com/codex/tasks/task_e_685422bb1f748331aed5d600a26a13b1