### PR TITLE
Add council search shortcode

### DIFF
--- a/council-debt-counters.php
+++ b/council-debt-counters.php
@@ -33,6 +33,8 @@ require_once plugin_dir_path( __FILE__ ) . 'includes/class-debt-adjustments-page
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-whistleblower-form.php';
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-admin-dashboard-widget.php';
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-shortcode-playground.php';
+require_once plugin_dir_path( __FILE__ ) . 'includes/class-council-search.php';
+require_once plugin_dir_path( __FILE__ ) . 'includes/class-stats-page.php';
 
 register_activation_hook( __FILE__, function() {
     \CouncilDebtCounters\Custom_Fields::install();
@@ -62,6 +64,8 @@ add_action( 'plugins_loaded', function() {
     \CouncilDebtCounters\Whistleblower_Form::init();
     \CouncilDebtCounters\Admin_Dashboard_Widget::init();
     \CouncilDebtCounters\Shortcode_Playground::init();
+    \CouncilDebtCounters\Council_Search::init();
+    \CouncilDebtCounters\Stats_Page::init();
 } );
 
 /**

--- a/includes/class-council-search.php
+++ b/includes/class-council-search.php
@@ -1,0 +1,76 @@
+<?php
+namespace CouncilDebtCounters;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class Council_Search {
+    const SHORTCODE = 'council_search';
+
+    public static function init() {
+        add_shortcode( self::SHORTCODE, [ __CLASS__, 'render' ] );
+        add_action( 'wp_enqueue_scripts', [ __CLASS__, 'register_assets' ] );
+        add_action( 'wp_ajax_cdc_search_councils', [ __CLASS__, 'ajax_search' ] );
+        add_action( 'wp_ajax_nopriv_cdc_search_councils', [ __CLASS__, 'ajax_search' ] );
+    }
+
+    public static function register_assets() {
+        $plugin_file = dirname( __DIR__ ) . '/council-debt-counters.php';
+        wp_register_script( 'cdc-council-search', plugins_url( 'public/js/council-search.js', $plugin_file ), [], '0.1.0', true );
+        wp_localize_script( 'cdc-council-search', 'cdcSearch', [
+            'ajaxUrl' => admin_url( 'admin-ajax.php' ),
+            'nonce'   => wp_create_nonce( 'cdc_search_nonce' ),
+            'message' => __( "If you cannot find your local council in these search results it just means we have not yet analysed it, but we will - and soon!", 'council-debt-counters' ),
+        ] );
+    }
+
+    public static function render() {
+        wp_enqueue_style( 'bootstrap-5' );
+        wp_enqueue_script( 'bootstrap-5' );
+        wp_enqueue_script( 'cdc-council-search' );
+        ob_start();
+        ?>
+        <div class="cdc-search-widget">
+            <input type="text" class="form-control mb-2" id="cdc-council-search" placeholder="<?php esc_attr_e( 'Search for your council…', 'council-debt-counters' ); ?>" autocomplete="off" />
+            <div id="cdc-search-results" class="list-group"></div>
+            <div id="cdc-search-message" class="mt-2 text-muted small"></div>
+        </div>
+        <?php
+        return ob_get_clean();
+    }
+
+    public static function ajax_search() {
+        check_ajax_referer( 'cdc_search_nonce', 'nonce' );
+        $query = sanitize_text_field( wp_unslash( $_GET['q'] ?? '' ) );
+        if ( strlen( $query ) < 3 ) {
+            wp_send_json_success( [] );
+        }
+        $ip  = $_SERVER['REMOTE_ADDR'] ?? 'unknown';
+        $key = 'cdc_search_rate_' . md5( $ip );
+        if ( false !== get_transient( $key ) ) {
+            wp_send_json_error( [ 'message' => __( "Whoa there! You're searching too quickly, slow it down or the system will confuse you for a robot!", 'council-debt-counters' ) ] );
+        }
+        set_transient( $key, 1, 2 );
+        Stats_Page::log_search( $query );
+        $args = [
+            'post_type'   => 'page',
+            'post_status' => 'publish',
+            'post_parent' => 3642,
+            's'           => $query,
+            'numberposts' => -1,
+            'orderby'     => 'title',
+            'order'       => 'ASC',
+            'fields'      => 'ids',
+        ];
+        $posts = get_posts( $args );
+        $results = [];
+        foreach ( $posts as $id ) {
+            $results[] = [
+                'title' => get_the_title( $id ),
+                'url'   => get_permalink( $id ),
+            ];
+        }
+        wp_send_json_success( $results );
+    }
+}

--- a/includes/class-stats-page.php
+++ b/includes/class-stats-page.php
@@ -1,0 +1,50 @@
+<?php
+namespace CouncilDebtCounters;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class Stats_Page {
+    const PAGE_SLUG = 'cdc-stats';
+    const OPTION_KEY = 'cdc_search_stats';
+
+    public static function init() {
+        add_action( 'admin_menu', [ __CLASS__, 'add_menu' ] );
+    }
+
+    public static function add_menu() {
+        add_submenu_page(
+            'council-debt-counters',
+            __( 'Stats', 'council-debt-counters' ),
+            __( 'Stats', 'council-debt-counters' ),
+            'manage_options',
+            self::PAGE_SLUG,
+            [ __CLASS__, 'render_page' ]
+        );
+    }
+
+    public static function render_page() {
+        echo '<div class="wrap"><h1>' . esc_html__( 'Search Stats', 'council-debt-counters' ) . '</h1>';
+        $stats = get_option( self::OPTION_KEY, [] );
+        if ( empty( $stats ) ) {
+            echo '<p>' . esc_html__( 'No searches logged yet.', 'council-debt-counters' ) . '</p></div>';
+            return;
+        }
+        echo '<table class="widefat striped"><thead><tr><th>' . esc_html__( 'Search Term', 'council-debt-counters' ) . '</th><th>' . esc_html__( 'Count', 'council-debt-counters' ) . '</th></tr></thead><tbody>';
+        foreach ( $stats as $term => $count ) {
+            echo '<tr><td>' . esc_html( $term ) . '</td><td>' . intval( $count ) . '</td></tr>';
+        }
+        echo '</tbody></table></div>';
+    }
+
+    public static function log_search( string $term ) {
+        $term  = mb_strtolower( $term );
+        $stats = get_option( self::OPTION_KEY, [] );
+        if ( ! isset( $stats[ $term ] ) ) {
+            $stats[ $term ] = 0;
+        }
+        $stats[ $term ]++;
+        update_option( self::OPTION_KEY, $stats, false );
+    }
+}

--- a/public/js/council-search.js
+++ b/public/js/council-search.js
@@ -1,0 +1,49 @@
+(function(){
+    'use strict';
+    function debounce(fn, delay){
+        let timer;
+        return function(){
+            clearTimeout(timer);
+            timer = setTimeout(fn, delay);
+        };
+    }
+    document.addEventListener('DOMContentLoaded', function(){
+        const input = document.getElementById('cdc-council-search');
+        if(!input) return;
+        const list = document.getElementById('cdc-search-results');
+        const msg = document.getElementById('cdc-search-message');
+        const info = window.cdcSearch && window.cdcSearch.message ? window.cdcSearch.message : '';
+        function render(items){
+            list.innerHTML = '';
+            if(!items || items.length === 0){
+                msg.textContent = info;
+                return;
+            }
+            msg.textContent = info;
+            items.forEach(function(i){
+                const a = document.createElement('a');
+                a.className = 'list-group-item list-group-item-action';
+                a.href = i.url;
+                a.textContent = i.title;
+                list.appendChild(a);
+            });
+        }
+        function search(){
+            const q = input.value.trim();
+            if(q.length < 3){
+                list.innerHTML = '';
+                msg.textContent = '';
+                return;
+            }
+            const url = `${cdcSearch.ajaxUrl}?action=cdc_search_councils&nonce=${cdcSearch.nonce}&q=${encodeURIComponent(q)}`;
+            fetch(url).then(r=>r.json()).then(data=>{
+                if(data.success){
+                    render(data.data);
+                }else if(data.data && data.data.message){
+                    msg.textContent = data.data.message;
+                }
+            }).catch(()=>{});
+        }
+        input.addEventListener('input', debounce(search, 300));
+    });
+})();


### PR DESCRIPTION
## Summary
- add Stats admin page to track search queries
- add frontend shortcode `[council_search]` with AJAX search
- implement rate limiting and logging
- ship `council-search.js` for UI

## Testing
- `./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6855f918727483318b0b9ac4889b9d6f