### PR TITLE
Add whistleblower reports admin area with AJAX form

### DIFF
--- a/admin/views/councils-page.php
+++ b/admin/views/councils-page.php
@@ -56,7 +56,7 @@ if ( $action === 'edit' ) {
                 <li class="nav-item"><button class="nav-link" data-bs-toggle="tab" data-bs-target="#tab-docs" type="button" role="tab"><?php esc_html_e( 'Documents', 'council-debt-counters' ); ?></button></li>
             <?php endif; ?>
             <?php if ( $post_id ) : ?>
-                <li class="nav-item"><button class="nav-link" data-bs-toggle="tab" data-bs-target="#tab-reports" type="button" role="tab"><?php esc_html_e( 'Whistleblowers', 'council-debt-counters' ); ?></button></li>
+                <!-- Whistleblower reports moved to dedicated admin page -->
             <?php endif; ?>
         </ul>
         <div class="tab-content pt-3">
@@ -184,44 +184,7 @@ if ( $action === 'edit' ) {
             </div>
             <?php endif; ?>
             <?php if ( $post_id ) : ?>
-            <div class="tab-pane fade" id="tab-reports" role="tabpanel">
-                <p class="description"><code>[whistleblower_form id="<?php echo esc_attr( $post_id ); ?>"]</code></p>
-                <?php $reports = get_posts([
-                    'post_type'   => \CouncilDebtCounters\Whistleblower_Form::CPT,
-                    'numberposts' => -1,
-                    'meta_key'    => 'council_id',
-                    'meta_value'  => $post_id,
-                ]); ?>
-                <?php if ( empty( $reports ) ) : ?>
-                    <p><?php esc_html_e( 'No reports yet.', 'council-debt-counters' ); ?></p>
-                <?php else : ?>
-                <table class="widefat">
-                    <thead>
-                        <tr>
-                            <th><?php esc_html_e( 'Date', 'council-debt-counters' ); ?></th>
-                            <th><?php esc_html_e( 'Description', 'council-debt-counters' ); ?></th>
-                            <th><?php esc_html_e( 'Attachment', 'council-debt-counters' ); ?></th>
-                            <th><?php esc_html_e( 'Email', 'council-debt-counters' ); ?></th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                    <?php foreach ( $reports as $r ) : ?>
-                        <tr>
-                            <td><?php echo esc_html( get_the_date( '', $r ) ); ?></td>
-                            <td><?php echo esc_html( wp_trim_words( $r->post_content, 15, '…' ) ); ?></td>
-                            <td>
-                                <?php $aid = get_post_meta( $r->ID, 'attachment_id', true ); ?>
-                                <?php if ( $aid ) : ?>
-                                    <?php echo wp_get_attachment_link( $aid ); ?>
-                                <?php endif; ?>
-                            </td>
-                            <td><?php echo esc_html( get_post_meta( $r->ID, 'contact_email', true ) ); ?></td>
-                        </tr>
-                    <?php endforeach; ?>
-                    </tbody>
-                </table>
-                <?php endif; ?>
-            </div>
+            <!-- Whistleblower reports moved to dedicated admin page -->
             <?php endif; ?>
         </div>
         <?php submit_button( __( 'Save Council', 'council-debt-counters' ) ); ?>

--- a/admin/views/whistleblower-reports-page.php
+++ b/admin/views/whistleblower-reports-page.php
@@ -1,0 +1,68 @@
+<?php
+use CouncilDebtCounters\Whistleblower_Form;
+use CouncilDebtCounters\Whistleblower_Reports_Page;
+
+if ( ! defined( 'ABSPATH' ) ) exit;
+
+$report_id = isset( $_GET['report'] ) ? intval( $_GET['report'] ) : 0;
+
+if ( $report_id ) {
+    $report = get_post( $report_id );
+    if ( $report && $report->post_type === Whistleblower_Form::CPT ) {
+        $council_id   = (int) get_post_meta( $report_id, 'council_id', true );
+        $email        = get_post_meta( $report_id, 'contact_email', true );
+        $attachment_id = get_post_meta( $report_id, 'attachment_id', true );
+        $ip           = get_post_meta( $report_id, 'ip_address', true );
+        ?>
+        <div class="wrap">
+            <h1><?php esc_html_e( 'Whistleblower Report', 'council-debt-counters' ); ?></h1>
+            <p><strong><?php esc_html_e( 'Date:', 'council-debt-counters' ); ?></strong> <?php echo esc_html( get_the_date( '', $report ) ); ?></p>
+            <p><strong><?php esc_html_e( 'Council:', 'council-debt-counters' ); ?></strong> <?php echo $council_id ? esc_html( get_the_title( $council_id ) ) : esc_html__( 'Unknown', 'council-debt-counters' ); ?></p>
+            <p><strong><?php esc_html_e( 'Contact Email:', 'council-debt-counters' ); ?></strong> <?php echo esc_html( $email ); ?></p>
+            <p><strong><?php esc_html_e( 'IP Address:', 'council-debt-counters' ); ?></strong> <?php echo esc_html( $ip ); ?></p>
+            <p><strong><?php esc_html_e( 'Description:', 'council-debt-counters' ); ?></strong></p>
+            <div class="card p-3 mb-3"><?php echo wp_kses_post( nl2br( esc_html( $report->post_content ) ) ); ?></div>
+            <?php if ( $attachment_id ) : ?>
+                <p><strong><?php esc_html_e( 'Attachment:', 'council-debt-counters' ); ?></strong> <?php echo wp_get_attachment_link( $attachment_id ); ?></p>
+            <?php endif; ?>
+            <p><a href="<?php echo esc_url( admin_url( 'admin.php?page=' . Whistleblower_Reports_Page::SLUG ) ); ?>" class="button"><?php esc_html_e( 'Back to list', 'council-debt-counters' ); ?></a></p>
+        </div>
+        <?php
+    } else {
+        echo '<div class="wrap"><p>' . esc_html__( 'Report not found.', 'council-debt-counters' ) . '</p></div>';
+    }
+    return;
+}
+
+$reports = get_posts([
+    'post_type'   => Whistleblower_Form::CPT,
+    'numberposts' => -1,
+]);
+?>
+<div class="wrap">
+    <h1><?php esc_html_e( 'Whistleblower Reports', 'council-debt-counters' ); ?></h1>
+    <?php if ( empty( $reports ) ) : ?>
+        <p><?php esc_html_e( 'No reports found.', 'council-debt-counters' ); ?></p>
+    <?php else : ?>
+    <table class="widefat fixed striped">
+        <thead>
+            <tr>
+                <th><?php esc_html_e( 'Date', 'council-debt-counters' ); ?></th>
+                <th><?php esc_html_e( 'Council', 'council-debt-counters' ); ?></th>
+                <th><?php esc_html_e( 'Summary', 'council-debt-counters' ); ?></th>
+                <th><?php esc_html_e( 'Email', 'council-debt-counters' ); ?></th>
+            </tr>
+        </thead>
+        <tbody>
+        <?php foreach ( $reports as $r ) : ?>
+            <tr>
+                <td><?php echo esc_html( get_the_date( '', $r ) ); ?></td>
+                <td><?php $cid = get_post_meta( $r->ID, 'council_id', true ); echo $cid ? esc_html( get_the_title( $cid ) ) : esc_html__( 'Unknown', 'council-debt-counters' ); ?></td>
+                <td><a href="<?php echo esc_url( admin_url( 'admin.php?page=' . Whistleblower_Reports_Page::SLUG . '&report=' . $r->ID ) ); ?>"><?php echo esc_html( wp_trim_words( $r->post_content, 10, '…' ) ); ?></a></td>
+                <td><?php echo esc_html( get_post_meta( $r->ID, 'contact_email', true ) ); ?></td>
+            </tr>
+        <?php endforeach; ?>
+        </tbody>
+    </table>
+    <?php endif; ?>
+</div>

--- a/council-debt-counters.php
+++ b/council-debt-counters.php
@@ -30,6 +30,7 @@ require_once plugin_dir_path( __FILE__ ) . 'includes/class-custom-fields.php';
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-openai-helper.php';
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-ai-extractor.php';
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-debt-adjustments-page.php';
+require_once plugin_dir_path( __FILE__ ) . 'includes/class-whistleblower-reports-page.php';
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-whistleblower-form.php';
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-admin-dashboard-widget.php';
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-shortcode-playground.php';
@@ -60,6 +61,7 @@ add_action( 'plugins_loaded', function() {
     \CouncilDebtCounters\License_Manager::init();
     \CouncilDebtCounters\OpenAI_Helper::init();
     \CouncilDebtCounters\Whistleblower_Form::init();
+    \CouncilDebtCounters\Whistleblower_Reports_Page::init();
     \CouncilDebtCounters\Admin_Dashboard_Widget::init();
     \CouncilDebtCounters\Shortcode_Playground::init();
 } );

--- a/includes/class-whistleblower-reports-page.php
+++ b/includes/class-whistleblower-reports-page.php
@@ -1,0 +1,29 @@
+<?php
+namespace CouncilDebtCounters;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class Whistleblower_Reports_Page {
+    const SLUG = 'cdc-whistleblower-reports';
+
+    public static function init() {
+        add_action( 'admin_menu', [ __CLASS__, 'add_menu' ] );
+    }
+
+    public static function add_menu() {
+        add_submenu_page(
+            'council-debt-counters',
+            __( 'Whistleblower Reports', 'council-debt-counters' ),
+            __( 'Whistleblower Reports', 'council-debt-counters' ),
+            'manage_options',
+            self::SLUG,
+            [ __CLASS__, 'render' ]
+        );
+    }
+
+    public static function render() {
+        include plugin_dir_path( __DIR__ ) . 'admin/views/whistleblower-reports-page.php';
+    }
+}

--- a/public/js/whistleblower-form.js
+++ b/public/js/whistleblower-form.js
@@ -1,0 +1,39 @@
+(document=>{
+  document.addEventListener('DOMContentLoaded',()=>{
+    const form=document.querySelector('.cdc-waste-form');
+    if(!form)return;
+    form.addEventListener('submit',e=>{
+      e.preventDefault();
+      const handle=token=>{
+        const data=new FormData(form);
+        if(token){data.set('g-recaptcha-response',token);}
+        data.append('action','cdc_report_waste');
+        fetch(cdcWhistle.ajaxUrl,{method:'POST',credentials:'same-origin',body:data})
+          .then(r=>r.json())
+          .then(res=>{
+            const box=form.nextElementSibling;
+            if(res.success){
+              form.reset();
+              box.className='alert alert-success cdc-response mt-3';
+              box.textContent=cdcWhistle.success;
+            }else{
+              box.className='alert alert-danger cdc-response mt-3';
+              box.textContent=res.data||cdcWhistle.failure;
+            }
+          })
+          .catch(()=>{
+            const box=form.nextElementSibling;
+            box.className='alert alert-danger cdc-response mt-3';
+            box.textContent=cdcWhistle.failure;
+          });
+      };
+      if(cdcWhistle.siteKey){
+        grecaptcha.enterprise.ready(()=>{
+          grecaptcha.enterprise.execute(cdcWhistle.siteKey,{action:'report'}).then(handle);
+        });
+      }else{
+        handle('');
+      }
+    });
+  });
+})(document);


### PR DESCRIPTION
## Summary
- create Whistleblower Reports admin page and menu
- log IP address and rate‑limit report submissions
- submit whistleblower form via AJAX with success/failure messages
- move whistleblower list out of council editor

## Testing
- `vendor/bin/phpunit`
- `vendor/bin/phpcs` *(fails: numerous style errors)*

------
https://chatgpt.com/codex/tasks/task_e_6855fa3fba948331bebda94a11b29e7a