### PR TITLE
Fix whistleblower rate limit handling

### DIFF
--- a/admin/views/whistleblower-reports-page.php
+++ b/admin/views/whistleblower-reports-page.php
@@ -37,6 +37,7 @@ if ( $report_id ) {
 $reports = get_posts([
     'post_type'   => Whistleblower_Form::CPT,
     'numberposts' => -1,
+    'post_status' => 'private', // Reports are saved as private
 ]);
 ?>
 <div class="wrap">

--- a/includes/class-whistleblower-form.php
+++ b/includes/class-whistleblower-form.php
@@ -7,6 +7,8 @@
 
 namespace CouncilDebtCounters;
 
+use CouncilDebtCounters\Error_Logger;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
@@ -77,10 +79,13 @@ class Whistleblower_Form {
 
                $ip         = sanitize_text_field( wp_unslash( $_SERVER['REMOTE_ADDR'] ?? '' ) );
                $limit_key   = 'cdc_waste_limit_' . md5( $ip );
-               $last_submit = get_transient( $limit_key );
-               if ( $last_submit ) {
-                       return new \WP_Error( 'rate_limited', __( "Whoa there! You're blowing that whistle a bit too quickly for the system to believe you're a human. Grab a drink and take a few minutes to relax before trying again.", 'council-debt-counters' ) );
-               }
+              $last_submit = get_transient( $limit_key );
+              $cooldown    = MINUTE_IN_SECONDS * 5;
+              Error_Logger::log_debug( 'Processing whistleblower submission from ' . $ip );
+              if ( $last_submit && ( time() - (int) $last_submit ) < $cooldown ) {
+                      Error_Logger::log_info( 'Rate limit triggered for IP ' . $ip );
+                      return new \WP_Error( 'rate_limited', __( "Whoa there! You're blowing that whistle a bit too quickly for the system to believe you're a human. Grab a drink and take a few minutes to relax before trying again.", 'council-debt-counters' ) );
+              }
 
                $council_id = isset( $_POST['cdc_council_id'] ) ? intval( wp_unslash( $_POST['cdc_council_id'] ) ) : 0;
 
@@ -89,8 +94,10 @@ class Whistleblower_Form {
                if ( $site_key && $secret_key ) {
                        $token = sanitize_text_field( wp_unslash( $_POST['g-recaptcha-response'] ?? '' ) );
                        if ( empty( $token ) ) {
+                               Error_Logger::log_error( 'reCAPTCHA token missing for IP ' . $ip );
                                return new \WP_Error( 'recaptcha', __( 'reCAPTCHA verification failed.', 'council-debt-counters' ) );
                        }
+                       Error_Logger::log_debug( 'Verifying reCAPTCHA for IP ' . $ip );
                        $verify = wp_remote_post(
                                'https://www.google.com/recaptcha/api/siteverify',
                                array(
@@ -104,6 +111,7 @@ class Whistleblower_Form {
                        );
                        $body = json_decode( wp_remote_retrieve_body( $verify ), true );
                        if ( empty( $body['success'] ) ) {
+                               Error_Logger::log_error( 'reCAPTCHA failure for IP ' . $ip );
                                return new \WP_Error( 'recaptcha', __( 'reCAPTCHA verification failed.', 'council-debt-counters' ) );
                        }
                }
@@ -122,9 +130,10 @@ class Whistleblower_Form {
                                'gif'  => 'image/gif',
                        );
 
-                       if ( isset( $_FILES['cdc_file']['size'] ) && $_FILES['cdc_file']['size'] > $max_size ) {
-                               return new \WP_Error( 'file_size', __( 'File exceeds maximum size of 5MB.', 'council-debt-counters' ) );
-                       }
+               if ( isset( $_FILES['cdc_file']['size'] ) && $_FILES['cdc_file']['size'] > $max_size ) {
+                       Error_Logger::log_error( 'Uploaded file too large from IP ' . $ip );
+                       return new \WP_Error( 'file_size', __( 'File exceeds maximum size of 5MB.', 'council-debt-counters' ) );
+               }
 
                        require_once ABSPATH . 'wp-admin/includes/file.php';
                        $uploaded = wp_handle_upload(
@@ -139,6 +148,7 @@ class Whistleblower_Form {
                                $filetype = wp_check_filetype( $uploaded['file'] );
                                if ( ! in_array( $filetype['type'], $allowed_mime, true ) ) {
                                        @unlink( $uploaded['file'] );
+                                       Error_Logger::log_error( 'Invalid file type uploaded from IP ' . $ip );
                                        return new \WP_Error( 'file_type', __( 'Invalid file type.', 'council-debt-counters' ) );
                                }
                                $attachment_id = wp_insert_attachment(
@@ -149,6 +159,7 @@ class Whistleblower_Form {
                                        ),
                                        $uploaded['file']
                                );
+                               Error_Logger::log_debug( 'File uploaded for whistleblower report from ' . $ip );
                        }
                }
 
@@ -176,6 +187,7 @@ class Whistleblower_Form {
                $count = (int) get_option( 'cdc_waste_report_count', 0 );
                update_option( 'cdc_waste_report_count', $count + 1 );
                set_transient( $limit_key, time(), MINUTE_IN_SECONDS * 5 );
+               Error_Logger::log_info( 'Whistleblower report saved with ID ' . $post_id . ' from ' . $ip );
                return $post_id;
        }
 
@@ -187,12 +199,20 @@ class Whistleblower_Form {
                        return;
                }
 
+               if ( defined( 'DOING_AJAX' ) && DOING_AJAX ) {
+                       return;
+               }
+
+               Error_Logger::log_debug( 'Handling standard whistleblower submission' );
+
                $result = self::process_submission();
                if ( is_wp_error( $result ) ) {
+                       Error_Logger::log_error( 'Whistleblower submission error: ' . $result->get_error_message() );
                        wp_die( esc_html( $result->get_error_message() ) );
                }
 
                wp_safe_redirect( add_query_arg( 'report', 'thanks', wp_get_referer() ) );
+               Error_Logger::log_info( 'Whistleblower report submitted via form with ID ' . $result );
                exit;
        }
 
@@ -202,9 +222,11 @@ class Whistleblower_Form {
        public static function ajax_submission() {
                $result = self::process_submission();
                if ( is_wp_error( $result ) ) {
+                       Error_Logger::log_error( 'Whistleblower AJAX error: ' . $result->get_error_message() );
                        wp_send_json_error( $result->get_error_message() );
                }
 
+               Error_Logger::log_info( 'Whistleblower report submitted via AJAX with ID ' . $result );
                wp_send_json_success( __( 'Thank you for your report.', 'council-debt-counters' ) );
        }
 
@@ -235,6 +257,7 @@ class Whistleblower_Form {
                        'success'  => __( 'Thank you for your report.', 'council-debt-counters' ),
                        'failure'  => __( 'Submission failed. Please try again.', 'council-debt-counters' ),
                        'delayMsg' => __( "Whoa there! You're blowing that whistle a bit too quickly for the system to believe you're a human. Grab a drink and take a few minutes to relax before trying again.", 'council-debt-counters' ),
+                       'submitting' => __( 'Submitting', 'council-debt-counters' ),
                ) );
 
 		ob_start();

--- a/public/js/whistleblower-form.js
+++ b/public/js/whistleblower-form.js
@@ -4,6 +4,10 @@
     if(!form)return;
     form.addEventListener('submit',e=>{
       e.preventDefault();
+      const button=form.querySelector('button[type="submit"]');
+      const original=button.innerHTML;
+      button.disabled=true;
+      button.innerHTML='<span class="spinner-border spinner-border-sm me-2" role="status" aria-hidden="true"></span>'+cdcWhistle.submitting;
       const handle=token=>{
         const data=new FormData(form);
         if(token){data.set('g-recaptcha-response',token);}
@@ -25,6 +29,10 @@
             const box=form.nextElementSibling;
             box.className='alert alert-danger cdc-response mt-3';
             box.textContent=cdcWhistle.failure;
+          })
+          .finally(()=>{
+            button.disabled=false;
+            button.innerHTML=original;
           });
       };
       if(cdcWhistle.siteKey){


### PR DESCRIPTION
## Summary
- prevent false rate limit triggers by checking timestamp difference
- show spinner and disable submit button while AJAX call is running

## Testing
- `./vendor/bin/phpcs includes/class-whistleblower-form.php` *(fails: many style violations)*
- `./vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68566bd0f9f08331a8b188a0f0ed3c2b