### PR TITLE
Add ratio, leaderboard and social sharing features

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ yarn-error.log
 # Log files
 *.log
 troubleshooting.log
+.phpunit.result.cache
 
 # OS-generated files
 .DS_Store

--- a/includes/class-shortcode-renderer.php
+++ b/includes/class-shortcode-renderer.php
@@ -107,11 +107,15 @@ class Shortcode_Renderer {
                 add_shortcode( 'total_interest_counter', array( __CLASS__, 'render_total_interest_counter' ) );
                 add_shortcode( 'total_revenue_counter', array( __CLASS__, 'render_total_revenue_counter' ) );
                 add_shortcode( 'total_custom_counter', array( __CLASS__, 'render_total_custom_counter' ) );
-		add_action( 'wp_enqueue_scripts', array( __CLASS__, 'register_assets' ) );
-		add_action( 'admin_enqueue_scripts', array( __CLASS__, 'register_assets' ) );
-		add_action( 'wp_ajax_cdc_log_js', array( __CLASS__, 'ajax_log_js' ) );
-		add_action( 'wp_ajax_nopriv_cdc_log_js', array( __CLASS__, 'ajax_log_js' ) );
-	}
+                add_shortcode( 'cdc_leaderboard', array( __CLASS__, 'render_leaderboard' ) );
+                add_shortcode( 'cdc_share_buttons', array( __CLASS__, 'render_share_buttons' ) );
+                add_action( 'wp_enqueue_scripts', array( __CLASS__, 'register_assets' ) );
+                add_action( 'admin_enqueue_scripts', array( __CLASS__, 'register_assets' ) );
+                add_action( 'wp_ajax_cdc_log_js', array( __CLASS__, 'ajax_log_js' ) );
+                add_action( 'wp_ajax_nopriv_cdc_log_js', array( __CLASS__, 'ajax_log_js' ) );
+                add_action( 'wp_ajax_cdc_log_share', array( __CLASS__, 'ajax_log_share' ) );
+                add_action( 'wp_ajax_nopriv_cdc_log_share', array( __CLASS__, 'ajax_log_share' ) );
+        }
 
 	public static function register_assets() {
 		$plugin_file = dirname( __DIR__ ) . '/council-debt-counters.php';
@@ -134,8 +138,9 @@ class Shortcode_Renderer {
 		wp_register_style( 'cdc-counter-font', $font_url, array(), null );
 		wp_add_inline_style( 'cdc-counter-font', ".cdc-counter{font-family:'{$font}',sans-serif;font-weight:{$weight};}" );
 		wp_register_script( 'countup', $countup_js, array(), '2.6.2', true );
-		wp_register_script( 'cdc-counter-animations', plugins_url( 'public/js/counter-animations.js', $plugin_file ), array( 'countup' ), '0.1.0', true );
-		wp_register_style( 'bootstrap-5', $bootstrap_css, array(), '5.3.1' );
+                wp_register_script( 'cdc-counter-animations', plugins_url( 'public/js/counter-animations.js', $plugin_file ), array( 'countup' ), '0.1.0', true );
+                wp_register_script( 'cdc-share-tracking', plugins_url( 'public/js/share-tracking.js', $plugin_file ), array(), '0.1.0', true );
+                wp_register_style( 'bootstrap-5', $bootstrap_css, array(), '5.3.1' );
 		wp_register_script( 'bootstrap-5', $bootstrap_js, array(), '5.3.1', true );
 		wp_localize_script(
 			'cdc-counter-animations',
@@ -212,7 +217,10 @@ class Shortcode_Renderer {
 			'H' => (int) Custom_Fields::get_value( $id, 'band_h_properties' ),
 		);
 
-		$population = (int) Custom_Fields::get_value( $id, 'population' );
+                $population = (int) Custom_Fields::get_value( $id, 'population' );
+
+                $reserves = (float) Custom_Fields::get_value( $id, 'usable_reserves' );
+                $reserves_ratio = ( $reserves > 0 && $total > 0 ) ? round( ( $reserves / $total ) * 100, 1 ) : null;
 
 		$debt_repayment_explainer = __( 'Growth uses the annual interest figure from the latest accounts. Actual borrowing and repayments may differ.', 'council-debt-counters' );
 
@@ -230,10 +238,14 @@ class Shortcode_Renderer {
                                 <span aria-hidden="true">&#x2139;</span><span class="visually-hidden"><?php esc_html_e( 'View details', 'council-debt-counters' ); ?></span>
                         </button>
 			<div class="collapse" id="<?php echo esc_attr( $collapse_id ); ?>">
-				<ul class="mt-2 list-unstyled">
-						<li><?php esc_html_e( 'Interest Paid (annual):', 'council-debt-counters' ); ?> £<?php echo esc_html( number_format_i18n( (float) $details['interest'], 2 ) ); ?></li>
-						<li><?php esc_html_e( 'Net growth/reduction per second:', 'council-debt-counters' ); ?> £<?php echo esc_html( number_format_i18n( $growth_per_second, 6 ) ); ?></li>
-				</ul>
+                                <ul class="mt-2 list-unstyled">
+                                                <li><?php esc_html_e( 'Interest Paid (annual):', 'council-debt-counters' ); ?> £<?php echo esc_html( number_format_i18n( (float) $details['interest'], 2 ) ); ?></li>
+                                                <li><?php esc_html_e( 'Net growth/reduction per second:', 'council-debt-counters' ); ?> £<?php echo esc_html( number_format_i18n( $growth_per_second, 6 ) ); ?></li>
+                                                <?php if ( null !== $reserves_ratio ) : ?>
+                                                <li><?php esc_html_e( 'Reserves to Debt Ratio:', 'council-debt-counters' ); ?> <?php echo esc_html( number_format_i18n( $reserves_ratio, 1 ) ); ?>%</li>
+                                                <li class="small text-muted"><?php esc_html_e( 'A lower ratio indicates a higher reliance on borrowing relative to savings.', 'council-debt-counters' ); ?></li>
+                                                <?php endif; ?>
+                                </ul>
 				<?php if ( array_sum( $bands ) > 0 ) : ?>
 					<h5><?php esc_html_e( 'Debt per property by Council Tax Band:', 'council-debt-counters' ); ?></h5>
 					<ul class="mt-2 list-unstyled">
@@ -305,10 +317,10 @@ endforeach;
 
         public static function render_custom_counter( $atts ) {
                 $id   = self::get_council_id_from_atts( $atts );
-		$type = sanitize_key( $atts['type'] ?? '' );
-		if ( 0 === $id || '' === $type ) {
-			return '';
-		}
+                $type = sanitize_key( $atts['type'] ?? '' );
+                if ( 0 === $id || '' === $type ) {
+                        return '';
+                }
 		$map = array(
 			'reserves'    => 'usable_reserves',
 			'spending'    => 'annual_spending',
@@ -321,6 +333,51 @@ endforeach;
 			return '';
 		}
                 return self::render_annual_counter( $id, $map[ $type ], $type );
+        }
+
+        public static function render_share_buttons( $atts ) {
+                $id = self::get_council_id_from_atts( $atts );
+                if ( 0 === $id ) {
+                        return '';
+                }
+
+                $name     = get_the_title( $id );
+                $interest  = (float) Custom_Fields::get_value( $id, 'interest_paid_on_debt' );
+                $debt      = (float) Custom_Fields::get_value( $id, 'total_debt' );
+                $permalink = get_permalink();
+
+                if ( $interest > 0 ) {
+                        $message = sprintf( __( '%1$s spends £%2$s a year on debt interest. Find out more:', 'council-debt-counters' ), $name, number_format_i18n( $interest, 1 ) );
+                } else {
+                        $message = sprintf( __( '%1$s’s debt is £%2$s. See how it compares:', 'council-debt-counters' ), $name, number_format_i18n( $debt, 0 ) );
+                }
+
+                $encoded = rawurlencode( $message . ' ' . $permalink );
+
+                wp_enqueue_style( 'bootstrap-5' );
+                wp_enqueue_script( 'bootstrap-5' );
+                wp_enqueue_script( 'cdc-share-tracking' );
+                wp_localize_script( 'cdc-share-tracking', 'cdcShare', array(
+                        'ajaxUrl' => admin_url( 'admin-ajax.php' ),
+                        'nonce'   => wp_create_nonce( 'cdc_log_share' ),
+                ) );
+
+                ob_start();
+                ?>
+                <div class="cdc-share-buttons mt-3">
+                        <div class="fw-bold mb-1"><?php esc_html_e( 'Share this', 'council-debt-counters' ); ?></div>
+                        <a class="btn btn-outline-primary btn-sm me-2 cdc-share-link" data-council-id="<?php echo esc_attr( $id ); ?>" data-share-type="twitter" target="_blank" rel="noopener noreferrer" href="https://x.com/intent/tweet?text=<?php echo esc_attr( $encoded ); ?>">
+                                X
+                        </a>
+                        <a class="btn btn-outline-success btn-sm me-2 cdc-share-link" data-council-id="<?php echo esc_attr( $id ); ?>" data-share-type="whatsapp" target="_blank" rel="noopener noreferrer" href="https://wa.me/?text=<?php echo esc_attr( $encoded ); ?>">
+                                WhatsApp
+                        </a>
+                        <a class="btn btn-outline-primary btn-sm cdc-share-link" data-council-id="<?php echo esc_attr( $id ); ?>" data-share-type="facebook" target="_blank" rel="noopener noreferrer" href="https://www.facebook.com/sharer/sharer.php?u=<?php echo esc_attr( rawurlencode( $permalink ) ); ?>">
+                                Facebook
+                        </a>
+                </div>
+                <?php
+                return ob_get_clean();
         }
 
         private static function render_total_annual_counter( string $field, string $type = '' ) {
@@ -475,12 +532,151 @@ endforeach;
                 return ob_get_clean();
         }
 
-	public static function ajax_log_js() {
-		check_ajax_referer( 'cdc_log_js', 'nonce' );
-		$message = sanitize_text_field( wp_unslash( $_POST['message'] ?? '' ) );
-		if ( $message ) {
-			Error_Logger::log_info( 'JS: ' . $message );
-		}
-		wp_die();
-	}
+        public static function render_leaderboard( $atts ) {
+                $atts = shortcode_atts(
+                        array(
+                                'type'   => 'highest_debt',
+                                'limit'  => 10,
+                                'format' => 'table',
+                                'link'   => '0',
+                        ),
+                        $atts
+                );
+
+                $type   = sanitize_key( $atts['type'] );
+                $limit  = max( 1, intval( $atts['limit'] ) );
+                $format = in_array( $atts['format'], array( 'table', 'list' ), true ) ? $atts['format'] : 'table';
+                $with_link = (bool) intval( $atts['link'] );
+
+                $posts = get_posts(
+                        array(
+                                'post_type'   => 'council',
+                                'numberposts' => -1,
+                                'fields'      => 'ids',
+                        )
+                );
+
+                $rows = array();
+                foreach ( $posts as $id ) {
+                        $data = array();
+                        $debt      = (float) Custom_Fields::get_value( $id, 'total_debt' );
+                        $population = (float) Custom_Fields::get_value( $id, 'population' );
+                        $reserves  = (float) Custom_Fields::get_value( $id, 'usable_reserves' );
+                        $spending  = (float) Custom_Fields::get_value( $id, 'annual_spending' );
+                        $income    = (float) Custom_Fields::get_value( $id, 'total_income' );
+                        $deficit   = (float) Custom_Fields::get_value( $id, 'annual_deficit' );
+                        $interest  = (float) Custom_Fields::get_value( $id, 'interest_paid' );
+
+                        switch ( $type ) {
+                                case 'highest_debt':
+                                        $value = $debt;
+                                        break;
+                                case 'debt_per_resident':
+                                        $value = ( $population > 0 ) ? $debt / $population : null;
+                                        break;
+                                case 'debt_to_reserves_ratio':
+                                        $value = ( $reserves > 0 ) ? $debt / $reserves : null;
+                                        break;
+                                case 'biggest_deficit':
+                                        $value = $deficit !== 0 ? $deficit : ( $spending - $income );
+                                        break;
+                                case 'lowest_reserves':
+                                        $value = $reserves;
+                                        break;
+                                case 'highest_spending_per_resident':
+                                        $value = ( $population > 0 ) ? $spending / $population : null;
+                                        break;
+                                case 'highest_interest_paid':
+                                        $value = $interest;
+                                        break;
+                                default:
+                                        $value = null;
+                        }
+
+                        if ( null === $value ) {
+                                continue;
+                        }
+
+                        $rows[] = array(
+                                'id'    => $id,
+                                'name'  => get_the_title( $id ),
+                                'value' => $value,
+                        );
+                }
+
+                $desc = true;
+                if ( 'lowest_reserves' === $type ) {
+                        $desc = false;
+                }
+
+                usort(
+                        $rows,
+                        function ( $a, $b ) use ( $desc ) {
+                                if ( $a['value'] === $b['value'] ) {
+                                        return 0;
+                                }
+                                if ( $desc ) {
+                                        return ( $a['value'] < $b['value'] ) ? 1 : -1;
+                                } else {
+                                        return ( $a['value'] < $b['value'] ) ? -1 : 1;
+                                }
+                        }
+                );
+
+                $rows = array_slice( $rows, 0, $limit );
+
+                wp_enqueue_style( 'bootstrap-5' );
+                wp_enqueue_script( 'bootstrap-5' );
+
+                ob_start();
+                if ( 'list' === $format ) {
+                        echo '<ul class="list-group">';
+                        foreach ( $rows as $row ) {
+                                $label = ( in_array( $type, array( 'debt_to_reserves_ratio' ), true ) ) ? number_format_i18n( $row['value'], 2 ) . '%' : '£' . number_format_i18n( $row['value'], 2 );
+                                echo '<li class="list-group-item d-flex justify-content-between align-items-center">';
+                                echo esc_html( $row['name'] );
+                                echo '<span class="badge bg-secondary">' . esc_html( $label ) . '</span>';
+                                if ( $with_link ) {
+                                        echo ' <a class="ms-2" href="' . esc_url( get_permalink( $row['id'] ) ) . '">' . esc_html__( 'View details', 'council-debt-counters' ) . '</a>';
+                                }
+                                echo '</li>';
+                        }
+                        echo '</ul>';
+                } else {
+                        echo '<table class="table table-striped">';
+                        echo '<thead><tr><th>' . esc_html__( 'Council', 'council-debt-counters' ) . '</th><th>' . esc_html__( 'Value', 'council-debt-counters' ) . '</th>'; 
+                        if ( $with_link ) {
+                                echo '<th></th>';
+                        }
+                        echo '</tr></thead><tbody>';
+                        foreach ( $rows as $row ) {
+                                $label = ( in_array( $type, array( 'debt_to_reserves_ratio' ), true ) ) ? number_format_i18n( $row['value'], 2 ) . '%' : '£' . number_format_i18n( $row['value'], 2 );
+                                echo '<tr><td>' . esc_html( $row['name'] ) . '</td><td>' . esc_html( $label ) . '</td>';
+                                if ( $with_link ) {
+                                        echo '<td><a href="' . esc_url( get_permalink( $row['id'] ) ) . '">' . esc_html__( 'View details', 'council-debt-counters' ) . '</a></td>';
+                                }
+                                echo '</tr>';
+                        }
+                        echo '</tbody></table>';
+                }
+                return ob_get_clean();
+        }
+
+        public static function ajax_log_js() {
+                check_ajax_referer( 'cdc_log_js', 'nonce' );
+                $message = sanitize_text_field( wp_unslash( $_POST['message'] ?? '' ) );
+                if ( $message ) {
+                        Error_Logger::log_info( 'JS: ' . $message );
+                }
+                wp_die();
+        }
+
+        public static function ajax_log_share() {
+                check_ajax_referer( 'cdc_log_share', 'nonce' );
+                $id = isset( $_POST['id'] ) ? intval( $_POST['id'] ) : 0;
+                if ( $id ) {
+                        Stats_Page::log_share( $id );
+                }
+                wp_die();
+        }
 }

--- a/includes/class-stats-page.php
+++ b/includes/class-stats-page.php
@@ -8,6 +8,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 class Stats_Page {
     const PAGE_SLUG = 'cdc-stats';
     const OPTION_KEY = 'cdc_search_stats';
+    const SHARE_KEY = 'cdc_share_stats';
 
     public static function init() {
         add_action( 'admin_menu', [ __CLASS__, 'add_menu' ] );
@@ -25,17 +26,32 @@ class Stats_Page {
     }
 
     public static function render_page() {
-        echo '<div class="wrap"><h1>' . esc_html__( 'Search Stats', 'council-debt-counters' ) . '</h1>';
+        echo '<div class="wrap">';
+        echo '<h1>' . esc_html__( 'Search Stats', 'council-debt-counters' ) . '</h1>';
         $stats = get_option( self::OPTION_KEY, [] );
         if ( empty( $stats ) ) {
-            echo '<p>' . esc_html__( 'No searches logged yet.', 'council-debt-counters' ) . '</p></div>';
-            return;
+            echo '<p>' . esc_html__( 'No searches logged yet.', 'council-debt-counters' ) . '</p>';
+        } else {
+            echo '<table class="widefat striped"><thead><tr><th>' . esc_html__( 'Search Term', 'council-debt-counters' ) . '</th><th>' . esc_html__( 'Count', 'council-debt-counters' ) . '</th></tr></thead><tbody>';
+            foreach ( $stats as $term => $count ) {
+                echo '<tr><td>' . esc_html( $term ) . '</td><td>' . intval( $count ) . '</td></tr>';
+            }
+            echo '</tbody></table>';
         }
-        echo '<table class="widefat striped"><thead><tr><th>' . esc_html__( 'Search Term', 'council-debt-counters' ) . '</th><th>' . esc_html__( 'Count', 'council-debt-counters' ) . '</th></tr></thead><tbody>';
-        foreach ( $stats as $term => $count ) {
-            echo '<tr><td>' . esc_html( $term ) . '</td><td>' . intval( $count ) . '</td></tr>';
+
+        echo '<h1 class="mt-5">' . esc_html__( 'Most Shared Councils', 'council-debt-counters' ) . '</h1>';
+        $shares = get_option( self::SHARE_KEY, [] );
+        if ( empty( $shares ) ) {
+            echo '<p>' . esc_html__( 'No shares logged yet.', 'council-debt-counters' ) . '</p>';
+        } else {
+            arsort( $shares );
+            echo '<table class="widefat striped"><thead><tr><th>' . esc_html__( 'Council', 'council-debt-counters' ) . '</th><th>' . esc_html__( 'Shares', 'council-debt-counters' ) . '</th></tr></thead><tbody>';
+            foreach ( $shares as $id => $count ) {
+                echo '<tr><td>' . esc_html( get_the_title( $id ) ) . '</td><td>' . intval( $count ) . '</td></tr>';
+            }
+            echo '</tbody></table>';
         }
-        echo '</tbody></table></div>';
+        echo '</div>';
     }
 
     public static function log_search( string $term ) {
@@ -46,5 +62,14 @@ class Stats_Page {
         }
         $stats[ $term ]++;
         update_option( self::OPTION_KEY, $stats, false );
+    }
+
+    public static function log_share( int $id ) {
+        $shares = get_option( self::SHARE_KEY, [] );
+        if ( ! isset( $shares[ $id ] ) ) {
+            $shares[ $id ] = 0;
+        }
+        $shares[ $id ]++;
+        update_option( self::SHARE_KEY, $shares, false );
     }
 }

--- a/public/js/share-tracking.js
+++ b/public/js/share-tracking.js
@@ -1,0 +1,28 @@
+(function(){
+    'use strict';
+    function logShare(el){
+        if(!window.cdcShare) return;
+        try{
+            var data=new FormData();
+            data.append('action','cdc_log_share');
+            data.append('nonce',cdcShare.nonce);
+            data.append('id',el.dataset.councilId);
+            navigator.sendBeacon(cdcShare.ajaxUrl,data);
+        }catch(e){}
+    }
+    function track(el){
+        var type=el.dataset.shareType||'';
+        if(window.gtag){
+            window.gtag('event','share',{event_category:'CDC Share',event_label:type});
+        }else if(window.ga){
+            window.ga('send','event','CDC Share',type);
+        }
+        logShare(el);
+    }
+    document.addEventListener('DOMContentLoaded',function(){
+        document.querySelectorAll('.cdc-share-link').forEach(function(a){
+            a.addEventListener('click',function(){track(a);});
+        });
+    });
+})();
+


### PR DESCRIPTION
## Summary
- add reserves-to-debt ratio in council debt details
- implement `[cdc_leaderboard]` shortcode for ranked tables
- implement `[cdc_share_buttons]` shortcode with share tracking
- track share counts in Stats admin page
- include JS for share tracking and ignore phpunit cache

## Testing
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6856b1f3d27083319e9eed51417848a0