### PR TITLE
Add draft status and sample CSV upload

### DIFF
--- a/admin/css/import-progress.css
+++ b/admin/css/import-progress.css
@@ -1,0 +1,25 @@
+#cdc-import-overlay {
+	position: fixed;
+	top: 0;
+	left: 0;
+	right: 0;
+	bottom: 0;
+	background: rgba(255, 255, 255, 0.8);
+	z-index: 10000;
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+}
+#cdc-import-overlay p {
+	margin-top: 10px;
+	font-size: 16px;
+}
+#cdc-import-overlay .progress {
+	width: 80%;
+	height: 8px;
+	margin-top: 8px;
+}
+#cdc-import-overlay .progress-bar {
+	transition: width 0.5s linear;
+}

--- a/admin/js/import-csv.js
+++ b/admin/js/import-csv.js
@@ -1,0 +1,79 @@
+(function (document) {
+	document.addEventListener(
+		'DOMContentLoaded',
+		function () {
+			var form = document.getElementById( 'cdc-import-form' );
+			if ( ! form) {
+				return;
+			}
+			var file              = form.querySelector( 'input[type="file"]' );
+			var submit            = form.querySelector( 'button[type="submit"]' );
+			var overlay           = document.createElement( 'div' );
+			overlay.id            = 'cdc-import-overlay';
+			overlay.style.display = 'none';
+			overlay.innerHTML     = '<span class="spinner is-active"></span><div class="progress w-75 mt-2" style="height:8px"><div class="progress-bar"></div></div><p></p>';
+			document.body.appendChild( overlay );
+			form.addEventListener(
+				'submit',
+				function (e) {
+					e.preventDefault();
+					if ( ! file.files.length) {
+						return;
+					}
+					submit.disabled       = true;
+					overlay.style.display = 'flex';
+					var bar               = overlay.querySelector( '.progress-bar' );
+					var msg               = overlay.querySelector( 'p' );
+					var reader            = new FileReader();
+					reader.onload         = function (ev) {
+						var lines = ev.target.result.trim().split( /\r?\n/ );
+						if (lines.length <= 1) {
+							msg.textContent = cdcImport.done;
+							bar.style.width = '100%';
+							submit.disabled = false;
+							return;
+						}
+						var header = lines[0].split( ',' );
+						var index  = 0,total = lines.length - 1;
+						function next(){
+							if (index >= total) {
+								bar.style.width = '100%';
+								msg.textContent = cdcImport.done;
+								setTimeout(
+									function () {
+										location.reload();},
+									800
+								);
+								return;
+							}
+							var parts = lines[index + 1].split( ',' );
+							var row   = {};
+							header.forEach(
+								function (h,i) {
+									row[h] = parts[i] || '';}
+							);
+							var data = new FormData();
+							data.append( 'action','cdc_import_row' );
+							data.append( 'nonce',cdcImport.nonce );
+							data.append( 'row',JSON.stringify( row ) );
+							fetch( cdcImport.ajaxUrl,{method:'POST',credentials:'same-origin',body:data} )
+								.finally(
+									function () {
+										index++;
+										var pct         = Math.round( (index / total) * 100 );
+										bar.style.width = pct + '%';
+										msg.textContent = cdcImport.progress.replace( '%1',index ).replace( '%2',total );
+										next();
+									}
+								);
+						}
+						msg.textContent = cdcImport.progress.replace( '%1',0 ).replace( '%2',total );
+						bar.style.width = '0%';
+						next();
+					};
+					reader.readAsText( file.files[0] );
+				}
+			);
+		}
+	);
+})( document );

--- a/admin/views/councils-page.php
+++ b/admin/views/councils-page.php
@@ -3,19 +3,20 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-$action  = isset( $_GET['action'] ) ? sanitize_text_field( $_GET['action'] ) : '';
-$post_id = isset( $_GET['post'] ) ? intval( $_GET['post'] ) : 0;
 
-if ( $action === 'delete' && $post_id ) {
-	check_admin_referer( 'cdc_delete_council_' . $post_id );
-	wp_delete_post( $post_id, true );
-	echo '<div class="alert alert-success"><p>' . esc_html__( 'Council deleted.', 'council-debt-counters' ) . '</p></div>';
-	$action = '';
+$req_action = isset( $_GET['action'] ) ? sanitize_text_field( $_GET['action'] ) : '';
+$council_id = isset( $_GET['post'] ) ? intval( $_GET['post'] ) : 0;
+
+if ( 'delete' === $req_action && $council_id ) {
+		check_admin_referer( 'cdc_delete_council_' . $council_id );
+		wp_delete_post( $council_id, true );
+		echo '<div class="alert alert-success"><p>' . esc_html__( 'Council deleted.', 'council-debt-counters' ) . '</p></div>';
+		$req_action = '';
 }
 
-if ( $action === 'edit' ) {
-	echo '<div class="wrap">';
-	echo '<h1>' . esc_html( $post_id ? __( 'Edit Council', 'council-debt-counters' ) : __( 'Add Council', 'council-debt-counters' ) ) . '</h1>';
+if ( 'edit' === $req_action ) {
+		echo '<div class="wrap">';
+		echo '<h1>' . esc_html( $council_id ? __( 'Edit Council', 'council-debt-counters' ) : __( 'Add Council', 'council-debt-counters' ) ) . '</h1>';
 	$fields  = \CouncilDebtCounters\Custom_Fields::get_fields();
 	$enabled = (array) get_option( 'cdc_enabled_counters', array() );
 	$mapping = array(
@@ -33,40 +34,40 @@ if ( $action === 'edit' ) {
 	}
 	$docs_field = null;
 	foreach ( $fields as $field ) {
-		if ( $field->name === 'statement_of_accounts' ) {
+		if ( 'statement_of_accounts' === $field->name ) {
 			$docs_field = $field;
 			continue; }
 		$placed = false;
-		foreach ( $mapping as $type => $names ) {
-			if ( in_array( $field->name, $names, true ) ) {
-				if ( isset( $groups[ $type ] ) ) {
-					$groups[ $type ][] = $field; }
-				$placed = true;
-				break;
+		foreach ( $mapping as $group_key => $field_names ) {
+			if ( in_array( $field->name, $field_names, true ) ) {
+				if ( isset( $groups[ $group_key ] ) ) {
+					$groups[ $group_key ][] = $field; }
+					$placed = true;
+					break;
 			}
 		}
 		if ( ! $placed ) {
 			$groups['general'][] = $field; }
 	}
-	$docs = $post_id ? \CouncilDebtCounters\Docs_Manager::list_documents( $post_id ) : array();
+		$docs = $council_id ? \CouncilDebtCounters\Docs_Manager::list_documents( $council_id ) : array();
 	?>
 	<form method="post" enctype="multipart/form-data" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
 		<input type="hidden" name="action" value="cdc_save_council">
 		<?php wp_nonce_field( 'cdc_save_council' ); ?>
-		<input type="hidden" name="post_id" value="<?php echo esc_attr( $post_id ); ?>">
+				<input type="hidden" name="post_id" value="<?php echo esc_attr( $council_id ); ?>">
 		<ul class="nav nav-tabs" role="tablist">
 			<li class="nav-item"><button class="nav-link active" data-bs-toggle="tab" data-bs-target="#tab-general" type="button" role="tab"><?php esc_html_e( 'General', 'council-debt-counters' ); ?></button></li>
 			<?php
-			foreach ( $enabled as $tab ) :
-				if ( empty( $groups[ $tab ] ) ) {
-					continue;}
+			foreach ( $enabled as $tab_key ) :
+				if ( empty( $groups[ $tab_key ] ) ) {
+								continue;}
 				?>
-				<li class="nav-item"><button class="nav-link" data-bs-toggle="tab" data-bs-target="#tab-<?php echo esc_attr( $tab ); ?>" type="button" role="tab"><?php echo esc_html( ucfirst( $tab ) ); ?></button></li>
-			<?php endforeach; ?>
+								<li class="nav-item"><button class="nav-link" data-bs-toggle="tab" data-bs-target="#tab-<?php echo esc_attr( $tab_key ); ?>" type="button" role="tab"><?php echo esc_html( ucfirst( $tab_key ) ); ?></button></li>
+						<?php endforeach; ?>
 			<?php if ( $docs_field ) : ?>
 				<li class="nav-item"><button class="nav-link" data-bs-toggle="tab" data-bs-target="#tab-docs" type="button" role="tab"><?php esc_html_e( 'Documents', 'council-debt-counters' ); ?></button></li>
 			<?php endif; ?>
-			<?php if ( $post_id ) : ?>
+						<?php if ( $council_id ) : ?>
 				<!-- Whistleblower reports moved to dedicated admin page -->
 			<?php endif; ?>
 		</ul>
@@ -77,38 +78,38 @@ if ( $action === 'edit' ) {
 				$council_types     = array( 'Unitary', 'County', 'District', 'Metropolitan Borough', 'London Borough', 'Parish', 'Town', 'Combined Authority' );
 				$council_locations = array( 'England', 'Wales', 'Scotland', 'Northern Ireland' );
 				foreach ( $groups['general'] as $field ) :
-					$val      = $post_id ? \CouncilDebtCounters\Custom_Fields::get_value( $post_id, $field->name ) : '';
-					$type     = $field->type === 'text' ? 'text' : 'number';
-					$required = $field->required ? 'required' : '';
-					$readonly = in_array( $field->name, \CouncilDebtCounters\Custom_Fields::READONLY_FIELDS, true );
+						$val         = $council_id ? \CouncilDebtCounters\Custom_Fields::get_value( $council_id, $field->name ) : '';
+						$input_type  = 'text' === $field->type ? 'text' : 'number';
+						$is_required = (bool) $field->required;
+						$readonly    = in_array( $field->name, \CouncilDebtCounters\Custom_Fields::READONLY_FIELDS, true );
 					?>
 					<tr>
 						<th scope="row"><label for="cdc-field-<?php echo esc_attr( $field->id ); ?>"><?php echo esc_html( $field->label ); ?>
-						<?php
-						if ( $field->required ) {
-							echo ' *';}
-						?>
+					<?php
+					if ( $field->required ) {
+						echo ' *';}
+					?>
 						</label></th>
 						<td>
-							<?php if ( $field->name === 'council_type' ) : ?>
-								<select id="cdc-field-<?php echo esc_attr( $field->id ); ?>" name="cdc_fields[<?php echo esc_attr( $field->id ); ?>]" <?php echo $required; ?> <?php echo $readonly ? 'disabled' : ''; ?>>
-									<?php foreach ( $council_types as $t ) : ?>
+										<?php if ( 'council_type' === $field->name ) : ?>
+																<select id="cdc-field-<?php echo esc_attr( $field->id ); ?>" name="cdc_fields[<?php echo esc_attr( $field->id ); ?>]" <?php echo $is_required ? 'required' : ''; ?> <?php echo $readonly ? 'disabled' : ''; ?>>
+											<?php foreach ( $council_types as $t ) : ?>
 										<option value="<?php echo esc_attr( $t ); ?>" <?php selected( $val, $t ); ?>><?php echo esc_html( $t ); ?></option>
 									<?php endforeach; ?>
 								</select>
-							<?php elseif ( $field->name === 'council_location' ) : ?>
-								<select id="cdc-field-<?php echo esc_attr( $field->id ); ?>" name="cdc_fields[<?php echo esc_attr( $field->id ); ?>]" <?php echo $required; ?> <?php echo $readonly ? 'disabled' : ''; ?>>
-									<?php foreach ( $council_locations as $t ) : ?>
+														<?php elseif ( 'council_location' === $field->name ) : ?>
+																<select id="cdc-field-<?php echo esc_attr( $field->id ); ?>" name="cdc_fields[<?php echo esc_attr( $field->id ); ?>]" <?php echo $is_required ? 'required' : ''; ?> <?php echo $readonly ? 'disabled' : ''; ?>>
+															<?php foreach ( $council_locations as $t ) : ?>
 										<option value="<?php echo esc_attr( $t ); ?>" <?php selected( $val, $t ); ?>><?php echo esc_html( $t ); ?></option>
 									<?php endforeach; ?>
 								</select>
-							<?php elseif ( $field->type === 'money' ) : ?>
+														<?php elseif ( 'money' === $field->type ) : ?>
 								<div class="input-group">
 									<span class="input-group-text">&pound;</span>
-									<input data-cdc-field="<?php echo esc_attr( $field->name ); ?>" type="number" step="0.01" id="cdc-field-<?php echo esc_attr( $field->id ); ?>" value="<?php echo esc_attr( $val ); ?>" class="regular-text" <?php echo $readonly ? 'readonly disabled' : 'name="cdc_fields[' . esc_attr( $field->id ) . ']" ' . $required; ?>>
+																		<input data-cdc-field="<?php echo esc_attr( $field->name ); ?>" type="number" step="0.01" id="cdc-field-<?php echo esc_attr( $field->id ); ?>" value="<?php echo esc_attr( $val ); ?>" class="regular-text" <?php echo $readonly ? 'readonly disabled' : 'name="cdc_fields[' . esc_attr( $field->id ) . ']"'; ?> <?php echo $is_required ? 'required' : ''; ?>>
 								</div>
 							<?php else : ?>
-								<input data-cdc-field="<?php echo esc_attr( $field->name ); ?>" type="<?php echo esc_attr( $type ); ?>" id="cdc-field-<?php echo esc_attr( $field->id ); ?>" value="<?php echo esc_attr( $val ); ?>" class="regular-text" <?php echo $readonly ? 'readonly disabled' : 'name="cdc_fields[' . esc_attr( $field->id ) . ']" ' . $required; ?>>
+																<input data-cdc-field="<?php echo esc_attr( $field->name ); ?>" type="<?php echo esc_attr( $input_type ); ?>" id="cdc-field-<?php echo esc_attr( $field->id ); ?>" value="<?php echo esc_attr( $val ); ?>" class="regular-text" <?php echo $readonly ? 'readonly disabled' : 'name="cdc_fields[' . esc_attr( $field->id ) . ']"'; ?> <?php echo $is_required ? 'required' : ''; ?>>
 							<?php endif; ?>
 						</td>
 					</tr>
@@ -116,7 +117,7 @@ if ( $action === 'edit' ) {
 				<tr>
 					<th scope="row"><label for="cdc-post-status"><?php esc_html_e( 'Status', 'council-debt-counters' ); ?></label></th>
 					<td>
-						<?php $current_status = $post_id ? get_post_status( $post_id ) : 'draft'; ?>
+												<?php $current_status = $council_id ? get_post_status( $council_id ) : 'draft'; ?>
 						<select id="cdc-post-status" name="post_status">
 							<option value="publish" <?php selected( $current_status, 'publish' ); ?>><?php esc_html_e( 'Active', 'council-debt-counters' ); ?></option>
 							<option value="draft" <?php selected( $current_status, 'draft' ); ?>><?php esc_html_e( 'Draft', 'council-debt-counters' ); ?></option>
@@ -127,47 +128,47 @@ if ( $action === 'edit' ) {
 				</table>
 			</div>
 			<?php
-			foreach ( $enabled as $tab ) :
-				if ( empty( $groups[ $tab ] ) ) {
-					continue;}
+			foreach ( $enabled as $tab_key ) :
+				if ( empty( $groups[ $tab_key ] ) ) {
+								continue;}
 				?>
-			<div class="tab-pane fade" id="tab-<?php echo esc_attr( $tab ); ?>" role="tabpanel">
-				<p class="description"><code>[council_counter id="<?php echo esc_attr( $post_id ); ?>" type="<?php echo esc_attr( $tab ); ?>"]</code></p>
-				<table class="form-table" role="presentation">
-				<?php
-				foreach ( $groups[ $tab ] as $field ) :
-					$val      = $post_id ? \CouncilDebtCounters\Custom_Fields::get_value( $post_id, $field->name ) : '';
-					$type     = $field->type === 'text' ? 'text' : 'number';
-					$required = $field->required ? 'required' : '';
-					$readonly = in_array( $field->name, \CouncilDebtCounters\Custom_Fields::READONLY_FIELDS, true );
-					?>
+						<div class="tab-pane fade" id="tab-<?php echo esc_attr( $tab_key ); ?>" role="tabpanel">
+								<p class="description"><code>[council_counter id="<?php echo esc_attr( $council_id ); ?>" type="<?php echo esc_attr( $tab_key ); ?>"]</code></p>
+								<table class="form-table" role="presentation">
+								<?php
+								foreach ( $groups[ $tab_key ] as $field ) :
+										$val         = $council_id ? \CouncilDebtCounters\Custom_Fields::get_value( $council_id, $field->name ) : '';
+										$input_type  = 'text' === $field->type ? 'text' : 'number';
+										$is_required = (bool) $field->required;
+										$readonly    = in_array( $field->name, \CouncilDebtCounters\Custom_Fields::READONLY_FIELDS, true );
+									?>
 					<tr>
 						<th scope="row"><label for="cdc-field-<?php echo esc_attr( $field->id ); ?>"><?php echo esc_html( $field->label ); ?>
-						<?php
-						if ( $field->required ) {
-							echo ' *';}
-						?>
+									<?php
+									if ( $field->required ) {
+										echo ' *';}
+									?>
 						</label></th>
 						<td>
-							<?php if ( $field->name === 'council_type' ) : ?>
-								<select id="cdc-field-<?php echo esc_attr( $field->id ); ?>" name="cdc_fields[<?php echo esc_attr( $field->id ); ?>]" <?php echo $required; ?> <?php echo $readonly ? 'disabled' : ''; ?>>
-									<?php foreach ( $council_types as $t ) : ?>
+														<?php if ( 'council_type' === $field->name ) : ?>
+																<select id="cdc-field-<?php echo esc_attr( $field->id ); ?>" name="cdc_fields[<?php echo esc_attr( $field->id ); ?>]" <?php echo $is_required ? 'required' : ''; ?> <?php echo $readonly ? 'disabled' : ''; ?>>
+															<?php foreach ( $council_types as $t ) : ?>
 										<option value="<?php echo esc_attr( $t ); ?>" <?php selected( $val, $t ); ?>><?php echo esc_html( $t ); ?></option>
 									<?php endforeach; ?>
 								</select>
-							<?php elseif ( $field->name === 'council_location' ) : ?>
-								<select id="cdc-field-<?php echo esc_attr( $field->id ); ?>" name="cdc_fields[<?php echo esc_attr( $field->id ); ?>]" <?php echo $required; ?> <?php echo $readonly ? 'disabled' : ''; ?>>
-									<?php foreach ( $council_locations as $t ) : ?>
+														<?php elseif ( 'council_location' === $field->name ) : ?>
+																<select id="cdc-field-<?php echo esc_attr( $field->id ); ?>" name="cdc_fields[<?php echo esc_attr( $field->id ); ?>]" <?php echo $is_required ? 'required' : ''; ?> <?php echo $readonly ? 'disabled' : ''; ?>>
+															<?php foreach ( $council_locations as $t ) : ?>
 										<option value="<?php echo esc_attr( $t ); ?>" <?php selected( $val, $t ); ?>><?php echo esc_html( $t ); ?></option>
 									<?php endforeach; ?>
 								</select>
-							<?php elseif ( $field->type === 'money' ) : ?>
+														<?php elseif ( 'money' === $field->type ) : ?>
 								<div class="input-group">
 									<span class="input-group-text">&pound;</span>
-									<input data-cdc-field="<?php echo esc_attr( $field->name ); ?>" type="number" step="0.01" id="cdc-field-<?php echo esc_attr( $field->id ); ?>" value="<?php echo esc_attr( $val ); ?>" class="regular-text" <?php echo $readonly ? 'readonly disabled' : 'name="cdc_fields[' . esc_attr( $field->id ) . ']" ' . $required; ?>>
+																		<input data-cdc-field="<?php echo esc_attr( $field->name ); ?>" type="number" step="0.01" id="cdc-field-<?php echo esc_attr( $field->id ); ?>" value="<?php echo esc_attr( $val ); ?>" class="regular-text" <?php echo $readonly ? 'readonly disabled' : 'name="cdc_fields[' . esc_attr( $field->id ) . ']"'; ?> <?php echo $is_required ? 'required' : ''; ?>>
 								</div>
 							<?php else : ?>
-								<input data-cdc-field="<?php echo esc_attr( $field->name ); ?>" type="<?php echo esc_attr( $type ); ?>" id="cdc-field-<?php echo esc_attr( $field->id ); ?>" value="<?php echo esc_attr( $val ); ?>" class="regular-text" <?php echo $readonly ? 'readonly disabled' : 'name="cdc_fields[' . esc_attr( $field->id ) . ']" ' . $required; ?>>
+																<input data-cdc-field="<?php echo esc_attr( $field->name ); ?>" type="<?php echo esc_attr( $input_type ); ?>" id="cdc-field-<?php echo esc_attr( $field->id ); ?>" value="<?php echo esc_attr( $val ); ?>" class="regular-text" <?php echo $readonly ? 'readonly disabled' : 'name="cdc_fields[' . esc_attr( $field->id ) . ']"'; ?> <?php echo $is_required ? 'required' : ''; ?>>
 							<?php endif; ?>
 						</td>
 					</tr>
@@ -181,7 +182,7 @@ if ( $action === 'edit' ) {
 					<tr>
 						<th scope="row"><label for="cdc-soa"><?php echo esc_html( $docs_field->label ); ?></label></th>
 						<td>
-							<?php $val = $post_id ? \CouncilDebtCounters\Custom_Fields::get_value( $post_id, 'statement_of_accounts' ) : ''; ?>
+														<?php $val = $council_id ? \CouncilDebtCounters\Custom_Fields::get_value( $council_id, 'statement_of_accounts' ) : ''; ?>
 							<?php if ( $val ) : ?>
 								<p><a href="<?php echo esc_url( plugins_url( 'docs/' . $val, dirname( __DIR__, 2 ) . '/council-debt-counters.php' ) ); ?>" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'View current document', 'council-debt-counters' ); ?></a></p>
 							<?php endif; ?>
@@ -249,7 +250,7 @@ if ( $action === 'edit' ) {
 				<?php endif; ?>
 			</div>
 			<?php endif; ?>
-			<?php if ( $post_id ) : ?>
+						<?php if ( $council_id ) : ?>
 			<!-- Whistleblower reports moved to dedicated admin page -->
 			<?php endif; ?>
 		</div>
@@ -263,7 +264,7 @@ if ( $action === 'edit' ) {
 $status_param   = isset( $_GET['status'] ) ? sanitize_key( $_GET['status'] ) : 'publish';
 $valid_statuses = array( 'publish', 'draft', 'under_review' );
 if ( ! in_array( $status_param, $valid_statuses, true ) ) {
-	$status_param = 'publish';
+		$status_param = 'publish';
 }
 $councils = get_posts(
 	array(

--- a/admin/views/councils-page.php
+++ b/admin/views/councils-page.php
@@ -1,232 +1,331 @@
 <?php
-if ( ! defined( 'ABSPATH' ) ) exit;
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
 
 $action  = isset( $_GET['action'] ) ? sanitize_text_field( $_GET['action'] ) : '';
 $post_id = isset( $_GET['post'] ) ? intval( $_GET['post'] ) : 0;
 
 if ( $action === 'delete' && $post_id ) {
-    check_admin_referer( 'cdc_delete_council_' . $post_id );
-    wp_delete_post( $post_id, true );
-    echo '<div class="alert alert-success"><p>' . esc_html__( 'Council deleted.', 'council-debt-counters' ) . '</p></div>';
-    $action = '';
+	check_admin_referer( 'cdc_delete_council_' . $post_id );
+	wp_delete_post( $post_id, true );
+	echo '<div class="alert alert-success"><p>' . esc_html__( 'Council deleted.', 'council-debt-counters' ) . '</p></div>';
+	$action = '';
 }
 
 if ( $action === 'edit' ) {
-    echo '<div class="wrap">';
-    echo '<h1>' . esc_html( $post_id ? __( 'Edit Council', 'council-debt-counters' ) : __( 'Add Council', 'council-debt-counters' ) ) . '</h1>';
-    $fields = \CouncilDebtCounters\Custom_Fields::get_fields();
-    $enabled = (array) get_option( 'cdc_enabled_counters', [] );
-    $mapping = [
-        'debt' => [ 'current_liabilities','long_term_liabilities','finance_lease_pfi_liabilities','manual_debt_entry','interest_paid_on_debt','total_debt' ],
-        'spending' => [ 'annual_spending' ],
-        'income' => [ 'total_income' ],
-        'deficit' => [ 'annual_deficit' ],
-        'interest' => [ 'interest_paid' ],
-        'reserves' => [ 'usable_reserves' ],
-        'consultancy' => [ 'consultancy_spend' ],
-    ];
-    $groups = [ 'general' => [] ];
-    foreach ( $enabled as $e ) {
-        $groups[ $e ] = [];
-    }
-    $docs_field = null;
-    foreach ( $fields as $field ) {
-        if ( $field->name === 'statement_of_accounts' ) { $docs_field = $field; continue; }
-        $placed = false;
-        foreach ( $mapping as $type => $names ) {
-            if ( in_array( $field->name, $names, true ) ) {
-                if ( isset( $groups[ $type ] ) ) { $groups[ $type ][] = $field; }
-                $placed = true; break;
-            }
-        }
-        if ( ! $placed ) { $groups['general'][] = $field; }
-    }
-    $docs = $post_id ? \CouncilDebtCounters\Docs_Manager::list_documents( $post_id ) : [];
-    ?>
-    <form method="post" enctype="multipart/form-data" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
-        <input type="hidden" name="action" value="cdc_save_council">
-        <?php wp_nonce_field( 'cdc_save_council' ); ?>
-        <input type="hidden" name="post_id" value="<?php echo esc_attr( $post_id ); ?>">
-        <ul class="nav nav-tabs" role="tablist">
-            <li class="nav-item"><button class="nav-link active" data-bs-toggle="tab" data-bs-target="#tab-general" type="button" role="tab"><?php esc_html_e( 'General', 'council-debt-counters' ); ?></button></li>
-            <?php foreach ( $enabled as $tab ) : if ( empty( $groups[ $tab ] ) ) continue; ?>
-                <li class="nav-item"><button class="nav-link" data-bs-toggle="tab" data-bs-target="#tab-<?php echo esc_attr( $tab ); ?>" type="button" role="tab"><?php echo esc_html( ucfirst( $tab ) ); ?></button></li>
-            <?php endforeach; ?>
-            <?php if ( $docs_field ) : ?>
-                <li class="nav-item"><button class="nav-link" data-bs-toggle="tab" data-bs-target="#tab-docs" type="button" role="tab"><?php esc_html_e( 'Documents', 'council-debt-counters' ); ?></button></li>
-            <?php endif; ?>
-            <?php if ( $post_id ) : ?>
-                <!-- Whistleblower reports moved to dedicated admin page -->
-            <?php endif; ?>
-        </ul>
-        <div class="tab-content pt-3">
-            <div class="tab-pane fade show active" id="tab-general" role="tabpanel">
-                <table class="form-table" role="presentation">
-                <?php foreach ( $groups['general'] as $field ) :
-                    $val = $post_id ? \CouncilDebtCounters\Custom_Fields::get_value( $post_id, $field->name ) : '';
-                    $type = $field->type === 'text' ? 'text' : 'number';
-                    $required = $field->required ? 'required' : '';
-                    $readonly = in_array( $field->name, \CouncilDebtCounters\Custom_Fields::READONLY_FIELDS, true ); ?>
-                    <tr>
-                        <th scope="row"><label for="cdc-field-<?php echo esc_attr( $field->id ); ?>"><?php echo esc_html( $field->label ); ?><?php if ( $field->required ) echo ' *'; ?></label></th>
-                        <td>
-                            <?php if ( $field->type === 'money' ) : ?>
-                                <div class="input-group">
-                                    <span class="input-group-text">&pound;</span>
-                                    <input data-cdc-field="<?php echo esc_attr( $field->name ); ?>" type="number" step="0.01" id="cdc-field-<?php echo esc_attr( $field->id ); ?>" value="<?php echo esc_attr( $val ); ?>" class="regular-text" <?php echo $readonly ? 'readonly disabled' : 'name="cdc_fields[' . esc_attr( $field->id ) . ']" ' . $required; ?>>
-                                </div>
-                            <?php else : ?>
-                                <input data-cdc-field="<?php echo esc_attr( $field->name ); ?>" type="<?php echo esc_attr( $type ); ?>" id="cdc-field-<?php echo esc_attr( $field->id ); ?>" value="<?php echo esc_attr( $val ); ?>" class="regular-text" <?php echo $readonly ? 'readonly disabled' : 'name="cdc_fields[' . esc_attr( $field->id ) . ']" ' . $required; ?>>
-                            <?php endif; ?>
-                        </td>
-                    </tr>
-                <?php endforeach; ?>
-                </table>
-            </div>
-            <?php foreach ( $enabled as $tab ) : if ( empty( $groups[ $tab ] ) ) continue; ?>
-            <div class="tab-pane fade" id="tab-<?php echo esc_attr( $tab ); ?>" role="tabpanel">
-                <p class="description"><code>[council_counter id="<?php echo esc_attr( $post_id ); ?>" type="<?php echo esc_attr( $tab ); ?>"]</code></p>
-                <table class="form-table" role="presentation">
-                <?php foreach ( $groups[ $tab ] as $field ) :
-                    $val = $post_id ? \CouncilDebtCounters\Custom_Fields::get_value( $post_id, $field->name ) : '';
-                    $type = $field->type === 'text' ? 'text' : 'number';
-                    $required = $field->required ? 'required' : '';
-                    $readonly = in_array( $field->name, \CouncilDebtCounters\Custom_Fields::READONLY_FIELDS, true ); ?>
-                    <tr>
-                        <th scope="row"><label for="cdc-field-<?php echo esc_attr( $field->id ); ?>"><?php echo esc_html( $field->label ); ?><?php if ( $field->required ) echo ' *'; ?></label></th>
-                        <td>
-                            <?php if ( $field->type === 'money' ) : ?>
-                                <div class="input-group">
-                                    <span class="input-group-text">&pound;</span>
-                                    <input data-cdc-field="<?php echo esc_attr( $field->name ); ?>" type="number" step="0.01" id="cdc-field-<?php echo esc_attr( $field->id ); ?>" value="<?php echo esc_attr( $val ); ?>" class="regular-text" <?php echo $readonly ? 'readonly disabled' : 'name="cdc_fields[' . esc_attr( $field->id ) . ']" ' . $required; ?>>
-                                </div>
-                            <?php else : ?>
-                                <input data-cdc-field="<?php echo esc_attr( $field->name ); ?>" type="<?php echo esc_attr( $type ); ?>" id="cdc-field-<?php echo esc_attr( $field->id ); ?>" value="<?php echo esc_attr( $val ); ?>" class="regular-text" <?php echo $readonly ? 'readonly disabled' : 'name="cdc_fields[' . esc_attr( $field->id ) . ']" ' . $required; ?>>
-                            <?php endif; ?>
-                        </td>
-                    </tr>
-                <?php endforeach; ?>
-                </table>
-            </div>
-            <?php endforeach; ?>
-            <?php if ( $docs_field ) : ?>
-            <div class="tab-pane fade" id="tab-docs" role="tabpanel">
-                <table class="form-table" role="presentation">
-                    <tr>
-                        <th scope="row"><label for="cdc-soa"><?php echo esc_html( $docs_field->label ); ?></label></th>
-                        <td>
-                            <?php $val = $post_id ? \CouncilDebtCounters\Custom_Fields::get_value( $post_id, 'statement_of_accounts' ) : ''; ?>
-                            <?php if ( $val ) : ?>
-                                <p><a href="<?php echo esc_url( plugins_url( 'docs/' . $val, dirname( __DIR__, 2 ) . '/council-debt-counters.php' ) ); ?>" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'View current document', 'council-debt-counters' ); ?></a></p>
-                            <?php endif; ?>
-                            <input type="file" id="cdc-soa" name="statement_of_accounts_file" accept="application/pdf">
-                            <p class="description"><?php esc_html_e( 'or import from URL', 'council-debt-counters' ); ?></p>
-                            <input type="url" name="statement_of_accounts_url" class="regular-text" placeholder="https://example.com/file.pdf">
-                            <p class="description mt-2">
-                                <label for="cdc-soa-year" class="form-label"><?php esc_html_e( 'Financial Year', 'council-debt-counters' ); ?></label>
-                                <select id="cdc-soa-year" name="statement_of_accounts_year">
-                                    <?php foreach ( \CouncilDebtCounters\Docs_Manager::financial_years() as $y ) : ?>
-                                        <option value="<?php echo esc_attr( $y ); ?>" <?php selected( \CouncilDebtCounters\Docs_Manager::current_financial_year(), $y ); ?>><?php echo esc_html( $y ); ?></option>
-                                    <?php endforeach; ?>
-                                </select>
-                            </p>
-                            <?php $orphans = \CouncilDebtCounters\Docs_Manager::list_orphan_documents(); ?>
-                            <?php if ( ! empty( $orphans ) ) : ?>
-                                <p class="description mt-2"><?php esc_html_e( 'Or attach an existing document', 'council-debt-counters' ); ?></p>
-                                <select name="statement_of_accounts_existing">
-                                    <option value=""><?php esc_html_e( 'Select document', 'council-debt-counters' ); ?></option>
-                                    <?php foreach ( $orphans as $doc ) : ?>
-                                        <option value="<?php echo esc_attr( $doc->filename ); ?>"><?php echo esc_html( $doc->filename ); ?></option>
-                                    <?php endforeach; ?>
-                                </select>
-                            <?php endif; ?>
-                        </td>
-                    </tr>
-                </table>
-                <?php if ( ! empty( $docs ) ) : ?>
-                <h2><?php esc_html_e( 'Existing Documents', 'council-debt-counters' ); ?></h2>
-                <table class="widefat">
-                    <thead>
-                        <tr>
-                            <th><?php esc_html_e( 'File', 'council-debt-counters' ); ?></th>
-                            <th><?php esc_html_e( 'Year', 'council-debt-counters' ); ?></th>
-                            <th><?php esc_html_e( 'Type', 'council-debt-counters' ); ?></th>
-                            <th><?php esc_html_e( 'Actions', 'council-debt-counters' ); ?></th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                    <?php foreach ( $docs as $d ) : ?>
-                        <tr>
-                            <td><?php echo esc_html( $d->filename ); ?></td>
-                            <td>
-                                <select name="docs[<?php echo esc_attr( $d->id ); ?>][financial_year]">
-                                    <?php foreach ( \CouncilDebtCounters\Docs_Manager::financial_years() as $y ) : ?>
-                                        <option value="<?php echo esc_attr( $y ); ?>" <?php selected( $d->financial_year, $y ); ?>><?php echo esc_html( $y ); ?></option>
-                                    <?php endforeach; ?>
-                                </select>
-                            </td>
-                            <td>
-                                <select name="docs[<?php echo esc_attr( $d->id ); ?>][doc_type]">
-                                    <option value="statement_of_accounts" <?php selected( $d->doc_type, 'statement_of_accounts' ); ?>><?php esc_html_e( 'Statement of Accounts', 'council-debt-counters' ); ?></option>
-                                </select>
-                            </td>
-                            <td>
-                                <button type="button" value="<?php echo esc_attr( $d->id ); ?>" class="button cdc-extract-ai"><span class="dashicons dashicons-lightbulb"></span> <?php esc_html_e( 'Extract Figures', 'council-debt-counters' ); ?></button>
+	echo '<div class="wrap">';
+	echo '<h1>' . esc_html( $post_id ? __( 'Edit Council', 'council-debt-counters' ) : __( 'Add Council', 'council-debt-counters' ) ) . '</h1>';
+	$fields  = \CouncilDebtCounters\Custom_Fields::get_fields();
+	$enabled = (array) get_option( 'cdc_enabled_counters', array() );
+	$mapping = array(
+		'debt'        => array( 'current_liabilities', 'long_term_liabilities', 'finance_lease_pfi_liabilities', 'manual_debt_entry', 'interest_paid_on_debt', 'total_debt' ),
+		'spending'    => array( 'annual_spending' ),
+		'income'      => array( 'total_income' ),
+		'deficit'     => array( 'annual_deficit' ),
+		'interest'    => array( 'interest_paid' ),
+		'reserves'    => array( 'usable_reserves' ),
+		'consultancy' => array( 'consultancy_spend' ),
+	);
+	$groups  = array( 'general' => array() );
+	foreach ( $enabled as $e ) {
+		$groups[ $e ] = array();
+	}
+	$docs_field = null;
+	foreach ( $fields as $field ) {
+		if ( $field->name === 'statement_of_accounts' ) {
+			$docs_field = $field;
+			continue; }
+		$placed = false;
+		foreach ( $mapping as $type => $names ) {
+			if ( in_array( $field->name, $names, true ) ) {
+				if ( isset( $groups[ $type ] ) ) {
+					$groups[ $type ][] = $field; }
+				$placed = true;
+				break;
+			}
+		}
+		if ( ! $placed ) {
+			$groups['general'][] = $field; }
+	}
+	$docs = $post_id ? \CouncilDebtCounters\Docs_Manager::list_documents( $post_id ) : array();
+	?>
+	<form method="post" enctype="multipart/form-data" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
+		<input type="hidden" name="action" value="cdc_save_council">
+		<?php wp_nonce_field( 'cdc_save_council' ); ?>
+		<input type="hidden" name="post_id" value="<?php echo esc_attr( $post_id ); ?>">
+		<ul class="nav nav-tabs" role="tablist">
+			<li class="nav-item"><button class="nav-link active" data-bs-toggle="tab" data-bs-target="#tab-general" type="button" role="tab"><?php esc_html_e( 'General', 'council-debt-counters' ); ?></button></li>
+			<?php
+			foreach ( $enabled as $tab ) :
+				if ( empty( $groups[ $tab ] ) ) {
+					continue;}
+				?>
+				<li class="nav-item"><button class="nav-link" data-bs-toggle="tab" data-bs-target="#tab-<?php echo esc_attr( $tab ); ?>" type="button" role="tab"><?php echo esc_html( ucfirst( $tab ) ); ?></button></li>
+			<?php endforeach; ?>
+			<?php if ( $docs_field ) : ?>
+				<li class="nav-item"><button class="nav-link" data-bs-toggle="tab" data-bs-target="#tab-docs" type="button" role="tab"><?php esc_html_e( 'Documents', 'council-debt-counters' ); ?></button></li>
+			<?php endif; ?>
+			<?php if ( $post_id ) : ?>
+				<!-- Whistleblower reports moved to dedicated admin page -->
+			<?php endif; ?>
+		</ul>
+		<div class="tab-content pt-3">
+			<div class="tab-pane fade show active" id="tab-general" role="tabpanel">
+				<table class="form-table" role="presentation">
+				<?php
+				$council_types     = array( 'Unitary', 'County', 'District', 'Metropolitan Borough', 'London Borough', 'Parish', 'Town', 'Combined Authority' );
+				$council_locations = array( 'England', 'Wales', 'Scotland', 'Northern Ireland' );
+				foreach ( $groups['general'] as $field ) :
+					$val      = $post_id ? \CouncilDebtCounters\Custom_Fields::get_value( $post_id, $field->name ) : '';
+					$type     = $field->type === 'text' ? 'text' : 'number';
+					$required = $field->required ? 'required' : '';
+					$readonly = in_array( $field->name, \CouncilDebtCounters\Custom_Fields::READONLY_FIELDS, true );
+					?>
+					<tr>
+						<th scope="row"><label for="cdc-field-<?php echo esc_attr( $field->id ); ?>"><?php echo esc_html( $field->label ); ?>
+						<?php
+						if ( $field->required ) {
+							echo ' *';}
+						?>
+						</label></th>
+						<td>
+							<?php if ( $field->name === 'council_type' ) : ?>
+								<select id="cdc-field-<?php echo esc_attr( $field->id ); ?>" name="cdc_fields[<?php echo esc_attr( $field->id ); ?>]" <?php echo $required; ?> <?php echo $readonly ? 'disabled' : ''; ?>>
+									<?php foreach ( $council_types as $t ) : ?>
+										<option value="<?php echo esc_attr( $t ); ?>" <?php selected( $val, $t ); ?>><?php echo esc_html( $t ); ?></option>
+									<?php endforeach; ?>
+								</select>
+							<?php elseif ( $field->name === 'council_location' ) : ?>
+								<select id="cdc-field-<?php echo esc_attr( $field->id ); ?>" name="cdc_fields[<?php echo esc_attr( $field->id ); ?>]" <?php echo $required; ?> <?php echo $readonly ? 'disabled' : ''; ?>>
+									<?php foreach ( $council_locations as $t ) : ?>
+										<option value="<?php echo esc_attr( $t ); ?>" <?php selected( $val, $t ); ?>><?php echo esc_html( $t ); ?></option>
+									<?php endforeach; ?>
+								</select>
+							<?php elseif ( $field->type === 'money' ) : ?>
+								<div class="input-group">
+									<span class="input-group-text">&pound;</span>
+									<input data-cdc-field="<?php echo esc_attr( $field->name ); ?>" type="number" step="0.01" id="cdc-field-<?php echo esc_attr( $field->id ); ?>" value="<?php echo esc_attr( $val ); ?>" class="regular-text" <?php echo $readonly ? 'readonly disabled' : 'name="cdc_fields[' . esc_attr( $field->id ) . ']" ' . $required; ?>>
+								</div>
+							<?php else : ?>
+								<input data-cdc-field="<?php echo esc_attr( $field->name ); ?>" type="<?php echo esc_attr( $type ); ?>" id="cdc-field-<?php echo esc_attr( $field->id ); ?>" value="<?php echo esc_attr( $val ); ?>" class="regular-text" <?php echo $readonly ? 'readonly disabled' : 'name="cdc_fields[' . esc_attr( $field->id ) . ']" ' . $required; ?>>
+							<?php endif; ?>
+						</td>
+					</tr>
+				<?php endforeach; ?>
+				<tr>
+					<th scope="row"><label for="cdc-post-status"><?php esc_html_e( 'Status', 'council-debt-counters' ); ?></label></th>
+					<td>
+						<?php $current_status = $post_id ? get_post_status( $post_id ) : 'draft'; ?>
+						<select id="cdc-post-status" name="post_status">
+							<option value="publish" <?php selected( $current_status, 'publish' ); ?>><?php esc_html_e( 'Active', 'council-debt-counters' ); ?></option>
+							<option value="draft" <?php selected( $current_status, 'draft' ); ?>><?php esc_html_e( 'Draft', 'council-debt-counters' ); ?></option>
+							<option value="under_review" <?php selected( $current_status, 'under_review' ); ?>><?php esc_html_e( 'Under Review', 'council-debt-counters' ); ?></option>
+						</select>
+					</td>
+				</tr>
+				</table>
+			</div>
+			<?php
+			foreach ( $enabled as $tab ) :
+				if ( empty( $groups[ $tab ] ) ) {
+					continue;}
+				?>
+			<div class="tab-pane fade" id="tab-<?php echo esc_attr( $tab ); ?>" role="tabpanel">
+				<p class="description"><code>[council_counter id="<?php echo esc_attr( $post_id ); ?>" type="<?php echo esc_attr( $tab ); ?>"]</code></p>
+				<table class="form-table" role="presentation">
+				<?php
+				foreach ( $groups[ $tab ] as $field ) :
+					$val      = $post_id ? \CouncilDebtCounters\Custom_Fields::get_value( $post_id, $field->name ) : '';
+					$type     = $field->type === 'text' ? 'text' : 'number';
+					$required = $field->required ? 'required' : '';
+					$readonly = in_array( $field->name, \CouncilDebtCounters\Custom_Fields::READONLY_FIELDS, true );
+					?>
+					<tr>
+						<th scope="row"><label for="cdc-field-<?php echo esc_attr( $field->id ); ?>"><?php echo esc_html( $field->label ); ?>
+						<?php
+						if ( $field->required ) {
+							echo ' *';}
+						?>
+						</label></th>
+						<td>
+							<?php if ( $field->name === 'council_type' ) : ?>
+								<select id="cdc-field-<?php echo esc_attr( $field->id ); ?>" name="cdc_fields[<?php echo esc_attr( $field->id ); ?>]" <?php echo $required; ?> <?php echo $readonly ? 'disabled' : ''; ?>>
+									<?php foreach ( $council_types as $t ) : ?>
+										<option value="<?php echo esc_attr( $t ); ?>" <?php selected( $val, $t ); ?>><?php echo esc_html( $t ); ?></option>
+									<?php endforeach; ?>
+								</select>
+							<?php elseif ( $field->name === 'council_location' ) : ?>
+								<select id="cdc-field-<?php echo esc_attr( $field->id ); ?>" name="cdc_fields[<?php echo esc_attr( $field->id ); ?>]" <?php echo $required; ?> <?php echo $readonly ? 'disabled' : ''; ?>>
+									<?php foreach ( $council_locations as $t ) : ?>
+										<option value="<?php echo esc_attr( $t ); ?>" <?php selected( $val, $t ); ?>><?php echo esc_html( $t ); ?></option>
+									<?php endforeach; ?>
+								</select>
+							<?php elseif ( $field->type === 'money' ) : ?>
+								<div class="input-group">
+									<span class="input-group-text">&pound;</span>
+									<input data-cdc-field="<?php echo esc_attr( $field->name ); ?>" type="number" step="0.01" id="cdc-field-<?php echo esc_attr( $field->id ); ?>" value="<?php echo esc_attr( $val ); ?>" class="regular-text" <?php echo $readonly ? 'readonly disabled' : 'name="cdc_fields[' . esc_attr( $field->id ) . ']" ' . $required; ?>>
+								</div>
+							<?php else : ?>
+								<input data-cdc-field="<?php echo esc_attr( $field->name ); ?>" type="<?php echo esc_attr( $type ); ?>" id="cdc-field-<?php echo esc_attr( $field->id ); ?>" value="<?php echo esc_attr( $val ); ?>" class="regular-text" <?php echo $readonly ? 'readonly disabled' : 'name="cdc_fields[' . esc_attr( $field->id ) . ']" ' . $required; ?>>
+							<?php endif; ?>
+						</td>
+					</tr>
+				<?php endforeach; ?>
+				</table>
+			</div>
+			<?php endforeach; ?>
+			<?php if ( $docs_field ) : ?>
+			<div class="tab-pane fade" id="tab-docs" role="tabpanel">
+				<table class="form-table" role="presentation">
+					<tr>
+						<th scope="row"><label for="cdc-soa"><?php echo esc_html( $docs_field->label ); ?></label></th>
+						<td>
+							<?php $val = $post_id ? \CouncilDebtCounters\Custom_Fields::get_value( $post_id, 'statement_of_accounts' ) : ''; ?>
+							<?php if ( $val ) : ?>
+								<p><a href="<?php echo esc_url( plugins_url( 'docs/' . $val, dirname( __DIR__, 2 ) . '/council-debt-counters.php' ) ); ?>" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'View current document', 'council-debt-counters' ); ?></a></p>
+							<?php endif; ?>
+							<input type="file" id="cdc-soa" name="statement_of_accounts_file" accept="application/pdf">
+							<p class="description"><?php esc_html_e( 'or import from URL', 'council-debt-counters' ); ?></p>
+							<input type="url" name="statement_of_accounts_url" class="regular-text" placeholder="https://example.com/file.pdf">
+							<p class="description mt-2">
+								<label for="cdc-soa-year" class="form-label"><?php esc_html_e( 'Financial Year', 'council-debt-counters' ); ?></label>
+								<select id="cdc-soa-year" name="statement_of_accounts_year">
+									<?php foreach ( \CouncilDebtCounters\Docs_Manager::financial_years() as $y ) : ?>
+										<option value="<?php echo esc_attr( $y ); ?>" <?php selected( \CouncilDebtCounters\Docs_Manager::current_financial_year(), $y ); ?>><?php echo esc_html( $y ); ?></option>
+									<?php endforeach; ?>
+								</select>
+							</p>
+							<?php $orphans = \CouncilDebtCounters\Docs_Manager::list_orphan_documents(); ?>
+							<?php if ( ! empty( $orphans ) ) : ?>
+								<p class="description mt-2"><?php esc_html_e( 'Or attach an existing document', 'council-debt-counters' ); ?></p>
+								<select name="statement_of_accounts_existing">
+									<option value=""><?php esc_html_e( 'Select document', 'council-debt-counters' ); ?></option>
+									<?php foreach ( $orphans as $doc ) : ?>
+										<option value="<?php echo esc_attr( $doc->filename ); ?>"><?php echo esc_html( $doc->filename ); ?></option>
+									<?php endforeach; ?>
+								</select>
+							<?php endif; ?>
+						</td>
+					</tr>
+				</table>
+				<?php if ( ! empty( $docs ) ) : ?>
+				<h2><?php esc_html_e( 'Existing Documents', 'council-debt-counters' ); ?></h2>
+				<table class="widefat">
+					<thead>
+						<tr>
+							<th><?php esc_html_e( 'File', 'council-debt-counters' ); ?></th>
+							<th><?php esc_html_e( 'Year', 'council-debt-counters' ); ?></th>
+							<th><?php esc_html_e( 'Type', 'council-debt-counters' ); ?></th>
+							<th><?php esc_html_e( 'Actions', 'council-debt-counters' ); ?></th>
+						</tr>
+					</thead>
+					<tbody>
+					<?php foreach ( $docs as $d ) : ?>
+						<tr>
+							<td><?php echo esc_html( $d->filename ); ?></td>
+							<td>
+								<select name="docs[<?php echo esc_attr( $d->id ); ?>][financial_year]">
+									<?php foreach ( \CouncilDebtCounters\Docs_Manager::financial_years() as $y ) : ?>
+										<option value="<?php echo esc_attr( $y ); ?>" <?php selected( $d->financial_year, $y ); ?>><?php echo esc_html( $y ); ?></option>
+									<?php endforeach; ?>
+								</select>
+							</td>
+							<td>
+								<select name="docs[<?php echo esc_attr( $d->id ); ?>][doc_type]">
+									<option value="statement_of_accounts" <?php selected( $d->doc_type, 'statement_of_accounts' ); ?>><?php esc_html_e( 'Statement of Accounts', 'council-debt-counters' ); ?></option>
+								</select>
+							</td>
+							<td>
+								<button type="button" value="<?php echo esc_attr( $d->id ); ?>" class="button cdc-extract-ai"><span class="dashicons dashicons-lightbulb"></span> <?php esc_html_e( 'Extract Figures', 'council-debt-counters' ); ?></button>
 
-                                <button type="submit" name="update_doc" value="<?php echo esc_attr( $d->id ); ?>" class="button button-secondary"><?php esc_html_e( 'Update', 'council-debt-counters' ); ?></button>
-                                <button type="submit" name="delete_doc" value="<?php echo esc_attr( $d->id ); ?>" class="button button-link-delete" onclick="return confirm('<?php esc_attr_e( 'Delete this document?', 'council-debt-counters' ); ?>');"><?php esc_html_e( 'Delete', 'council-debt-counters' ); ?></button>
-                            </td>
-                        </tr>
-                    <?php endforeach; ?>
-                    </tbody>
-                </table>
-                <?php endif; ?>
-            </div>
-            <?php endif; ?>
-            <?php if ( $post_id ) : ?>
-            <!-- Whistleblower reports moved to dedicated admin page -->
-            <?php endif; ?>
-        </div>
-        <?php submit_button( __( 'Save Council', 'council-debt-counters' ) ); ?>
-    </form>
-    </div>
-    <?php
-    return;
+								<button type="submit" name="update_doc" value="<?php echo esc_attr( $d->id ); ?>" class="button button-secondary"><?php esc_html_e( 'Update', 'council-debt-counters' ); ?></button>
+								<button type="submit" name="delete_doc" value="<?php echo esc_attr( $d->id ); ?>" class="button button-link-delete" onclick="return confirm('<?php esc_attr_e( 'Delete this document?', 'council-debt-counters' ); ?>');"><?php esc_html_e( 'Delete', 'council-debt-counters' ); ?></button>
+							</td>
+						</tr>
+					<?php endforeach; ?>
+					</tbody>
+				</table>
+				<?php endif; ?>
+			</div>
+			<?php endif; ?>
+			<?php if ( $post_id ) : ?>
+			<!-- Whistleblower reports moved to dedicated admin page -->
+			<?php endif; ?>
+		</div>
+		<?php submit_button( __( 'Save Council', 'council-debt-counters' ) ); ?>
+	</form>
+	</div>
+	<?php
+	return;
 }
 
-$councils = get_posts([
-    'post_type'   => 'council',
-    'numberposts' => -1,
-    'post_status' => [ 'publish', 'draft' ],
-]);
+$status_param   = isset( $_GET['status'] ) ? sanitize_key( $_GET['status'] ) : 'publish';
+$valid_statuses = array( 'publish', 'draft', 'under_review' );
+if ( ! in_array( $status_param, $valid_statuses, true ) ) {
+	$status_param = 'publish';
+}
+$councils = get_posts(
+	array(
+		'post_type'   => 'council',
+		'numberposts' => -1,
+		'post_status' => $status_param,
+	)
+);
+$counts   = wp_count_posts( 'council' );
 ?>
 <div class="wrap">
-    <h1><?php esc_html_e( 'Councils', 'council-debt-counters' ); ?></h1>
-    <a href="<?php echo esc_url( admin_url( 'admin.php?page=cdc-manage-councils&action=edit' ) ); ?>" class="btn btn-primary mb-3"><?php esc_html_e( 'Add New', 'council-debt-counters' ); ?></a>
-    <table class="table table-striped">
-        <thead>
-            <tr>
-                <th><?php esc_html_e( 'Name', 'council-debt-counters' ); ?></th>
-                <th><?php esc_html_e( 'Debt Counter', 'council-debt-counters' ); ?></th>
-                <th><?php esc_html_e( 'Actions', 'council-debt-counters' ); ?></th>
-            </tr>
-        </thead>
-        <tbody>
-            <?php if ( empty( $councils ) ) : ?>
-                <tr><td colspan="3"><?php esc_html_e( 'No councils found.', 'council-debt-counters' ); ?></td></tr>
-            <?php else : foreach ( $councils as $council ) : ?>
-                <tr>
-                    <td><?php echo esc_html( get_the_title( $council ) ); ?></td>
-                    <td>
-                        <?php echo do_shortcode( '[council_counter id="' . $council->ID . '"]' ); ?>
-                        <code>[council_counter id="<?php echo esc_attr( $council->ID ); ?>"]</code>
-                    </td>
-                    <td>
-                        <a href="<?php echo esc_url( admin_url( 'admin.php?page=cdc-manage-councils&action=edit&post=' . $council->ID ) ); ?>" class="btn btn-sm btn-secondary"><?php esc_html_e( 'Edit', 'council-debt-counters' ); ?></a>
-                        <a href="<?php echo esc_url( wp_nonce_url( admin_url( 'admin.php?page=cdc-manage-councils&action=delete&post=' . $council->ID ), 'cdc_delete_council_' . $council->ID ) ); ?>" class="btn btn-sm btn-danger" onclick="return confirm('<?php esc_attr_e( 'Delete this council?', 'council-debt-counters' ); ?>');"><?php esc_html_e( 'Delete', 'council-debt-counters' ); ?></a>
-                    </td>
-                </tr>
-            <?php endforeach; endif; ?>
-        </tbody>
-    </table>
+	<h1><?php esc_html_e( 'Councils', 'council-debt-counters' ); ?></h1>
+	<a href="<?php echo esc_url( admin_url( 'admin.php?page=cdc-manage-councils&action=edit' ) ); ?>" class="btn btn-primary mb-3"><?php esc_html_e( 'Add New', 'council-debt-counters' ); ?></a>
+	<ul class="nav nav-tabs mb-3">
+		<?php
+		$status_labels = array(
+			'publish'      => __( 'Active', 'council-debt-counters' ),
+			'draft'        => __( 'Draft', 'council-debt-counters' ),
+			'under_review' => __( 'Under Review', 'council-debt-counters' ),
+		);
+		foreach ( $status_labels as $s_key => $s_label ) :
+			$count = $counts->$s_key ?? 0;
+			?>
+			<li class="nav-item">
+				<a class="nav-link <?php echo $status_param === $s_key ? 'active' : ''; ?>" href="<?php echo esc_url( admin_url( 'admin.php?page=cdc-manage-councils&status=' . $s_key ) ); ?>">
+					<?php echo esc_html( $s_label . ' (' . $count . ')' ); ?>
+				</a>
+			</li>
+				<?php endforeach; ?>
+	</ul>
+	<table class="table table-striped">
+		<thead>
+			<tr>
+				<th><?php esc_html_e( 'Name', 'council-debt-counters' ); ?></th>
+				<th><?php esc_html_e( 'Debt Counter', 'council-debt-counters' ); ?></th>
+				<th><?php esc_html_e( 'Status', 'council-debt-counters' ); ?></th>
+				<th><?php esc_html_e( 'Actions', 'council-debt-counters' ); ?></th>
+			</tr>
+		</thead>
+		<tbody>
+			<?php if ( empty( $councils ) ) : ?>
+				<tr><td colspan="4"><?php esc_html_e( 'No councils found.', 'council-debt-counters' ); ?></td></tr>
+				<?php
+			else :
+				foreach ( $councils as $council ) :
+					?>
+				<tr>
+					<td><?php echo esc_html( get_the_title( $council ) ); ?></td>
+					<td>
+										<?php echo do_shortcode( '[council_counter id="' . $council->ID . '"]' ); ?>
+						<code>[council_counter id="<?php echo esc_attr( $council->ID ); ?>"]</code>
+					</td>
+					<td><?php echo esc_html( ucwords( str_replace( '_', ' ', $council->post_status ) ) ); ?></td>
+					<td>
+						<a href="<?php echo esc_url( admin_url( 'admin.php?page=cdc-manage-councils&action=edit&post=' . $council->ID ) ); ?>" class="btn btn-sm btn-secondary"><?php esc_html_e( 'Edit', 'council-debt-counters' ); ?></a>
+						<a href="<?php echo esc_url( wp_nonce_url( admin_url( 'admin.php?page=cdc-manage-councils&action=delete&post=' . $council->ID ), 'cdc_delete_council_' . $council->ID ) ); ?>" class="btn btn-sm btn-danger" onclick="return confirm('<?php esc_attr_e( 'Delete this council?', 'council-debt-counters' ); ?>');"><?php esc_html_e( 'Delete', 'council-debt-counters' ); ?></a>
+					</td>
+				</tr>
+							<?php
+			endforeach;
+endif;
+			?>
+		</tbody>
+	</table>
 </div>

--- a/admin/views/import-export-page.php
+++ b/admin/views/import-export-page.php
@@ -13,6 +13,28 @@ if ( ! defined( 'ABSPATH' ) ) exit;
         <?php esc_html_e( 'CSV/JSON must include a "council_name" column plus any custom field names.', 'council-debt-counters' ); ?>
         <a href="<?php echo esc_url( plugins_url( 'samples/sample-councils.csv', dirname( __DIR__, 2 ) . '/council-debt-counters.php' ) ); ?>" class="button button-small ms-2"><?php esc_html_e( 'Download Sample CSV', 'council-debt-counters' ); ?></a>
     </p>
+    <?php
+    $fields = \CouncilDebtCounters\Custom_Fields::get_fields();
+    ?>
+    <h3><?php esc_html_e( 'Available Fields', 'council-debt-counters' ); ?></h3>
+    <table class="widefat">
+        <thead>
+            <tr>
+                <th><?php esc_html_e( 'Field Label', 'council-debt-counters' ); ?></th>
+                <th><?php esc_html_e( 'CSV Column', 'council-debt-counters' ); ?></th>
+                <th><?php esc_html_e( 'Required', 'council-debt-counters' ); ?></th>
+            </tr>
+        </thead>
+        <tbody>
+            <?php foreach ( $fields as $f ) : ?>
+                <tr>
+                    <td><?php echo esc_html( $f->label ); ?></td>
+                    <td><code><?php echo esc_html( $f->name ); ?></code></td>
+                    <td><?php echo $f->required ? esc_html__( 'Yes', 'council-debt-counters' ) : esc_html__( 'No', 'council-debt-counters' ); ?></td>
+                </tr>
+            <?php endforeach; ?>
+        </tbody>
+    </table>
     <h2><?php esc_html_e( 'Export Councils', 'council-debt-counters' ); ?></h2>
     <form method="post">
         <?php wp_nonce_field( 'cdc_export', 'cdc_export_nonce' ); ?>

--- a/admin/views/import-export-page.php
+++ b/admin/views/import-export-page.php
@@ -11,6 +11,7 @@ if ( ! defined( 'ABSPATH' ) ) exit;
     </form>
     <p class="description">
         <?php esc_html_e( 'CSV/JSON must include a "council_name" column plus any custom field names.', 'council-debt-counters' ); ?>
+        <a href="<?php echo esc_url( plugins_url( 'samples/sample-councils.csv', dirname( __DIR__, 2 ) . '/council-debt-counters.php' ) ); ?>" class="button button-small ms-2"><?php esc_html_e( 'Download Sample CSV', 'council-debt-counters' ); ?></a>
     </p>
     <h2><?php esc_html_e( 'Export Councils', 'council-debt-counters' ); ?></h2>
     <form method="post">

--- a/admin/views/import-export-page.php
+++ b/admin/views/import-export-page.php
@@ -1,59 +1,61 @@
 <?php
-if ( ! defined( 'ABSPATH' ) ) exit;
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
 ?>
 <div class="wrap">
-    <h1><?php esc_html_e( 'Import & Export', 'council-debt-counters' ); ?></h1>
-    <h2><?php esc_html_e( 'Import Councils', 'council-debt-counters' ); ?></h2>
-    <form method="post" enctype="multipart/form-data">
-        <?php wp_nonce_field( 'cdc_load_csv', 'cdc_load_csv_nonce' ); ?>
-        <input type="file" name="cdc_csv_file" accept=".csv,.json" required />
-        <button type="submit" class="button"><?php esc_html_e( 'Import', 'council-debt-counters' ); ?></button>
-    </form>
-    <p class="description">
-        <?php esc_html_e( 'CSV/JSON must include a "council_name" column plus any custom field names.', 'council-debt-counters' ); ?>
-        <a href="<?php echo esc_url( plugins_url( 'samples/sample-councils.csv', dirname( __DIR__, 2 ) . '/council-debt-counters.php' ) ); ?>" class="button button-small ms-2"><?php esc_html_e( 'Download Sample CSV', 'council-debt-counters' ); ?></a>
-    </p>
-    <?php
-    $fields = \CouncilDebtCounters\Custom_Fields::get_fields();
-    ?>
-    <h3><?php esc_html_e( 'Available Fields', 'council-debt-counters' ); ?></h3>
-    <table class="widefat">
-        <thead>
-            <tr>
-                <th><?php esc_html_e( 'Field Label', 'council-debt-counters' ); ?></th>
-                <th><?php esc_html_e( 'CSV Column', 'council-debt-counters' ); ?></th>
-                <th><?php esc_html_e( 'Required', 'council-debt-counters' ); ?></th>
-            </tr>
-        </thead>
-        <tbody>
-            <?php foreach ( $fields as $f ) : ?>
-                <tr>
-                    <td><?php echo esc_html( $f->label ); ?></td>
-                    <td><code><?php echo esc_html( $f->name ); ?></code></td>
-                    <td><?php echo $f->required ? esc_html__( 'Yes', 'council-debt-counters' ) : esc_html__( 'No', 'council-debt-counters' ); ?></td>
-                </tr>
-            <?php endforeach; ?>
-        </tbody>
-    </table>
-    <h2><?php esc_html_e( 'Export Councils', 'council-debt-counters' ); ?></h2>
-    <form method="post">
-        <?php wp_nonce_field( 'cdc_export', 'cdc_export_nonce' ); ?>
-        <select name="format">
-            <option value="csv">CSV</option>
-            <option value="json">JSON</option>
-        </select>
-        <button type="submit" name="cdc_export" class="button button-primary"><?php esc_html_e( 'Download', 'council-debt-counters' ); ?></button>
-    </form>
-    <h2 class="mt-4"><?php esc_html_e( 'Export Settings', 'council-debt-counters' ); ?></h2>
-    <form method="post">
-        <?php wp_nonce_field( 'cdc_export_settings', 'cdc_export_settings_nonce' ); ?>
-        <button type="submit" name="cdc_export_settings" class="button button-primary"><?php esc_html_e( 'Download Settings', 'council-debt-counters' ); ?></button>
-    </form>
+	<h1><?php esc_html_e( 'Import & Export', 'council-debt-counters' ); ?></h1>
+	<h2><?php esc_html_e( 'Import Councils', 'council-debt-counters' ); ?></h2>
+	<form id="cdc-import-form" method="post" enctype="multipart/form-data">
+		<?php wp_nonce_field( 'cdc_load_csv', 'cdc_load_csv_nonce' ); ?>
+		<input type="file" name="cdc_csv_file" accept=".csv,.json" required />
+		<button type="submit" class="button"><?php esc_html_e( 'Import', 'council-debt-counters' ); ?></button>
+	</form>
+	<p class="description">
+		<?php esc_html_e( 'CSV/JSON must include a "council_name" column plus any custom field names.', 'council-debt-counters' ); ?>
+		<a href="<?php echo esc_url( plugins_url( 'samples/sample-councils.csv', dirname( __DIR__, 2 ) . '/council-debt-counters.php' ) ); ?>" class="button button-small ms-2"><?php esc_html_e( 'Download Sample CSV', 'council-debt-counters' ); ?></a>
+	</p>
+	<?php
+	$fields = \CouncilDebtCounters\Custom_Fields::get_fields();
+	?>
+	<h3><?php esc_html_e( 'Available Fields', 'council-debt-counters' ); ?></h3>
+	<table class="widefat">
+		<thead>
+			<tr>
+				<th><?php esc_html_e( 'Field Label', 'council-debt-counters' ); ?></th>
+				<th><?php esc_html_e( 'CSV Column', 'council-debt-counters' ); ?></th>
+				<th><?php esc_html_e( 'Required', 'council-debt-counters' ); ?></th>
+			</tr>
+		</thead>
+		<tbody>
+			<?php foreach ( $fields as $f ) : ?>
+				<tr>
+					<td><?php echo esc_html( $f->label ); ?></td>
+					<td><code><?php echo esc_html( $f->name ); ?></code></td>
+					<td><?php echo $f->required ? esc_html__( 'Yes', 'council-debt-counters' ) : esc_html__( 'No', 'council-debt-counters' ); ?></td>
+				</tr>
+			<?php endforeach; ?>
+		</tbody>
+	</table>
+	<h2><?php esc_html_e( 'Export Councils', 'council-debt-counters' ); ?></h2>
+	<form method="post">
+		<?php wp_nonce_field( 'cdc_export', 'cdc_export_nonce' ); ?>
+		<select name="format">
+			<option value="csv">CSV</option>
+			<option value="json">JSON</option>
+		</select>
+		<button type="submit" name="cdc_export" class="button button-primary"><?php esc_html_e( 'Download', 'council-debt-counters' ); ?></button>
+	</form>
+	<h2 class="mt-4"><?php esc_html_e( 'Export Settings', 'council-debt-counters' ); ?></h2>
+	<form method="post">
+		<?php wp_nonce_field( 'cdc_export_settings', 'cdc_export_settings_nonce' ); ?>
+		<button type="submit" name="cdc_export_settings" class="button button-primary"><?php esc_html_e( 'Download Settings', 'council-debt-counters' ); ?></button>
+	</form>
 
-    <h2 class="mt-4"><?php esc_html_e( 'Import Settings', 'council-debt-counters' ); ?></h2>
-    <form method="post" enctype="multipart/form-data">
-        <?php wp_nonce_field( 'cdc_import_settings', 'cdc_import_settings_nonce' ); ?>
-        <input type="file" name="cdc_settings_file" accept=".json" required />
-        <button type="submit" class="button"><?php esc_html_e( 'Import Settings', 'council-debt-counters' ); ?></button>
-    </form>
+	<h2 class="mt-4"><?php esc_html_e( 'Import Settings', 'council-debt-counters' ); ?></h2>
+	<form method="post" enctype="multipart/form-data">
+		<?php wp_nonce_field( 'cdc_import_settings', 'cdc_import_settings_nonce' ); ?>
+		<input type="file" name="cdc_settings_file" accept=".json" required />
+		<button type="submit" class="button"><?php esc_html_e( 'Import Settings', 'council-debt-counters' ); ?></button>
+	</form>
 </div>

--- a/includes/class-council-admin-page.php
+++ b/includes/class-council-admin-page.php
@@ -93,10 +93,15 @@ class Council_Admin_Page {
             }
         }
 
+        $status = sanitize_key( $_POST['post_status'] ?? 'publish' );
+        if ( ! in_array( $status, [ 'publish', 'draft', 'under_review' ], true ) ) {
+            $status = 'publish';
+        }
+
         if ( $post_id ) {
-            wp_update_post( [ 'ID' => $post_id, 'post_title' => $title ] );
+            wp_update_post( [ 'ID' => $post_id, 'post_title' => $title, 'post_status' => $status ] );
         } else {
-            $post_id = wp_insert_post( [ 'post_type' => 'council', 'post_status' => 'publish', 'post_title' => $title ] );
+            $post_id = wp_insert_post( [ 'post_type' => 'council', 'post_status' => $status, 'post_title' => $title ] );
         }
 
         foreach ( $fields as $field ) {

--- a/includes/class-council-post-type.php
+++ b/includes/class-council-post-type.php
@@ -34,6 +34,15 @@ class Council_Post_Type {
             'supports'           => [ 'title' ],
             'publicly_queryable' => false,
         ] );
+
+        register_post_status( 'under_review', [
+            'label'                     => _x( 'Under Review', 'post', 'council-debt-counters' ),
+            'public'                    => false,
+            'internal'                  => false,
+            'show_in_admin_all_list'    => true,
+            'show_in_admin_status_list' => true,
+            'label_count'               => _n_noop( 'Under Review (%s)', 'Under Review (%s)', 'council-debt-counters' ),
+        ] );
     }
 
     /**

--- a/includes/class-custom-fields.php
+++ b/includes/class-custom-fields.php
@@ -13,6 +13,7 @@ class Custom_Fields {
     const DEFAULT_FIELDS = [
         ['name' => 'council_name', 'label' => 'Council Name', 'type' => 'text', 'required' => 1],
         ['name' => 'council_type', 'label' => 'Council Type', 'type' => 'text', 'required' => 0],
+        ['name' => 'council_location', 'label' => 'Council Location', 'type' => 'text', 'required' => 0],
         ['name' => 'population', 'label' => 'Population', 'type' => 'number', 'required' => 0],
         ['name' => 'households', 'label' => 'Households', 'type' => 'number', 'required' => 0],
         ['name' => 'current_liabilities', 'label' => 'Current Liabilities', 'type' => 'money', 'required' => 1],

--- a/includes/class-data-loader.php
+++ b/includes/class-data-loader.php
@@ -4,315 +4,391 @@ namespace CouncilDebtCounters;
 use CouncilDebtCounters\Custom_Fields;
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 class Data_Loader {
-    /**
-     * Register hooks for CLI and admin import handling.
-     */
-    public static function init() {
-        add_action( 'admin_init', [ __CLASS__, 'handle_admin_action' ] );
-        if ( defined( 'WP_CLI' ) && WP_CLI ) {
-            \WP_CLI::add_command( 'cdc load_csv', [ __CLASS__, 'cli_load_csv' ] );
-            \WP_CLI::add_command( 'cdc load_json', [ __CLASS__, 'cli_load_json' ] );
-        }
-    }
+	/**
+	 * Register hooks for CLI and admin import handling.
+	 */
+	public static function init() {
+		add_action( 'admin_init', array( __CLASS__, 'handle_admin_action' ) );
+		add_action( 'wp_ajax_cdc_import_row', array( __CLASS__, 'ajax_import_row' ) );
+		if ( defined( 'WP_CLI' ) && WP_CLI ) {
+			\WP_CLI::add_command( 'cdc load_csv', array( __CLASS__, 'cli_load_csv' ) );
+			\WP_CLI::add_command( 'cdc load_json', array( __CLASS__, 'cli_load_json' ) );
+		}
+	}
 
-    /**
-     * Parse a CSV file and create or update council posts.
-     *
-     * @param string $path Path to the CSV file.
-     * @return int|\WP_Error Number of imported rows or WP_Error on failure.
-     */
-    public static function load_csv( string $path ) {
-        if ( ! file_exists( $path ) ) {
-            Error_Logger::log( 'CSV not found: ' . $path );
-            return new \WP_Error( 'csv_missing', __( 'CSV file not found.', 'council-debt-counters' ) );
-        }
+	/**
+	 * Parse a CSV file and create or update council posts.
+	 *
+	 * @param string $path Path to the CSV file.
+	 * @return int|\WP_Error Number of imported rows or WP_Error on failure.
+	 */
+	public static function load_csv( string $path ) {
+		if ( ! file_exists( $path ) ) {
+			Error_Logger::log( 'CSV not found: ' . $path );
+			return new \WP_Error( 'csv_missing', __( 'CSV file not found.', 'council-debt-counters' ) );
+		}
 
-        $handle = fopen( $path, 'r' );
-        if ( ! $handle ) {
-            Error_Logger::log( 'Unable to open CSV: ' . $path );
-            return new \WP_Error( 'csv_open_failed', __( 'Unable to open CSV file.', 'council-debt-counters' ) );
-        }
+		$handle = fopen( $path, 'r' );
+		if ( ! $handle ) {
+			Error_Logger::log( 'Unable to open CSV: ' . $path );
+			return new \WP_Error( 'csv_open_failed', __( 'Unable to open CSV file.', 'council-debt-counters' ) );
+		}
 
-        $header = fgetcsv( $handle );
-        if ( empty( $header ) ) {
-            fclose( $handle );
-            Error_Logger::log( 'CSV header missing: ' . $path );
-            return new \WP_Error( 'csv_header', __( 'CSV header missing.', 'council-debt-counters' ) );
-        }
+		$header = fgetcsv( $handle );
+		if ( empty( $header ) ) {
+			fclose( $handle );
+			Error_Logger::log( 'CSV header missing: ' . $path );
+			return new \WP_Error( 'csv_header', __( 'CSV header missing.', 'council-debt-counters' ) );
+		}
 
-        $count = 0;
-        while ( ( $row = fgetcsv( $handle ) ) !== false ) {
-            $data = array_combine( $header, $row );
-            if ( false === $data ) {
-                Error_Logger::log( 'Column mismatch in CSV: ' . $path );
-                continue;
-            }
-            if ( empty( $data['council_name'] ) ) {
-                Error_Logger::log( 'Missing council_name in CSV row' );
-                continue;
-            }
+		$count = 0;
+		while ( ( $row = fgetcsv( $handle ) ) !== false ) {
+			$data = array_combine( $header, $row );
+			if ( false === $data ) {
+				Error_Logger::log( 'Column mismatch in CSV: ' . $path );
+				continue;
+			}
+			if ( empty( $data['council_name'] ) ) {
+				Error_Logger::log( 'Missing council_name in CSV row' );
+				continue;
+			}
 
-            $name    = sanitize_text_field( $data['council_name'] );
-            $post    = get_page_by_title( $name, OBJECT, 'council' );
-            $post_id = $post ? $post->ID : 0;
+			$name    = sanitize_text_field( $data['council_name'] );
+			$post    = get_page_by_title( $name, OBJECT, 'council' );
+			$post_id = $post ? $post->ID : 0;
 
-            if ( $post_id ) {
-                wp_update_post( [ 'ID' => $post_id, 'post_title' => $name ] );
-            } else {
-                $post_id = wp_insert_post( [
-                    'post_title'  => $name,
-                    'post_type'   => 'council',
-                    'post_status' => 'draft',
-                ] );
-                if ( is_wp_error( $post_id ) ) {
-                    Error_Logger::log( 'Failed to insert council: ' . $name );
-                    continue;
-                }
-            }
+			if ( $post_id ) {
+				wp_update_post(
+					array(
+						'ID'         => $post_id,
+						'post_title' => $name,
+					)
+				);
+			} else {
+				$post_id = wp_insert_post(
+					array(
+						'post_title'  => $name,
+						'post_type'   => 'council',
+						'post_status' => 'draft',
+					)
+				);
+				if ( is_wp_error( $post_id ) ) {
+					Error_Logger::log( 'Failed to insert council: ' . $name );
+					continue;
+				}
+			}
 
-            foreach ( $data as $field => $value ) {
-                if ( 'council_name' === $field ) {
-                    continue;
-                }
-                if ( '' === $value ) {
-                    continue;
-                }
-                \CouncilDebtCounters\Custom_Fields::update_value( $post_id, $field, $value );
-            }
+			foreach ( $data as $field => $value ) {
+				if ( 'council_name' === $field ) {
+					continue;
+				}
+				if ( '' === $value ) {
+					continue;
+				}
+				\CouncilDebtCounters\Custom_Fields::update_value( $post_id, $field, $value );
+			}
 
-            if ( method_exists( '\\CouncilDebtCounters\\Council_Post_Type', 'calculate_total_debt' ) ) {
-                Council_Post_Type::calculate_total_debt( $post_id );
-            }
+			if ( method_exists( '\\CouncilDebtCounters\\Council_Post_Type', 'calculate_total_debt' ) ) {
+				Council_Post_Type::calculate_total_debt( $post_id );
+			}
 
-            $count++;
-        }
-        fclose( $handle );
-        Error_Logger::log_info( 'Imported councils from CSV: ' . $path );
-        return $count;
-    }
+			++$count;
+		}
+		fclose( $handle );
+		Error_Logger::log_info( 'Imported councils from CSV: ' . $path );
+		return $count;
+	}
 
-    /**
-     * Parse a JSON file and create or update council posts.
-     *
-     * @param string $path Path to JSON file.
-     * @return int|\WP_Error Number of imported rows or WP_Error on failure.
-     */
-    public static function load_json( string $path ) {
-        if ( ! file_exists( $path ) ) {
-            return new \WP_Error( 'json_missing', __( 'JSON file not found.', 'council-debt-counters' ) );
-        }
-        $contents = file_get_contents( $path );
-        if ( false === $contents ) {
-            return new \WP_Error( 'json_read', __( 'Unable to read JSON file.', 'council-debt-counters' ) );
-        }
-        $data = json_decode( $contents, true );
-        if ( ! is_array( $data ) ) {
-            return new \WP_Error( 'json_invalid', __( 'Invalid JSON.', 'council-debt-counters' ) );
-        }
-        $count = 0;
-        foreach ( $data as $row ) {
-            if ( empty( $row['council_name'] ) ) {
-                continue;
-            }
-            $name    = sanitize_text_field( $row['council_name'] );
-            $post    = get_page_by_title( $name, OBJECT, 'council' );
-            $post_id = $post ? $post->ID : 0;
+	/**
+	 * Parse a JSON file and create or update council posts.
+	 *
+	 * @param string $path Path to JSON file.
+	 * @return int|\WP_Error Number of imported rows or WP_Error on failure.
+	 */
+	public static function load_json( string $path ) {
+		if ( ! file_exists( $path ) ) {
+			return new \WP_Error( 'json_missing', __( 'JSON file not found.', 'council-debt-counters' ) );
+		}
+		$contents = file_get_contents( $path );
+		if ( false === $contents ) {
+			return new \WP_Error( 'json_read', __( 'Unable to read JSON file.', 'council-debt-counters' ) );
+		}
+		$data = json_decode( $contents, true );
+		if ( ! is_array( $data ) ) {
+			return new \WP_Error( 'json_invalid', __( 'Invalid JSON.', 'council-debt-counters' ) );
+		}
+		$count = 0;
+		foreach ( $data as $row ) {
+			if ( empty( $row['council_name'] ) ) {
+				continue;
+			}
+			$name    = sanitize_text_field( $row['council_name'] );
+			$post    = get_page_by_title( $name, OBJECT, 'council' );
+			$post_id = $post ? $post->ID : 0;
 
-            if ( $post_id ) {
-                wp_update_post( [ 'ID' => $post_id, 'post_title' => $name ] );
-            } else {
-                $post_id = wp_insert_post( [
-                    'post_title'  => $name,
-                    'post_type'   => 'council',
-                    'post_status' => 'publish',
-                ] );
-                if ( is_wp_error( $post_id ) ) {
-                    continue;
-                }
-            }
+			if ( $post_id ) {
+				wp_update_post(
+					array(
+						'ID'         => $post_id,
+						'post_title' => $name,
+					)
+				);
+			} else {
+				$post_id = wp_insert_post(
+					array(
+						'post_title'  => $name,
+						'post_type'   => 'council',
+						'post_status' => 'publish',
+					)
+				);
+				if ( is_wp_error( $post_id ) ) {
+					continue;
+				}
+			}
 
-            foreach ( $row as $field => $value ) {
-                if ( 'council_name' === $field ) {
-                    continue;
-                }
-                if ( '' === $value ) {
-                    continue;
-                }
-                Custom_Fields::update_value( $post_id, $field, $value );
-            }
+			foreach ( $row as $field => $value ) {
+				if ( 'council_name' === $field ) {
+					continue;
+				}
+				if ( '' === $value ) {
+					continue;
+				}
+				Custom_Fields::update_value( $post_id, $field, $value );
+			}
 
-            if ( method_exists( '\\CouncilDebtCounters\\Council_Post_Type', 'calculate_total_debt' ) ) {
-                Council_Post_Type::calculate_total_debt( $post_id );
-            }
+			if ( method_exists( '\\CouncilDebtCounters\\Council_Post_Type', 'calculate_total_debt' ) ) {
+				Council_Post_Type::calculate_total_debt( $post_id );
+			}
 
-            $count++;
-        }
-        Error_Logger::log_info( 'Imported councils from JSON: ' . $path );
-        return $count;
-    }
+			++$count;
+		}
+		Error_Logger::log_info( 'Imported councils from JSON: ' . $path );
+		return $count;
+	}
 
-    /**
-     * Handle CLI command to load CSV.
-     */
-    public static function cli_load_csv( $args, $assoc_args ) {
-        $path = $args[0] ?? '';
-        $result = self::load_csv( $path );
-        if ( is_wp_error( $result ) ) {
-            \WP_CLI::error( $result->get_error_message() );
-        }
-        \WP_CLI::success( sprintf( __( 'Imported %d councils.', 'council-debt-counters' ), $result ) );
-    }
+	/**
+	 * Handle CLI command to load CSV.
+	 */
+	public static function cli_load_csv( $args, $assoc_args ) {
+		$path   = $args[0] ?? '';
+		$result = self::load_csv( $path );
+		if ( is_wp_error( $result ) ) {
+			\WP_CLI::error( $result->get_error_message() );
+		}
+		\WP_CLI::success( sprintf( __( 'Imported %d councils.', 'council-debt-counters' ), $result ) );
+	}
 
-    public static function cli_load_json( $args, $assoc_args ) {
-        $path = $args[0] ?? '';
-        $result = self::load_json( $path );
-        if ( is_wp_error( $result ) ) {
-            \WP_CLI::error( $result->get_error_message() );
-        }
-        \WP_CLI::success( sprintf( __( 'Imported %d councils.', 'council-debt-counters' ), $result ) );
-    }
+	public static function cli_load_json( $args, $assoc_args ) {
+		$path   = $args[0] ?? '';
+		$result = self::load_json( $path );
+		if ( is_wp_error( $result ) ) {
+			\WP_CLI::error( $result->get_error_message() );
+		}
+		\WP_CLI::success( sprintf( __( 'Imported %d councils.', 'council-debt-counters' ), $result ) );
+	}
 
-    /**
-     * Export all councils as JSON or CSV.
-     */
-    public static function export_data( string $format = 'csv' ) {
-        $councils = get_posts( [ 'post_type' => 'council', 'numberposts' => -1 ] );
-        $fields    = Custom_Fields::get_fields();
-        $rows = [];
-        foreach ( $councils as $c ) {
-            $row = [ 'council_name' => $c->post_title ];
-            foreach ( $fields as $f ) {
-                if ( 'council_name' === $f->name ) {
-                    continue;
-                }
-                $row[ $f->name ] = Custom_Fields::get_value( $c->ID, $f->name );
-            }
-            $rows[] = $row;
-        }
-        if ( 'json' === $format ) {
-            return wp_json_encode( $rows );
-        }
-        if ( empty( $rows ) ) {
-            return '';
-        }
-        $fh = fopen( 'php://temp', 'r+' );
-        fputcsv( $fh, array_keys( $rows[0] ) );
-        foreach ( $rows as $r ) {
-            fputcsv( $fh, $r );
-        }
-        rewind( $fh );
-        $csv = stream_get_contents( $fh );
-        fclose( $fh );
-        return $csv;
-    }
+	/**
+	 * Export all councils as JSON or CSV.
+	 */
+	public static function export_data( string $format = 'csv' ) {
+		$councils = get_posts(
+			array(
+				'post_type'   => 'council',
+				'numberposts' => -1,
+			)
+		);
+		$fields   = Custom_Fields::get_fields();
+		$rows     = array();
+		foreach ( $councils as $c ) {
+			$row = array( 'council_name' => $c->post_title );
+			foreach ( $fields as $f ) {
+				if ( 'council_name' === $f->name ) {
+					continue;
+				}
+				$row[ $f->name ] = Custom_Fields::get_value( $c->ID, $f->name );
+			}
+			$rows[] = $row;
+		}
+		if ( 'json' === $format ) {
+			return wp_json_encode( $rows );
+		}
+		if ( empty( $rows ) ) {
+			return '';
+		}
+		$fh = fopen( 'php://temp', 'r+' );
+		fputcsv( $fh, array_keys( $rows[0] ) );
+		foreach ( $rows as $r ) {
+			fputcsv( $fh, $r );
+		}
+		rewind( $fh );
+		$csv = stream_get_contents( $fh );
+		fclose( $fh );
+		return $csv;
+	}
 
-    /**
-     * Export plugin settings and keys as JSON.
-     */
-    public static function export_settings() {
-        $options = [
-            License_Manager::OPTION_KEY   => get_option( License_Manager::OPTION_KEY, '' ),
-            License_Manager::OPTION_VALID => get_option( License_Manager::OPTION_VALID, '' ),
-            'cdc_openai_api_key'          => get_option( 'cdc_openai_api_key', '' ),
-            'cdc_recaptcha_site_key'      => get_option( 'cdc_recaptcha_site_key', '' ),
-            'cdc_recaptcha_secret_key'    => get_option( 'cdc_recaptcha_secret_key', '' ),
-            'cdc_openai_model'            => get_option( 'cdc_openai_model', 'gpt-3.5-turbo' ),
-            'cdc_enabled_counters'        => get_option( 'cdc_enabled_counters', [] ),
-            'cdc_log_level'               => get_option( 'cdc_log_level', 'standard' ),
-        ];
-        return wp_json_encode( $options );
-    }
+	/**
+	 * Export plugin settings and keys as JSON.
+	 */
+	public static function export_settings() {
+		$options = array(
+			License_Manager::OPTION_KEY   => get_option( License_Manager::OPTION_KEY, '' ),
+			License_Manager::OPTION_VALID => get_option( License_Manager::OPTION_VALID, '' ),
+			'cdc_openai_api_key'          => get_option( 'cdc_openai_api_key', '' ),
+			'cdc_recaptcha_site_key'      => get_option( 'cdc_recaptcha_site_key', '' ),
+			'cdc_recaptcha_secret_key'    => get_option( 'cdc_recaptcha_secret_key', '' ),
+			'cdc_openai_model'            => get_option( 'cdc_openai_model', 'gpt-3.5-turbo' ),
+			'cdc_enabled_counters'        => get_option( 'cdc_enabled_counters', array() ),
+			'cdc_log_level'               => get_option( 'cdc_log_level', 'standard' ),
+		);
+		return wp_json_encode( $options );
+	}
 
-    /**
-     * Import plugin settings from a JSON file.
-     *
-     * @param string $path Path to the JSON file.
-     * @return true|\WP_Error
-     */
-    public static function import_settings( string $path ) {
-        if ( ! file_exists( $path ) ) {
-            return new \WP_Error( 'settings_missing', __( 'Settings file not found.', 'council-debt-counters' ) );
-        }
-        $contents = file_get_contents( $path );
-        if ( false === $contents ) {
-            return new \WP_Error( 'settings_read', __( 'Unable to read settings file.', 'council-debt-counters' ) );
-        }
-        $data = json_decode( $contents, true );
-        if ( ! is_array( $data ) ) {
-            return new \WP_Error( 'settings_invalid', __( 'Invalid JSON.', 'council-debt-counters' ) );
-        }
-        foreach ( $data as $option => $value ) {
-            update_option( $option, $value );
-        }
-        return true;
-    }
+	/**
+	 * Import plugin settings from a JSON file.
+	 *
+	 * @param string $path Path to the JSON file.
+	 * @return true|\WP_Error
+	 */
+	public static function import_settings( string $path ) {
+		if ( ! file_exists( $path ) ) {
+			return new \WP_Error( 'settings_missing', __( 'Settings file not found.', 'council-debt-counters' ) );
+		}
+		$contents = file_get_contents( $path );
+		if ( false === $contents ) {
+			return new \WP_Error( 'settings_read', __( 'Unable to read settings file.', 'council-debt-counters' ) );
+		}
+		$data = json_decode( $contents, true );
+		if ( ! is_array( $data ) ) {
+			return new \WP_Error( 'settings_invalid', __( 'Invalid JSON.', 'council-debt-counters' ) );
+		}
+		foreach ( $data as $option => $value ) {
+			update_option( $option, $value );
+		}
+		return true;
+	}
 
-    /**
-     * Handle admin CSV upload action.
-     */
-    public static function handle_admin_action() {
-        if ( ! current_user_can( 'manage_options' ) ) {
-            return;
-        }
-        if ( isset( $_POST['cdc_export_settings'] ) ) {
-            check_admin_referer( 'cdc_export_settings', 'cdc_export_settings_nonce' );
-            $data = self::export_settings();
-            Error_Logger::log_info( 'Exported plugin settings' );
-            header( 'Content-Type: application/json' );
-            header( 'Content-Disposition: attachment; filename=cdc-settings.json' );
-            echo $data;
-            exit;
-        }
-        if ( isset( $_FILES['cdc_settings_file']['tmp_name'] ) ) {
-            check_admin_referer( 'cdc_import_settings', 'cdc_import_settings_nonce' );
-            $file   = $_FILES['cdc_settings_file']['tmp_name'];
-            $result = self::import_settings( $file );
-            add_action( 'admin_notices', function() use ( $result ) {
-                if ( is_wp_error( $result ) ) {
-                    echo '<div class="notice notice-error"><p>' . esc_html( $result->get_error_message() ) . '</p></div>';
-                } else {
-                    echo '<div class="notice notice-success"><p>' . esc_html__( 'Settings imported.', 'council-debt-counters' ) . '</p></div>';
-                }
-            } );
-            return;
-        }
-        if ( isset( $_POST['cdc_export'] ) ) {
-            check_admin_referer( 'cdc_export', 'cdc_export_nonce' );
-            $format = sanitize_key( $_POST['format'] ?? 'csv' );
-            $data   = self::export_data( $format );
-            Error_Logger::log_info( 'Exported councils as ' . $format );
-            if ( 'json' === $format ) {
-                header( 'Content-Type: application/json' );
-                header( 'Content-Disposition: attachment; filename=councils.json' );
-            } else {
-                header( 'Content-Type: text/csv' );
-                header( 'Content-Disposition: attachment; filename=councils.csv' );
-            }
-            echo $data;
-            exit;
-        }
-        if ( empty( $_FILES['cdc_csv_file']['tmp_name'] ) ) {
-            return;
-        }
-        check_admin_referer( 'cdc_load_csv', 'cdc_load_csv_nonce' );
-        $file = $_FILES['cdc_csv_file']['tmp_name'];
-        $ext  = pathinfo( $_FILES['cdc_csv_file']['name'], PATHINFO_EXTENSION );
-        if ( strtolower( $ext ) === 'json' ) {
-            $result = self::load_json( $file );
-        } else {
-            $result = self::load_csv( $file );
-        }
-        add_action( 'admin_notices', function() use ( $result ) {
-            if ( is_wp_error( $result ) ) {
-                echo '<div class="notice notice-error"><p>' . esc_html( $result->get_error_message() ) . '</p></div>';
-            } else {
-                echo '<div class="notice notice-success"><p>' . esc_html( sprintf( __( 'Imported %d councils.', 'council-debt-counters' ), $result ) ) . '</p></div>';
-            }
-        } );
-    }
+	/**
+	 * Handle admin CSV upload action.
+	 */
+	public static function handle_admin_action() {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return;
+		}
+		if ( isset( $_POST['cdc_export_settings'] ) ) {
+			check_admin_referer( 'cdc_export_settings', 'cdc_export_settings_nonce' );
+			$data = self::export_settings();
+			Error_Logger::log_info( 'Exported plugin settings' );
+			header( 'Content-Type: application/json' );
+			header( 'Content-Disposition: attachment; filename=cdc-settings.json' );
+			echo $data;
+			exit;
+		}
+		if ( isset( $_FILES['cdc_settings_file']['tmp_name'] ) ) {
+			check_admin_referer( 'cdc_import_settings', 'cdc_import_settings_nonce' );
+			$file   = $_FILES['cdc_settings_file']['tmp_name'];
+			$result = self::import_settings( $file );
+			add_action(
+				'admin_notices',
+				function () use ( $result ) {
+					if ( is_wp_error( $result ) ) {
+						echo '<div class="notice notice-error"><p>' . esc_html( $result->get_error_message() ) . '</p></div>';
+					} else {
+						echo '<div class="notice notice-success"><p>' . esc_html__( 'Settings imported.', 'council-debt-counters' ) . '</p></div>';
+					}
+				}
+			);
+			return;
+		}
+		if ( isset( $_POST['cdc_export'] ) ) {
+			check_admin_referer( 'cdc_export', 'cdc_export_nonce' );
+			$format = sanitize_key( $_POST['format'] ?? 'csv' );
+			$data   = self::export_data( $format );
+			Error_Logger::log_info( 'Exported councils as ' . $format );
+			if ( 'json' === $format ) {
+				header( 'Content-Type: application/json' );
+				header( 'Content-Disposition: attachment; filename=councils.json' );
+			} else {
+				header( 'Content-Type: text/csv' );
+				header( 'Content-Disposition: attachment; filename=councils.csv' );
+			}
+			echo $data;
+			exit;
+		}
+		if ( empty( $_FILES['cdc_csv_file']['tmp_name'] ) ) {
+			return;
+		}
+		check_admin_referer( 'cdc_load_csv', 'cdc_load_csv_nonce' );
+		$file = $_FILES['cdc_csv_file']['tmp_name'];
+		$ext  = pathinfo( $_FILES['cdc_csv_file']['name'], PATHINFO_EXTENSION );
+		if ( strtolower( $ext ) === 'json' ) {
+			$result = self::load_json( $file );
+		} else {
+			$result = self::load_csv( $file );
+		}
+		add_action(
+			'admin_notices',
+			function () use ( $result ) {
+				if ( is_wp_error( $result ) ) {
+					echo '<div class="notice notice-error"><p>' . esc_html( $result->get_error_message() ) . '</p></div>';
+				} else {
+					echo '<div class="notice notice-success"><p>' . esc_html( sprintf( __( 'Imported %d councils.', 'council-debt-counters' ), $result ) ) . '</p></div>';
+				}
+			}
+		);
+	}
+
+	/**
+	 * AJAX handler for importing a single CSV row.
+	 */
+	public static function ajax_import_row() {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error( __( 'Permission denied.', 'council-debt-counters' ) );
+		}
+		check_ajax_referer( 'cdc_import_csv_row', 'nonce' );
+		$row = json_decode( wp_unslash( $_POST['row'] ?? '' ), true );
+		if ( ! is_array( $row ) || empty( $row['council_name'] ) ) {
+			wp_send_json_error( __( 'Invalid row.', 'council-debt-counters' ) );
+		}
+
+		$name    = sanitize_text_field( $row['council_name'] );
+		$post    = get_page_by_title( $name, OBJECT, 'council' );
+		$post_id = $post ? $post->ID : 0;
+
+		if ( $post_id ) {
+			wp_update_post(
+				array(
+					'ID'         => $post_id,
+					'post_title' => $name,
+				)
+			);
+		} else {
+			$post_id = wp_insert_post(
+				array(
+					'post_title'  => $name,
+					'post_type'   => 'council',
+					'post_status' => 'draft',
+				)
+			);
+			if ( is_wp_error( $post_id ) ) {
+				wp_send_json_error( __( 'Insert failed.', 'council-debt-counters' ) );
+			}
+		}
+
+		foreach ( $row as $field => $value ) {
+			if ( 'council_name' === $field || $value === '' ) {
+				continue;
+			}
+			Custom_Fields::update_value( $post_id, $field, $value );
+		}
+
+		if ( method_exists( '\\CouncilDebtCounters\\Council_Post_Type', 'calculate_total_debt' ) ) {
+			Council_Post_Type::calculate_total_debt( $post_id );
+		}
+
+		wp_send_json_success( array( 'id' => $post_id ) );
+	}
 }
-

--- a/includes/class-data-loader.php
+++ b/includes/class-data-loader.php
@@ -66,7 +66,7 @@ class Data_Loader {
                 $post_id = wp_insert_post( [
                     'post_title'  => $name,
                     'post_type'   => 'council',
-                    'post_status' => 'publish',
+                    'post_status' => 'draft',
                 ] );
                 if ( is_wp_error( $post_id ) ) {
                     Error_Logger::log( 'Failed to insert council: ' . $name );

--- a/includes/class-settings-page.php
+++ b/includes/class-settings-page.php
@@ -2,7 +2,7 @@
 namespace CouncilDebtCounters;
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit;
+	exit;
 }
 
 use CouncilDebtCounters\Docs_Manager;
@@ -10,148 +10,188 @@ use CouncilDebtCounters\Council_Admin_Page;
 
 class Settings_Page {
 
-    const FONT_CHOICES = [ 'Oswald', 'Roboto', 'Open Sans', 'Lato', 'Montserrat', 'Source Sans Pro' ];
+	const FONT_CHOICES = array( 'Oswald', 'Roboto', 'Open Sans', 'Lato', 'Montserrat', 'Source Sans Pro' );
 
-    public static function init() {
-        add_action( 'admin_menu', [ __CLASS__, 'add_menu' ] );
-        add_action( 'admin_init', [ __CLASS__, 'register_settings' ] );
-    }
+	public static function init() {
+		add_action( 'admin_menu', array( __CLASS__, 'add_menu' ) );
+		add_action( 'admin_init', array( __CLASS__, 'register_settings' ) );
+		add_action( 'admin_enqueue_scripts', array( __CLASS__, 'enqueue_assets' ) );
+	}
 
-    public static function add_menu() {
-        add_menu_page(
-            __( 'Council Debt Counters', 'council-debt-counters' ),
-            __( 'Debt Counters', 'council-debt-counters' ),
-            'manage_options',
-            'council-debt-counters',
-            [ __CLASS__, 'render_page' ],
-            'dashicons-chart-line'
-        );
+	public static function add_menu() {
+		add_menu_page(
+			__( 'Council Debt Counters', 'council-debt-counters' ),
+			__( 'Debt Counters', 'council-debt-counters' ),
+			'manage_options',
+			'council-debt-counters',
+			array( __CLASS__, 'render_page' ),
+			'dashicons-chart-line'
+		);
 
-        add_submenu_page(
-            'council-debt-counters',
-            __( 'Licence Keys and Addons', 'council-debt-counters' ),
-            __( 'Licence Keys and Addons', 'council-debt-counters' ),
-            'manage_options',
-            'cdc-license-keys',
-            [ __CLASS__, 'render_license_page' ]
-        );
+		add_submenu_page(
+			'council-debt-counters',
+			__( 'Licence Keys and Addons', 'council-debt-counters' ),
+			__( 'Licence Keys and Addons', 'council-debt-counters' ),
+			'manage_options',
+			'cdc-license-keys',
+			array( __CLASS__, 'render_license_page' )
+		);
 
-        add_submenu_page(
-            'council-debt-counters',
-            __( 'Settings', 'council-debt-counters' ),
-            __( 'Settings', 'council-debt-counters' ),
-            'manage_options',
-            'cdc-settings',
-            [ __CLASS__, 'render_settings_page' ]
-        );
+		add_submenu_page(
+			'council-debt-counters',
+			__( 'Settings', 'council-debt-counters' ),
+			__( 'Settings', 'council-debt-counters' ),
+			'manage_options',
+			'cdc-settings',
+			array( __CLASS__, 'render_settings_page' )
+		);
 
-        add_submenu_page(
-            'council-debt-counters',
-            __( 'Import & Export', 'council-debt-counters' ),
-            __( 'Import & Export', 'council-debt-counters' ),
-            'manage_options',
-            'cdc-import-export',
-            [ __CLASS__, 'render_import_export_page' ]
-        );
+		add_submenu_page(
+			'council-debt-counters',
+			__( 'Import & Export', 'council-debt-counters' ),
+			__( 'Import & Export', 'council-debt-counters' ),
+			'manage_options',
+			'cdc-import-export',
+			array( __CLASS__, 'render_import_export_page' )
+		);
 
-        // Only add unique submenus here (do not duplicate "Councils")
-        add_submenu_page(
-            'council-debt-counters',
-            __( 'Manage Documents', 'council-debt-counters' ),
-            __( 'Manage Documents', 'council-debt-counters' ),
-            'manage_options',
-            'cdc-manage-docs',
-            [ __CLASS__, 'render_docs_page' ]
-        );
-        add_submenu_page(
-            'council-debt-counters',
-            __( 'Troubleshooting', 'council-debt-counters' ),
-            __( 'Troubleshooting', 'council-debt-counters' ),
-            'manage_options',
-            'cdc-troubleshooting',
-            [ __CLASS__, 'render_troubleshooting_page' ]
-        );
-    }
+		// Only add unique submenus here (do not duplicate "Councils")
+		add_submenu_page(
+			'council-debt-counters',
+			__( 'Manage Documents', 'council-debt-counters' ),
+			__( 'Manage Documents', 'council-debt-counters' ),
+			'manage_options',
+			'cdc-manage-docs',
+			array( __CLASS__, 'render_docs_page' )
+		);
+		add_submenu_page(
+			'council-debt-counters',
+			__( 'Troubleshooting', 'council-debt-counters' ),
+			__( 'Troubleshooting', 'council-debt-counters' ),
+			'manage_options',
+			'cdc-troubleshooting',
+			array( __CLASS__, 'render_troubleshooting_page' )
+		);
+	}
 
-    public static function register_settings() {
-        // Options on the Licence page.
-        register_setting( 'cdc_license', License_Manager::OPTION_KEY );
-        register_setting( 'cdc_license', License_Manager::OPTION_VALID );
-        register_setting( 'cdc_license', 'cdc_openai_api_key' );
-        register_setting( 'cdc_license', 'cdc_recaptcha_site_key' );
-        register_setting( 'cdc_license', 'cdc_recaptcha_secret_key' );
+	public static function register_settings() {
+		// Options on the Licence page.
+		register_setting( 'cdc_license', License_Manager::OPTION_KEY );
+		register_setting( 'cdc_license', License_Manager::OPTION_VALID );
+		register_setting( 'cdc_license', 'cdc_openai_api_key' );
+		register_setting( 'cdc_license', 'cdc_recaptcha_site_key' );
+		register_setting( 'cdc_license', 'cdc_recaptcha_secret_key' );
 
-        // Options on the Settings page.
-        register_setting( 'cdc_settings', 'cdc_openai_model', [ 'type' => 'string', 'default' => 'gpt-3.5-turbo' ] );
-        register_setting( 'cdc_settings', 'cdc_enabled_counters', [ 'type' => 'array', 'default' => [] ] );
-        register_setting(
-            'cdc_settings',
-            'cdc_log_level',
-            [
-                'type'              => 'string',
-                'default'           => 'standard',
-                'sanitize_callback' => [ __CLASS__, 'sanitize_log_level' ],
-            ]
-        );
-        register_setting(
-            'cdc_settings',
-            'cdc_counter_font',
-            [
-                'type'              => 'string',
-                'default'           => 'Oswald',
-                'sanitize_callback' => [ __CLASS__, 'sanitize_font' ],
-            ]
-        );
-        register_setting(
-            'cdc_settings',
-            'cdc_counter_weight',
-            [
-                'type'              => 'string',
-                'default'           => '600',
-                'sanitize_callback' => [ __CLASS__, 'sanitize_weight' ],
-            ]
-        );
-    }
+		// Options on the Settings page.
+		register_setting(
+			'cdc_settings',
+			'cdc_openai_model',
+			array(
+				'type'    => 'string',
+				'default' => 'gpt-3.5-turbo',
+			)
+		);
+		register_setting(
+			'cdc_settings',
+			'cdc_enabled_counters',
+			array(
+				'type'    => 'array',
+				'default' => array(),
+			)
+		);
+		register_setting(
+			'cdc_settings',
+			'cdc_log_level',
+			array(
+				'type'              => 'string',
+				'default'           => 'standard',
+				'sanitize_callback' => array( __CLASS__, 'sanitize_log_level' ),
+			)
+		);
+		register_setting(
+			'cdc_settings',
+			'cdc_counter_font',
+			array(
+				'type'              => 'string',
+				'default'           => 'Oswald',
+				'sanitize_callback' => array( __CLASS__, 'sanitize_font' ),
+			)
+		);
+		register_setting(
+			'cdc_settings',
+			'cdc_counter_weight',
+			array(
+				'type'              => 'string',
+				'default'           => '600',
+				'sanitize_callback' => array( __CLASS__, 'sanitize_weight' ),
+			)
+		);
+	}
 
-    public static function sanitize_log_level( $value ) {
-        $value = sanitize_key( $value );
-        return in_array( $value, [ 'verbose', 'standard', 'quiet' ], true ) ? $value : 'standard';
-    }
+	public static function enqueue_assets( $hook ) {
+		if ( 'debt-counters_page_cdc-import-export' !== $hook ) {
+			return;
+		}
+		$plugin_file = dirname( __DIR__ ) . '/council-debt-counters.php';
+		wp_enqueue_script(
+			'cdc-import-csv',
+			plugins_url( 'admin/js/import-csv.js', $plugin_file ),
+			array(),
+			'0.1.0',
+			true
+		);
+		wp_enqueue_style( 'cdc-import-progress', plugins_url( 'admin/css/import-progress.css', $plugin_file ), array(), '0.1.0' );
+		wp_localize_script(
+			'cdc-import-csv',
+			'cdcImport',
+			array(
+				'ajaxUrl'  => admin_url( 'admin-ajax.php' ),
+				'nonce'    => wp_create_nonce( 'cdc_import_csv_row' ),
+				'progress' => __( 'Imported %1 of %2 rows…', 'council-debt-counters' ),
+				'done'     => __( 'Import complete', 'council-debt-counters' ),
+			)
+		);
+	}
 
-    public static function sanitize_font( $value ) {
-        $value = sanitize_text_field( $value );
-        return in_array( $value, self::FONT_CHOICES, true ) ? $value : 'Oswald';
-    }
+	public static function sanitize_log_level( $value ) {
+		$value = sanitize_key( $value );
+		return in_array( $value, array( 'verbose', 'standard', 'quiet' ), true ) ? $value : 'standard';
+	}
 
-    public static function sanitize_weight( $value ) {
-        $value = preg_replace( '/[^0-9]/', '', $value );
-        if ( $value < 100 || $value > 900 ) {
-            return '600';
-        }
-        return $value;
-    }
+	public static function sanitize_font( $value ) {
+		$value = sanitize_text_field( $value );
+		return in_array( $value, self::FONT_CHOICES, true ) ? $value : 'Oswald';
+	}
 
-    public static function render_page() {
-        include plugin_dir_path( __DIR__ ) . 'admin/views/instructions-page.php';
-    }
+	public static function sanitize_weight( $value ) {
+		$value = preg_replace( '/[^0-9]/', '', $value );
+		if ( $value < 100 || $value > 900 ) {
+			return '600';
+		}
+		return $value;
+	}
 
-    public static function render_license_page() {
-        include plugin_dir_path( __DIR__ ) . 'admin/views/license-page.php';
-    }
+	public static function render_page() {
+		include plugin_dir_path( __DIR__ ) . 'admin/views/instructions-page.php';
+	}
 
-    public static function render_settings_page() {
-        include plugin_dir_path( __DIR__ ) . 'admin/views/settings-page.php';
-    }
+	public static function render_license_page() {
+		include plugin_dir_path( __DIR__ ) . 'admin/views/license-page.php';
+	}
 
-    public static function render_import_export_page() {
-        include plugin_dir_path( __DIR__ ) . 'admin/views/import-export-page.php';
-    }
+	public static function render_settings_page() {
+		include plugin_dir_path( __DIR__ ) . 'admin/views/settings-page.php';
+	}
 
-    public static function render_docs_page() {
-        include plugin_dir_path( __DIR__ ) . 'admin/views/docs-manager-page.php';
-    }
+	public static function render_import_export_page() {
+		include plugin_dir_path( __DIR__ ) . 'admin/views/import-export-page.php';
+	}
 
-    public static function render_troubleshooting_page() {
-        include plugin_dir_path( __DIR__ ) . 'admin/views/troubleshooting-page.php';
-    }
+	public static function render_docs_page() {
+		include plugin_dir_path( __DIR__ ) . 'admin/views/docs-manager-page.php';
+	}
+
+	public static function render_troubleshooting_page() {
+		include plugin_dir_path( __DIR__ ) . 'admin/views/troubleshooting-page.php';
+	}
 }

--- a/samples/sample-councils.csv
+++ b/samples/sample-councils.csv
@@ -1,0 +1,2 @@
+council_name,council_type,council_location,current_liabilities,long_term_liabilities,finance_lease_pfi_liabilities,interest_paid_on_debt
+Example Council,Unitary,England,1000000,2500000,500000,150000


### PR DESCRIPTION
## Summary
- provide a sample CSV download on the Import/Export page
- insert `council_location` field
- create councils uploaded via CSV in draft status
- register new `under_review` post status
- allow editing council post status
- filter councils list by status with counts
- added dropdowns for council type/location
- include sample CSV

## Testing
- `vendor/bin/phpunit`
- `vendor/bin/phpcs --standard=phpcs.xml.dist admin/views/councils-page.php` *(fails: 28 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6856e42cf7ec83319033892430762200