### PR TITLE
Update council edit toolbar

### DIFF
--- a/admin/js/council-form.js
+++ b/admin/js/council-form.js
@@ -22,6 +22,33 @@
         var form = actionInput.closest('form');
         if (!form) return;
 
+        var statusSelect = document.getElementById('cdc-post-status');
+        var assignee = document.querySelector('select[name="assigned_user"]');
+        var msgArea = document.getElementById('cdc-status-msg');
+        function flash(msg){
+            if(!msgArea) return;
+            msgArea.innerHTML = '<div class="alert alert-success mb-0">'+msg+'</div>';
+            setTimeout(function(){ msgArea.innerHTML = ''; },3000);
+        }
+        function sendToolbar(data){
+            data.append('action','cdc_update_toolbar');
+            data.append('post_id', cdcToolbarData.id);
+            data.append('nonce', cdcToolbarData.nonce);
+            fetch(ajaxurl,{method:'POST',credentials:'same-origin',body:data})
+                .then(function(r){return r.json();})
+                .then(function(res){ if(res.success && res.data && res.data.message){ flash(res.data.message); } });
+        }
+        if(statusSelect){
+            statusSelect.addEventListener('change', function(){
+                var d=new FormData(); d.append('post_status', statusSelect.value); sendToolbar(d);
+            });
+        }
+        if(assignee){
+            assignee.addEventListener('change', function(){
+                var d=new FormData(); d.append('assigned_user', assignee.value); sendToolbar(d);
+            });
+        }
+
         function validateField(field){
             if(!field.required) return;
             if(field.value.trim()===''){ field.classList.add('is-invalid'); }

--- a/admin/js/council-form.js
+++ b/admin/js/council-form.js
@@ -24,6 +24,7 @@
 
         var statusSelect = document.getElementById('cdc-post-status');
         var assignee = document.querySelector('select[name="assigned_user"]');
+        var uploadBtn = document.getElementById('cdc-upload-doc');
         var msgArea = document.getElementById('cdc-status-msg');
         function flash(msg){
             if(!msgArea) return;
@@ -46,6 +47,37 @@
         if(assignee){
             assignee.addEventListener('change', function(){
                 var d=new FormData(); d.append('assigned_user', assignee.value); sendToolbar(d);
+            });
+        }
+        if(uploadBtn){
+            uploadBtn.addEventListener('click', function(e){
+                e.preventDefault();
+                var file=document.getElementById('cdc-soa');
+                var url=form.querySelector('input[name="statement_of_accounts_url"]');
+                var year=document.getElementById('cdc-soa-year');
+                var existing=form.querySelector('select[name="statement_of_accounts_existing"]');
+                var d=new FormData();
+                d.append('action','cdc_upload_doc');
+                d.append('nonce', cdcToolbarData.nonce);
+                d.append('council_id', cdcToolbarData.id);
+                if(year) d.append('year', year.value);
+                if(file && file.files.length){ d.append('file', file.files[0]); }
+                if(url && url.value){ d.append('url', url.value); }
+                if(existing && existing.value){ d.append('existing', existing.value); }
+                fetch(ajaxurl,{method:'POST',credentials:'same-origin',body:d})
+                    .then(function(r){return r.json();})
+                    .then(function(res){
+                        if(res.success && res.data && res.data.html){
+                            var table=document.getElementById('cdc-docs-table');
+                            if(table){
+                                var tbody=table.querySelector('tbody');
+                                tbody.insertAdjacentHTML('beforeend', res.data.html);
+                            }
+                            flash(res.data.message || 'Document added.');
+                        } else if(res.data && res.data.message){
+                            alert(res.data.message);
+                        }
+                    });
             });
         }
 
@@ -135,10 +167,11 @@
                 document.body.appendChild(overlay);
             }
         });
-        document.querySelectorAll(".cdc-extract-ai").forEach(function(btn){
-            btn.addEventListener("click", function(e){
-                e.preventDefault();
-                var docId = btn.value;
+        document.addEventListener('click', function(e){
+            var target = e.target.closest('.cdc-extract-ai');
+            if(!target) return;
+            e.preventDefault();
+            var docId = target.value;
                 var overlay = document.createElement("div");
                 overlay.id = "cdc-ai-overlay";
                 overlay.innerHTML = "<span class=\"spinner is-active\"></span><div class=\"progress w-75 mt-2\" style=\"height:8px\"><div class=\"progress-bar\" style=\"width:0%\"></div></div><p></p>";

--- a/admin/views/councils-page.php
+++ b/admin/views/councils-page.php
@@ -232,19 +232,20 @@ if ( 'edit' === $req_action ) {
 							<?php $orphans = \CouncilDebtCounters\Docs_Manager::list_orphan_documents(); ?>
 							<?php if ( ! empty( $orphans ) ) : ?>
 								<p class="description mt-2"><?php esc_html_e( 'Or attach an existing document', 'council-debt-counters' ); ?></p>
-								<select name="statement_of_accounts_existing">
+                                                                <select name="statement_of_accounts_existing">
 									<option value=""><?php esc_html_e( 'Select document', 'council-debt-counters' ); ?></option>
 									<?php foreach ( $orphans as $doc ) : ?>
 										<option value="<?php echo esc_attr( $doc->filename ); ?>"><?php echo esc_html( $doc->filename ); ?></option>
 									<?php endforeach; ?>
-								</select>
-							<?php endif; ?>
-						</td>
-					</tr>
-				</table>
+                                                                </select>
+                                                                <button type="button" id="cdc-upload-doc" class="button button-secondary mt-2"><?php esc_html_e( 'Add Document', 'council-debt-counters' ); ?></button>
+                                                        <?php endif; ?>
+                                                </td>
+                                        </tr>
+                                </table>
 				<?php if ( ! empty( $docs ) ) : ?>
 				<h2><?php esc_html_e( 'Existing Documents', 'council-debt-counters' ); ?></h2>
-				<table class="widefat">
+                                <table id="cdc-docs-table" class="widefat">
 					<thead>
 						<tr>
 							<th><?php esc_html_e( 'File', 'council-debt-counters' ); ?></th>

--- a/admin/views/councils-page.php
+++ b/admin/views/councils-page.php
@@ -22,12 +22,15 @@ if ( 'edit' === $req_action ) {
                 } else {
                         echo '<h1>' . esc_html__( 'Add Council', 'council-debt-counters' ) . '</h1>';
                 }
-                $assigned = $council_id ? intval( get_post_meta( $council_id, 'assigned_user', true ) ) : 0;
-                $users = get_users( [ 'fields' => [ 'ID', 'display_name' ] ] );
-                $reports = $council_id ? count( get_posts( [ 'post_type' => \CouncilDebtCounters\Whistleblower_Form::CPT, 'numberposts' => -1, 'post_status' => 'private', 'meta_key' => 'council_id', 'meta_value' => $council_id ] ) ) : 0;
+                $assigned       = $council_id ? intval( get_post_meta( $council_id, 'assigned_user', true ) ) : 0;
+                $current_status = $council_id ? get_post_status( $council_id ) : 'draft';
+                $users          = get_users( [ 'fields' => [ 'ID', 'display_name' ] ] );
+                $reports        = $council_id ? count( get_posts( [ 'post_type' => \CouncilDebtCounters\Whistleblower_Form::CPT, 'numberposts' => -1, 'post_status' => 'private', 'meta_key' => 'council_id', 'meta_value' => $council_id ] ) ) : 0;
                 echo '<div id="cdc-toolbar" class="mb-3 d-flex justify-content-between align-items-center">';
-                echo '<div id="cdc-status-msg"></div>';
-                echo '<div class="d-flex align-items-center">';
+                $msg = isset( $_GET['updated'] ) ? '<div class="alert alert-success mb-0">' . esc_html__( 'Update successful.', 'council-debt-counters' ) . '</div>' : '';
+                echo '<div id="cdc-status-msg">' . $msg . '</div>';
+                echo '<div class="d-flex align-items-center flex-nowrap">';
+                echo '<select id="cdc-post-status" class="form-select me-2"><option value="publish"' . selected( $current_status, 'publish', false ) . '>' . esc_html__( 'Active', 'council-debt-counters' ) . '</option><option value="draft"' . selected( $current_status, 'draft', false ) . '>' . esc_html__( 'Draft', 'council-debt-counters' ) . '</option><option value="under_review"' . selected( $current_status, 'under_review', false ) . '>' . esc_html__( 'Under Review', 'council-debt-counters' ) . '</option></select>';
                 echo '<select name="assigned_user" class="form-select me-2"><option value="0">' . esc_html__( 'Unassigned', 'council-debt-counters' ) . '</option>';
                 foreach ( $users as $u ) {
                         printf( '<option value="%d"%s>%s</option>', $u->ID, selected( $assigned, $u->ID, false ), esc_html( $u->display_name ) );
@@ -148,17 +151,6 @@ if ( 'edit' === $req_action ) {
 						</td>
 					</tr>
 				<?php endforeach; ?>
-				<tr>
-					<th scope="row"><label for="cdc-post-status"><?php esc_html_e( 'Status', 'council-debt-counters' ); ?></label></th>
-					<td>
-												<?php $current_status = $council_id ? get_post_status( $council_id ) : 'draft'; ?>
-						<select id="cdc-post-status" name="post_status">
-							<option value="publish" <?php selected( $current_status, 'publish' ); ?>><?php esc_html_e( 'Active', 'council-debt-counters' ); ?></option>
-							<option value="draft" <?php selected( $current_status, 'draft' ); ?>><?php esc_html_e( 'Draft', 'council-debt-counters' ); ?></option>
-							<option value="under_review" <?php selected( $current_status, 'under_review' ); ?>><?php esc_html_e( 'Under Review', 'council-debt-counters' ); ?></option>
-						</select>
-					</td>
-				</tr>
 				</table>
 			</div>
 			<?php

--- a/includes/class-docs-manager.php
+++ b/includes/class-docs-manager.php
@@ -408,14 +408,17 @@ class Docs_Manager {
                 }
             }
             // Fallback to pdftotext if available.
-            if ( function_exists( 'shell_exec' ) && trim( shell_exec( 'command -v pdftotext' ) ) ) {
-                $cmd    = 'pdftotext ' . escapeshellarg( $file ) . ' -';
+            if ( function_exists( 'shell_exec' ) ) {
+                $bin_check = shell_exec( 'command -v pdftotext' );
+                if ( ! empty( $bin_check ) ) {
+                    $cmd    = 'pdftotext ' . escapeshellarg( $file ) . ' -';
                 $output = shell_exec( $cmd );
                 if ( ! empty( $output ) ) {
                     Error_Logger::log_debug( 'pdftotext used for extraction' );
                     return $output;
                 }
                 Error_Logger::log_error( 'pdftotext returned no output for ' . $file );
+                }
             }
             return '';
         }

--- a/includes/class-docs-manager.php
+++ b/includes/class-docs-manager.php
@@ -42,6 +42,7 @@ class Docs_Manager {
         add_action( 'admin_post_cdc_dismiss_ai_figures', [ __CLASS__, 'handle_dismiss_ai' ] );
         add_action( 'admin_notices', [ __CLASS__, 'show_ai_suggestions' ] );
         add_action( 'wp_ajax_cdc_extract_figures', [ __CLASS__, 'handle_ajax_extract' ] );
+        add_action( 'wp_ajax_cdc_upload_doc', [ __CLASS__, 'handle_ajax_upload_doc' ] );
     }
 
     public static function install() {
@@ -384,6 +385,73 @@ class Docs_Manager {
         $msg    = __( 'Extraction complete. Review suggestions below.', 'council-debt-counters' );
         $tokens = is_array( $result ) && isset( $result['tokens'] ) ? intval( $result['tokens'] ) : 0;
         wp_send_json_success( [ 'message' => $msg, 'tokens' => $tokens ] );
+    }
+
+    public static function handle_ajax_upload_doc() {
+        if ( ! current_user_can( 'manage_options' ) ) {
+            wp_send_json_error( [ 'message' => __( 'Permission denied.', 'council-debt-counters' ) ], 403 );
+        }
+        check_ajax_referer( 'cdc_save_council', 'nonce' );
+
+        $cid  = intval( $_POST['council_id'] ?? 0 );
+        if ( ! $cid ) {
+            wp_send_json_error( [ 'message' => __( 'Invalid council.', 'council-debt-counters' ) ] );
+        }
+        $year = sanitize_text_field( $_POST['year'] ?? self::current_financial_year() );
+        $filename = '';
+        $result = null;
+        if ( ! empty( $_FILES['file']['name'] ) ) {
+            $filename = basename( $_FILES['file']['name'] );
+            $result   = self::upload_document( $_FILES['file'], 'statement_of_accounts', $cid, $year );
+        } elseif ( ! empty( $_POST['url'] ) ) {
+            $url      = esc_url_raw( $_POST['url'] );
+            $filename = basename( parse_url( $url, PHP_URL_PATH ) );
+            $result   = self::import_from_url( $url, 'statement_of_accounts', $cid, $year );
+        } elseif ( ! empty( $_POST['existing'] ) ) {
+            $filename = sanitize_file_name( $_POST['existing'] );
+            self::assign_document( $filename, $cid, 'statement_of_accounts', $year );
+            $result = true;
+        } else {
+            wp_send_json_error( [ 'message' => __( 'No document specified.', 'council-debt-counters' ) ] );
+        }
+
+        if ( $result === true ) {
+            $doc = self::get_document( $filename );
+            if ( $doc ) {
+                wp_send_json_success( [
+                    'html'    => self::render_doc_row( $doc ),
+                    'message' => __( 'Document added.', 'council-debt-counters' ),
+                ] );
+            }
+        }
+        wp_send_json_error( [ 'message' => is_string( $result ) ? $result : __( 'Upload failed.', 'council-debt-counters' ) ] );
+    }
+
+    public static function render_doc_row( $doc ) {
+        ob_start();
+        ?>
+        <tr>
+            <td><?php echo esc_html( $doc->filename ); ?></td>
+            <td>
+                <select name="docs[<?php echo esc_attr( $doc->id ); ?>][financial_year]">
+                    <?php foreach ( self::financial_years() as $y ) : ?>
+                        <option value="<?php echo esc_attr( $y ); ?>" <?php selected( $doc->financial_year, $y ); ?>><?php echo esc_html( $y ); ?></option>
+                    <?php endforeach; ?>
+                </select>
+            </td>
+            <td>
+                <select name="docs[<?php echo esc_attr( $doc->id ); ?>][doc_type]">
+                    <option value="statement_of_accounts" <?php selected( $doc->doc_type, 'statement_of_accounts' ); ?>><?php esc_html_e( 'Statement of Accounts', 'council-debt-counters' ); ?></option>
+                </select>
+            </td>
+            <td>
+                <button type="button" value="<?php echo esc_attr( $doc->id ); ?>" class="button cdc-extract-ai"><span class="dashicons dashicons-lightbulb"></span> <?php esc_html_e( 'Extract Figures', 'council-debt-counters' ); ?></button>
+                <button type="submit" name="update_doc" value="<?php echo esc_attr( $doc->id ); ?>" class="button button-secondary"><?php esc_html_e( 'Update', 'council-debt-counters' ); ?></button>
+                <button type="submit" name="delete_doc" value="<?php echo esc_attr( $doc->id ); ?>" class="button button-link-delete" onclick="return confirm('<?php echo esc_js( __( 'Delete this document?', 'council-debt-counters' ) ); ?>');"><?php esc_html_e( 'Delete', 'council-debt-counters' ); ?></button>
+            </td>
+        </tr>
+        <?php
+        return ob_get_clean();
     }
 
     private static function extract_text( string $file ) {


### PR DESCRIPTION
## Summary
- move status dropdown into edit toolbar
- save assignee and status with AJAX
- redirect back to edit screen after save
- handle null shell_exec return for pdf text extraction

## Testing
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_68570480a7cc83318423b0b63d22837f