### PR TITLE
Expose council CPT and add admin links

### DIFF
--- a/admin/views/councils-page.php
+++ b/admin/views/councils-page.php
@@ -38,6 +38,12 @@ if ( 'edit' === $req_action ) {
                 echo '</select>';
                 if ( $council_id ) {
                         echo '<span class="badge bg-info me-2">' . esc_html__( 'Reports:', 'council-debt-counters' ) . ' ' . intval( $reports ) . '</span>';
+                        $view_link = get_permalink( $council_id );
+                        echo '<a href="' . esc_url( $view_link ) . '" class="btn btn-sm btn-primary me-2" target="_blank" rel="noopener noreferrer">' . esc_html__( 'View Live Page', 'council-debt-counters' ) . '</a>';
+                        if ( defined( 'ELEMENTOR_VERSION' ) ) {
+                                $edit_link = admin_url( 'post.php?post=' . $council_id . '&action=elementor' );
+                                echo '<a href="' . esc_url( $edit_link ) . '" class="btn btn-sm btn-secondary me-2">' . esc_html__( 'Edit with Elementor', 'council-debt-counters' ) . '</a>';
+                        }
                         $del = wp_nonce_url( admin_url( 'admin.php?page=cdc-manage-councils&action=delete&post=' . $council_id ), 'cdc_delete_council_' . $council_id );
                         echo '<a href="' . esc_url( $del ) . '" class="btn btn-sm btn-danger" onclick="return confirm(\'' . esc_js( __( 'Delete this council?', 'council-debt-counters' ) ) . '\');">' . esc_html__( 'Trash Council', 'council-debt-counters' ) . '</a>';
                 }

--- a/includes/class-council-post-type.php
+++ b/includes/class-council-post-type.php
@@ -26,13 +26,16 @@ class Council_Post_Type {
                 'name'          => __( 'Councils', 'council-debt-counters' ),
                 'singular_name' => __( 'Council', 'council-debt-counters' ),
             ],
-            'public'             => false,
+            'public'             => true,
             'show_ui'            => true,
             'show_in_menu'       => false,
             'show_in_admin_bar'  => false,
             'capability_type'    => 'post',
             'supports'           => [ 'title' ],
-            'publicly_queryable' => false,
+            'publicly_queryable' => true,
+            'show_in_rest'       => true,
+            'has_archive'        => true,
+            'rewrite'            => [ 'slug' => 'council' ],
         ] );
 
         register_post_status( 'under_review', [


### PR DESCRIPTION
## Summary
- make the "council" post type public and REST accessible
- show "View Live Page" and "Edit with Elementor" buttons when editing a council

## Testing
- `vendor/bin/phpunit`
- `vendor/bin/phpcs --standard=phpcs.xml.dist --error-severity=1 --warning-severity=0 | head`

------
https://chatgpt.com/codex/tasks/task_e_685708f20d3c8331ba9870bb6b642958