### PR TITLE
Add financial source and status message fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The plugin will automatically create the necessary database tables on activation
 If you provide an OpenAI API key you can let the plugin attempt to pull key figures from uploaded Statement of Accounts documents. Select the desired model under **Debt Counters → Settings**; this option is ignored unless an API key has been entered on the **Licences & Addons** page. Models like **o3**, **o4-mini** and **gpt‑4o** are available alongside gpt‑3.5 and gpt‑4. The AI’s suggestions are shown in the admin area so you can review and confirm them before the values are stored for that council. Large PDFs are automatically split into smaller chunks so each OpenAI request stays within the model’s token limits. Requests are throttled to each model’s tokens-per-minute allowance (for example 200k TPM for o4-mini and 30k TPM for gpt‑4o). The progress overlay now displays how many tokens were used and shows a countdown bar so you know how long to wait. Requests allow up to 60 seconds by default; filter `cdc_openai_timeout` to change this.
 If the accounts indicate figures are in thousands of pounds (e.g. using "£000s" headings) the AI multiplies numbers by 1,000 so stored values are the full amounts.
 
-By default each council includes standard fields such as **Council Name**, **Council Type**, **Population**, **Households**, **Current Liabilities**, **Long-Term Liabilities**, **PFI or Finance Lease Liabilities**, **Interest Paid on Debt**. These mandatory fields cannot be removed, though you may edit their labels. A **Total Debt** field is calculated automatically from the others and is visible as a read-only value. Additional custom fields can be added, edited or removed from the admin screen and you can change whether they are required as well as their field type (text, number or monetary).
+By default each council includes standard fields such as **Council Name**, **Council Type**, **Population**, **Households**, **Current Liabilities**, **Long-Term Liabilities**, **PFI or Finance Lease Liabilities**, **Interest Paid on Debt**, and a **Financial Data Source URL** so visitors can view the statement used. These mandatory fields cannot be removed, though you may edit their labels. A **Total Debt** field is calculated automatically from the others and is visible as a read-only value. Additional custom fields &ndash; including a **Status Message** and **Status Message Type** &ndash; can be added, edited or removed from the admin screen and you can change whether they are required as well as their field type (text, number or monetary).
 
 Councils can be added, edited, and deleted from the **Debt Counters → Councils** page which uses a clean Bootstrap design. All custom fields are displayed on this screen so you can capture relevant information before uploading finance documents.
 
@@ -58,6 +58,10 @@ uses the selected council’s name, relevant figure and permalink so each share
 promotes that specific page rather than the site in general. When used outside
 of a council post you can pass an `id` (or `council_id`) attribute to specify
 which council’s data should be used.
+
+### Status messages
+
+Use `[council_status]` to display any status message you have recorded for a council. The shortcode falls back to the post status (Draft or Under Review) if no custom message is set and outputs a Bootstrap alert with the chosen style.
 
 
 ## Installation

--- a/admin/views/councils-page.php
+++ b/admin/views/councils-page.php
@@ -131,7 +131,7 @@ if ( 'edit' === $req_action ) {
                                                                 <?php if ( $is_required ) : ?>
                                                                         <div class="invalid-feedback"><?php esc_html_e( 'Required', 'council-debt-counters' ); ?></div>
                                                                 <?php endif; ?>
-														<?php elseif ( 'council_location' === $field->name ) : ?>
+<?php elseif ( 'council_location' === $field->name ) : ?>
                                                                        <select id="cdc-field-<?php echo esc_attr( $field->id ); ?>" name="cdc_fields[<?php echo esc_attr( $field->id ); ?>]" class="form-select" <?php echo $is_required ? 'required' : ''; ?> <?php echo $readonly ? 'disabled' : ''; ?>>
 															<?php foreach ( $council_locations as $t ) : ?>
 										<option value="<?php echo esc_attr( $t ); ?>" <?php selected( $val, $t ); ?>><?php echo esc_html( $t ); ?></option>
@@ -140,7 +140,25 @@ if ( 'edit' === $req_action ) {
                                                                 <?php if ( $is_required ) : ?>
                                                                         <div class="invalid-feedback"><?php esc_html_e( 'Required', 'council-debt-counters' ); ?></div>
                                                                 <?php endif; ?>
-														<?php elseif ( 'money' === $field->type ) : ?>
+<?php elseif ( 'financial_data_source_url' === $field->name ) : ?>
+<input data-cdc-field="<?php echo esc_attr( $field->name ); ?>" type="url" id="cdc-field-<?php echo esc_attr( $field->id ); ?>" value="<?php echo esc_attr( $val ); ?>" class="form-control" <?php echo $readonly ? 'readonly disabled' : 'name="cdc_fields[' . esc_attr( $field->id ) . ']"'; ?> <?php echo $is_required ? 'required' : ''; ?> placeholder="https://example.com/statement.pdf">
+<p class="description mt-1"><?php esc_html_e( 'Link to the published statement this data comes from.', 'council-debt-counters' ); ?></p>
+<?php elseif ( 'status_message_type' === $field->name ) : ?>
+<select id="cdc-field-<?php echo esc_attr( $field->id ); ?>" name="cdc_fields[<?php echo esc_attr( $field->id ); ?>]" class="form-select" <?php echo $is_required ? 'required' : ''; ?> <?php echo $readonly ? 'disabled' : ''; ?>>
+<?php foreach ( array( 'info', 'warning', 'danger' ) as $t ) : ?>
+<option value="<?php echo esc_attr( $t ); ?>" <?php selected( $val, $t ); ?>><?php echo esc_html( ucfirst( $t ) ); ?></option>
+<?php endforeach; ?>
+</select>
+<?php elseif ( 'financial_data_source_url' === $field->name ) : ?>
+<input data-cdc-field="<?php echo esc_attr( $field->name ); ?>" type="url" id="cdc-field-<?php echo esc_attr( $field->id ); ?>" value="<?php echo esc_attr( $val ); ?>" class="form-control" <?php echo $readonly ? 'readonly disabled' : 'name="cdc_fields[' . esc_attr( $field->id ) . ']"'; ?> <?php echo $is_required ? 'required' : ''; ?> placeholder="https://example.com/statement.pdf">
+<p class="description mt-1"><?php esc_html_e( 'Link to the published statement this data comes from.', 'council-debt-counters' ); ?></p>
+<?php elseif ( 'status_message_type' === $field->name ) : ?>
+<select id="cdc-field-<?php echo esc_attr( $field->id ); ?>" name="cdc_fields[<?php echo esc_attr( $field->id ); ?>]" <?php echo $is_required ? 'required' : ''; ?> <?php echo $readonly ? 'disabled' : ''; ?>>
+<?php foreach ( array( 'info', 'warning', 'danger' ) as $t ) : ?>
+<option value="<?php echo esc_attr( $t ); ?>" <?php selected( $val, $t ); ?>><?php echo esc_html( ucfirst( $t ) ); ?></option>
+<?php endforeach; ?>
+</select>
+<?php elseif ( 'money' === $field->type ) : ?>
                                                                 <div class="input-group">
                                                                         <span class="input-group-text">&pound;</span>
                                                                         <input data-cdc-field="<?php echo esc_attr( $field->name ); ?>" type="number" step="0.01" id="cdc-field-<?php echo esc_attr( $field->id ); ?>" value="<?php echo esc_attr( $val ); ?>" class="form-control" <?php echo $readonly ? 'readonly disabled' : 'name="cdc_fields[' . esc_attr( $field->id ) . ']"'; ?> <?php echo $is_required ? 'required' : ''; ?>>

--- a/includes/class-custom-fields.php
+++ b/includes/class-custom-fields.php
@@ -31,6 +31,9 @@ class Custom_Fields {
         ['name' => 'consultancy_spend', 'label' => 'Consultancy Spend', 'type' => 'money', 'required' => 0],
         ['name' => 'waste_report_count', 'label' => 'Waste Report Count', 'type' => 'number', 'required' => 0],
         ['name' => 'statement_of_accounts', 'label' => 'Statement of Accounts (PDF)', 'type' => 'text', 'required' => 0],
+        ['name' => 'financial_data_source_url', 'label' => 'Financial Data Source URL', 'type' => 'text', 'required' => 0],
+        ['name' => 'status_message', 'label' => 'Status Message', 'type' => 'text', 'required' => 0],
+        ['name' => 'status_message_type', 'label' => 'Status Message Type', 'type' => 'text', 'required' => 0],
     ];
 
     /**
@@ -118,7 +121,9 @@ class Custom_Fields {
      * Register custom meta keys for REST and sanitisation.
      */
     public static function register_meta_fields() {
-        foreach ( self::DEFAULT_FIELDS as $field ) {
+        $fields = self::get_fields();
+        foreach ( $fields as $field ) {
+            $field = (array) $field;
             register_meta( 'post', $field['name'], [
                 'object_subtype' => 'council',
                 'type'           => in_array( $field['type'], [ 'number', 'money' ], true ) ? 'number' : 'string',


### PR DESCRIPTION
## Summary
- add new fields for financial data source URL and council status messages
- expose all custom fields in Elementor by registering meta from DB
- allow shortcodes to inherit the current council ID
- add `[council_status]` shortcode for status messages
- document new fields and shortcode

## Testing
- `vendor/bin/phpcs` *(fails: many style errors)*
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_68570f454b4c8331a1a92235ce5789de