### PR TITLE
Allow shortcode to default ID and tweak toolbar

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ which council’s data should be used.
 
 ### Status messages
 
-Use `[council_status]` to display any status message you have recorded for a council. The shortcode falls back to the post status (Draft or Under Review) if no custom message is set and outputs a Bootstrap alert with the chosen style.
+Use `[council_status]` to display any status message you have recorded for a council. If the field is empty then nothing is shown.
 
 
 ## Installation

--- a/admin/css/toolbar.css
+++ b/admin/css/toolbar.css
@@ -1,0 +1,3 @@
+#cdc-toolbar .btn {
+    white-space: nowrap;
+}

--- a/admin/views/councils-page.php
+++ b/admin/views/councils-page.php
@@ -37,6 +37,7 @@ if ( 'edit' === $req_action ) {
                 }
                 echo '</select>';
                 if ( $council_id ) {
+                        echo '<span class="badge bg-secondary me-2">ID: ' . intval( $council_id ) . '</span>';
                         echo '<span class="badge bg-info me-2">' . esc_html__( 'Reports:', 'council-debt-counters' ) . ' ' . intval( $reports ) . '</span>';
                         $view_link = get_permalink( $council_id );
                         echo '<a href="' . esc_url( $view_link ) . '" class="btn btn-sm btn-primary me-2" target="_blank" rel="noopener noreferrer">' . esc_html__( 'View Live Page', 'council-debt-counters' ) . '</a>';

--- a/council-debt-counters.php
+++ b/council-debt-counters.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Council Debt Counters
  * Description: Animated counters visualising council debt figures.
- * Version: 0.2.3
+ * Version: 0.2.4
  * Author: Mike Rouse using OpenAI Codex
  * Author URI: https://www.mikerouse.co.uk
  * Text Domain: council-debt-counters

--- a/council-debt-counters.php
+++ b/council-debt-counters.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Council Debt Counters
  * Description: Animated counters visualising council debt figures.
- * Version: 0.2.4
+ * Version: 0.2.5
  * Author: Mike Rouse using OpenAI Codex
  * Author URI: https://www.mikerouse.co.uk
  * Text Domain: council-debt-counters

--- a/council-debt-counters.php
+++ b/council-debt-counters.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Council Debt Counters
  * Description: Animated counters visualising council debt figures.
- * Version: 0.2.2
+ * Version: 0.2.3
  * Author: Mike Rouse using OpenAI Codex
  * Author URI: https://www.mikerouse.co.uk
  * Text Domain: council-debt-counters

--- a/includes/class-council-admin-page.php
+++ b/includes/class-council-admin-page.php
@@ -65,6 +65,7 @@ class Council_Admin_Page {
         );
         wp_enqueue_style( 'cdc-ai-progress', plugins_url( 'admin/css/ai-progress.css', dirname( __DIR__ ) . '/council-debt-counters.php' ), [], '0.1.0' );
         wp_enqueue_style( 'cdc-upload-progress', plugins_url( 'admin/css/upload-progress.css', dirname( __DIR__ ) . '/council-debt-counters.php' ), [], '0.1.0' );
+        wp_enqueue_style( 'cdc-toolbar', plugins_url( 'admin/css/toolbar.css', dirname( __DIR__ ) . '/council-debt-counters.php' ), [], '0.1.0' );
         wp_localize_script( 'cdc-council-form', 'cdcAiMessages', [
             'steps' => [
                 __( 'Checking OpenAI API key…', 'council-debt-counters' ),

--- a/includes/class-council-search.php
+++ b/includes/class-council-search.php
@@ -54,14 +54,13 @@ class Council_Search {
         set_transient( $key, 1, 2 );
         Stats_Page::log_search( $query );
         $args = [
-            'post_type'   => 'page',
-            'post_status' => 'publish',
-            'post_parent' => 3642,
-            's'           => $query,
-            'numberposts' => -1,
-            'orderby'     => 'title',
-            'order'       => 'ASC',
-            'fields'      => 'ids',
+            'post_type'      => 'council',
+            'post_status'    => 'publish',
+            'posts_per_page' => -1,
+            's'              => $query,
+            'orderby'        => 'title',
+            'order'          => 'ASC',
+            'fields'         => 'ids',
         ];
         $posts = get_posts( $args );
         $results = [];

--- a/includes/class-shortcode-renderer.php
+++ b/includes/class-shortcode-renderer.php
@@ -171,19 +171,19 @@ class Shortcode_Renderer {
 		);
 	}
 
-	public static function render_counter( $atts ) {
-		$atts = shortcode_atts(
-			array(
-				'id'   => 0,
-				'type' => 'debt',
-			),
-			$atts
-		);
-		$id   = intval( $atts['id'] );
-		$type = sanitize_key( $atts['type'] );
-		if ( 0 === $id ) {
-			return '';
-		}
+       public static function render_counter( $atts ) {
+               $atts = shortcode_atts(
+                       array(
+                               'id'   => 0,
+                               'type' => 'debt',
+                       ),
+                       $atts
+               );
+               $id   = self::get_council_id_from_atts( $atts );
+               $type = sanitize_key( $atts['type'] );
+               if ( 0 === $id ) {
+                       return '';
+               }
 		if ( '' !== $type && 'debt' !== $type ) {
 			// Delegate to the custom counter handler for non-debt types
 			return self::render_custom_counter( $atts );

--- a/includes/class-shortcode-renderer.php
+++ b/includes/class-shortcode-renderer.php
@@ -410,17 +410,8 @@ endforeach;
                 $message = Custom_Fields::get_value( $id, 'status_message' );
                 $type    = Custom_Fields::get_value( $id, 'status_message_type' );
 
-                if ( '' === $message ) {
-                        $status = get_post_status( $id );
-                        if ( 'draft' === $status ) {
-                                $message = __( 'This council entry is in draft.', 'council-debt-counters' );
-                                $type    = 'warning';
-                        } elseif ( 'under_review' === $status ) {
-                                $message = __( 'This council entry is pending review.', 'council-debt-counters' );
-                                $type    = 'info';
-                        } else {
-                                return '';
-                        }
+                if ( ! is_string( $message ) || '' === trim( $message ) ) {
+                        return '';
                 }
 
                 $type = in_array( $type, array( 'info', 'warning', 'danger' ), true ) ? $type : 'info';

--- a/includes/class-whistleblower-form.php
+++ b/includes/class-whistleblower-form.php
@@ -40,15 +40,25 @@ class Whistleblower_Form {
 		 */
        private static function get_council_id_from_atts( array $atts ): int {
                $id = isset( $atts['id'] ) ? intval( $atts['id'] ) : 0;
+
                if ( 0 === $id && isset( $atts['council_id'] ) ) {
                        $id = intval( $atts['council_id'] );
                }
-               if ( ! $id && ! empty( $atts['council'] ) ) {
+
+               if ( 0 === $id && ! empty( $atts['council'] ) ) {
                        $post = get_page_by_title( sanitize_text_field( $atts['council'] ), OBJECT, 'council' );
+                       if ( ! $post ) {
+                               $post = get_page_by_path( sanitize_title( $atts['council'] ), OBJECT, 'council' );
+                       }
                        if ( $post ) {
                                $id = $post->ID;
                        }
                }
+
+               if ( 0 === $id && is_singular( 'council' ) ) {
+                       $id = get_the_ID();
+               }
+
                return $id;
        }
 


### PR DESCRIPTION
## Summary
- support `[council_counter]` without specifying an ID
- show the council post ID in the editor toolbar
- stop toolbar buttons from wrapping
- bump plugin version to 0.2.3

## Testing
- `composer install`
- `vendor/bin/phpunit --testdox`

------
https://chatgpt.com/codex/tasks/task_e_685715611bc08331b58df419acf4e247