### PR TITLE
Add default sharing thumbnail support

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ promotes that specific page rather than the site in general. When used outside
 of a council post you can pass an `id` (or `council_id`) attribute to specify
 which council’s data should be used.
 
+The social preview image defaults to the **Default Sharing Thumbnail** set on the
+plugin Settings page. You can override this per council by selecting a
+**Sharing Image** when editing a council.
+
 ### Status messages
 
 Use `[council_status]` to display any status message you have recorded for a council. The shortcode falls back to the post status (Draft or Under Review) if no custom message is set and outputs a Bootstrap alert with the chosen style.

--- a/admin/js/media-select.js
+++ b/admin/js/media-select.js
@@ -1,0 +1,44 @@
+(function(){
+    document.addEventListener('DOMContentLoaded',function(){
+        function setup(id){
+            var input=document.getElementById(id);
+            if(!input) return;
+            var button=document.getElementById(id+'-button');
+            var remove=document.getElementById(id+'-remove');
+            var preview=document.getElementById(id+'-preview');
+            var frame;
+            function update(url){
+                if(preview){
+                    preview.innerHTML=url?'<img src="'+url+'" style="max-width:150px;height:auto"/>':'';
+                }
+                if(remove){ remove.style.display=url?'':'none'; }
+            }
+            if(button){
+                button.addEventListener('click',function(e){
+                    e.preventDefault();
+                    if(frame){ frame.open(); return; }
+                    frame=wp.media({title:CDC_MEDIA_SELECT.title,button:{text:CDC_MEDIA_SELECT.button},multiple:false});
+                    frame.on('select',function(){
+                        var attachment=frame.state().get('selection').first().toJSON();
+                        input.value=attachment.id;
+                        update(attachment.url);
+                    });
+                    frame.open();
+                });
+            }
+            if(remove){
+                remove.addEventListener('click',function(e){
+                    e.preventDefault();
+                    input.value='';
+                    update('');
+                });
+            }
+            if(input.value){
+                var url=input.dataset.url;
+                update(url);
+            }
+        }
+        setup('cdc-default-thumbnail');
+        setup('cdc-sharing-image');
+    });
+})();

--- a/admin/views/councils-page.php
+++ b/admin/views/councils-page.php
@@ -174,9 +174,23 @@ if ( 'edit' === $req_action ) {
 							<?php endif; ?>
 						</td>
 					</tr>
-				<?php endforeach; ?>
-				</table>
-			</div>
+                                <?php endforeach; ?>
+                                <tr>
+                                        <th scope="row"><?php esc_html_e( 'Sharing Image', 'council-debt-counters' ); ?></th>
+                                        <td>
+                                                <?php $share = $council_id ? absint( get_post_meta( $council_id, 'cdc_sharing_image', true ) ) : 0; ?>
+                                                <div id="cdc-sharing-image-preview">
+                                                        <?php if ( $share ) : ?>
+                                                                <?php echo wp_get_attachment_image( $share, array( 150, 150 ) ); ?>
+                                                        <?php endif; ?>
+                                                </div>
+                                                <input type="hidden" id="cdc-sharing-image" name="cdc_sharing_image" value="<?php echo esc_attr( $share ); ?>" data-url="<?php echo esc_url( $share ? wp_get_attachment_url( $share ) : '' ); ?>" />
+                                                <button type="button" class="button" id="cdc-sharing-image-button"><?php esc_html_e( 'Select Image', 'council-debt-counters' ); ?></button>
+                                                <button type="button" class="button" id="cdc-sharing-image-remove" <?php if ( ! $share ) echo 'style="display:none"'; ?>><?php esc_html_e( 'Remove', 'council-debt-counters' ); ?></button>
+                                        </td>
+                                </tr>
+                                </table>
+                        </div>
 			<?php
 			foreach ( $enabled as $tab_key ) :
 				if ( empty( $groups[ $tab_key ] ) ) {

--- a/admin/views/settings-page.php
+++ b/admin/views/settings-page.php
@@ -61,6 +61,20 @@ $types = [
                     <input type="number" name="cdc_counter_weight" id="cdc_counter_weight" value="<?php echo esc_attr( $weight ); ?>" min="100" max="900" step="100" />
                 </td>
             </tr>
+            <tr>
+                <th scope="row"><?php esc_html_e( 'Default Sharing Thumbnail', 'council-debt-counters' ); ?></th>
+                <td>
+                    <?php $thumb = absint( get_option( 'cdc_default_sharing_thumbnail', 0 ) ); ?>
+                    <div id="cdc-default-thumbnail-preview">
+                        <?php if ( $thumb ) : ?>
+                            <?php echo wp_get_attachment_image( $thumb, array( 150, 150 ) ); ?>
+                        <?php endif; ?>
+                    </div>
+                    <input type="hidden" id="cdc-default-thumbnail" name="cdc_default_sharing_thumbnail" value="<?php echo esc_attr( $thumb ); ?>" data-url="<?php echo esc_url( $thumb ? wp_get_attachment_url( $thumb ) : '' ); ?>" />
+                    <button type="button" class="button" id="cdc-default-thumbnail-button"><?php esc_html_e( 'Select Image', 'council-debt-counters' ); ?></button>
+                    <button type="button" class="button" id="cdc-default-thumbnail-remove" <?php if ( ! $thumb ) echo 'style="display:none"'; ?>><?php esc_html_e( 'Remove', 'council-debt-counters' ); ?></button>
+                </td>
+            </tr>
         </table>
         <?php submit_button(); ?>
     </form>

--- a/council-debt-counters.php
+++ b/council-debt-counters.php
@@ -36,6 +36,7 @@ require_once plugin_dir_path( __FILE__ ) . 'includes/class-admin-dashboard-widge
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-shortcode-playground.php';
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-council-search.php';
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-stats-page.php';
+require_once plugin_dir_path( __FILE__ ) . 'includes/class-sharing-meta.php';
 
 register_activation_hook( __FILE__, function() {
     \CouncilDebtCounters\Custom_Fields::install();
@@ -68,6 +69,7 @@ add_action( 'plugins_loaded', function() {
     \CouncilDebtCounters\Shortcode_Playground::init();
     \CouncilDebtCounters\Council_Search::init();
     \CouncilDebtCounters\Stats_Page::init();
+    \CouncilDebtCounters\Sharing_Meta::init();
 } );
 
 /**

--- a/includes/class-council-admin-page.php
+++ b/includes/class-council-admin-page.php
@@ -56,6 +56,18 @@ class Council_Admin_Page {
         wp_enqueue_style( 'cdc-counter-font', $font_url, [], null );
         wp_add_inline_style( 'cdc-counter-font', ".cdc-counter{font-family:'{$font}',sans-serif;font-weight:{$weight};}" );
         wp_enqueue_script( 'cdc-counter-animations' );
+        wp_enqueue_media();
+        wp_enqueue_script(
+            'cdc-media-select',
+            plugins_url( 'admin/js/media-select.js', dirname( __DIR__ ) . '/council-debt-counters.php' ),
+            [],
+            '0.1.0',
+            true
+        );
+        wp_localize_script( 'cdc-media-select', 'CDC_MEDIA_SELECT', [
+            'title'  => __( 'Select Image', 'council-debt-counters' ),
+            'button' => __( 'Use this image', 'council-debt-counters' ),
+        ] );
         wp_enqueue_script(
             'cdc-council-form',
             plugins_url( 'admin/js/council-form.js', dirname( __DIR__ ) . '/council-debt-counters.php' ),
@@ -145,6 +157,15 @@ class Council_Admin_Page {
 
         if ( isset( $_POST['assigned_user'] ) ) {
             update_post_meta( $post_id, 'assigned_user', intval( $_POST['assigned_user'] ) );
+        }
+
+        if ( isset( $_POST['cdc_sharing_image'] ) ) {
+            $img = absint( $_POST['cdc_sharing_image'] );
+            if ( $img ) {
+                update_post_meta( $post_id, 'cdc_sharing_image', $img );
+            } else {
+                delete_post_meta( $post_id, 'cdc_sharing_image' );
+            }
         }
 
         // Document edits or deletions from the Documents tab

--- a/includes/class-settings-page.php
+++ b/includes/class-settings-page.php
@@ -117,41 +117,69 @@ class Settings_Page {
 				'sanitize_callback' => array( __CLASS__, 'sanitize_font' ),
 			)
 		);
-		register_setting(
-			'cdc_settings',
-			'cdc_counter_weight',
-			array(
-				'type'              => 'string',
-				'default'           => '600',
-				'sanitize_callback' => array( __CLASS__, 'sanitize_weight' ),
-			)
-		);
-	}
+                register_setting(
+                        'cdc_settings',
+                        'cdc_counter_weight',
+                        array(
+                                'type'              => 'string',
+                                'default'           => '600',
+                                'sanitize_callback' => array( __CLASS__, 'sanitize_weight' ),
+                        )
+                );
+                register_setting(
+                        'cdc_settings',
+                        'cdc_default_sharing_thumbnail',
+                        array(
+                                'type'              => 'integer',
+                                'default'           => 0,
+                                'sanitize_callback' => 'absint',
+                        )
+                );
+        }
 
-	public static function enqueue_assets( $hook ) {
-		if ( 'debt-counters_page_cdc-import-export' !== $hook ) {
-			return;
-		}
-		$plugin_file = dirname( __DIR__ ) . '/council-debt-counters.php';
-		wp_enqueue_script(
-			'cdc-import-csv',
-			plugins_url( 'admin/js/import-csv.js', $plugin_file ),
-			array(),
-			'0.1.0',
-			true
-		);
-		wp_enqueue_style( 'cdc-import-progress', plugins_url( 'admin/css/import-progress.css', $plugin_file ), array(), '0.1.0' );
-		wp_localize_script(
-			'cdc-import-csv',
-			'cdcImport',
-			array(
-				'ajaxUrl'  => admin_url( 'admin-ajax.php' ),
-				'nonce'    => wp_create_nonce( 'cdc_import_csv_row' ),
-				'progress' => __( 'Imported %1 of %2 rows…', 'council-debt-counters' ),
-				'done'     => __( 'Import complete', 'council-debt-counters' ),
-			)
-		);
-	}
+        public static function enqueue_assets( $hook ) {
+                $plugin_file = dirname( __DIR__ ) . '/council-debt-counters.php';
+
+                if ( 'debt-counters_page_cdc-import-export' === $hook ) {
+                        wp_enqueue_script(
+                                'cdc-import-csv',
+                                plugins_url( 'admin/js/import-csv.js', $plugin_file ),
+                                array(),
+                                '0.1.0',
+                                true
+                        );
+                        wp_enqueue_style( 'cdc-import-progress', plugins_url( 'admin/css/import-progress.css', $plugin_file ), array(), '0.1.0' );
+                        wp_localize_script(
+                                'cdc-import-csv',
+                                'cdcImport',
+                                array(
+                                        'ajaxUrl'  => admin_url( 'admin-ajax.php' ),
+                                        'nonce'    => wp_create_nonce( 'cdc_import_csv_row' ),
+                                        'progress' => __( 'Imported %1 of %2 rows…', 'council-debt-counters' ),
+                                        'done'     => __( 'Import complete', 'council-debt-counters' ),
+                                )
+                        );
+                }
+
+                if ( 'debt-counters_page_cdc-settings' === $hook ) {
+                        wp_enqueue_media();
+                        wp_enqueue_script(
+                                'cdc-media-select',
+                                plugins_url( 'admin/js/media-select.js', $plugin_file ),
+                                array(),
+                                '0.1.0',
+                                true
+                        );
+                        wp_localize_script(
+                                'cdc-media-select',
+                                'CDC_MEDIA_SELECT',
+                                array(
+                                        'title'  => __( 'Select Image', 'council-debt-counters' ),
+                                        'button' => __( 'Use this image', 'council-debt-counters' ),
+                                )
+                        );
+                }
+        }
 
 	public static function sanitize_log_level( $value ) {
 		$value = sanitize_key( $value );

--- a/includes/class-sharing-meta.php
+++ b/includes/class-sharing-meta.php
@@ -1,0 +1,30 @@
+<?php
+namespace CouncilDebtCounters;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class Sharing_Meta {
+    public static function init() {
+        add_action( 'wp_head', [ __CLASS__, 'output_meta' ] );
+    }
+
+    public static function output_meta() {
+        if ( ! is_singular( 'council' ) ) {
+            return;
+        }
+        $post_id = get_the_ID();
+        $img_id  = absint( get_post_meta( $post_id, 'cdc_sharing_image', true ) );
+        if ( ! $img_id ) {
+            $img_id = absint( get_option( 'cdc_default_sharing_thumbnail', 0 ) );
+        }
+        if ( $img_id ) {
+            $url = wp_get_attachment_url( $img_id );
+            if ( $url ) {
+                printf( "<meta property=\"og:image\" content=\"%s\" />\n", esc_url( $url ) );
+                printf( "<meta name=\"twitter:image\" content=\"%s\" />\n", esc_url( $url ) );
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- allow selecting a default sharing image in Settings
- support per-council sharing image overrides
- expose selected image via Open Graph and Twitter meta tags
- add media selector JS helper
- document sharing thumbnail feature

## Testing
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_68572258b6e88331bd7226b8420a086a