### PR TITLE
Rename leaderboard ratio type

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Display ranked tables or lists of councils with `[cdc_leaderboard]`. Example:
 ```
 
 Available `type` options include `highest_debt`, `debt_per_resident`,
-`debt_to_reserves_ratio`, `biggest_deficit`, `lowest_reserves`,
+`reserves_to_debt_ratio`, `biggest_deficit`, `lowest_reserves`,
 `highest_spending_per_resident` and `highest_interest_paid`. The `limit`
 parameter controls how many rows are shown, `format` can be `table` or `list`,
 and setting `link="1"` adds a View details link for each council.

--- a/includes/class-shortcode-renderer.php
+++ b/includes/class-shortcode-renderer.php
@@ -613,9 +613,9 @@ endforeach;
                                 case 'debt_per_resident':
                                         $value = ( $population > 0 ) ? $debt / $population : null;
                                         break;
-                                case 'debt_to_reserves_ratio':
-                                        $value = ( $reserves > 0 ) ? $debt / $reserves : null;
-                                        break;
+                               case 'reserves_to_debt_ratio':
+                                       $value = ( $debt > 0 ) ? $reserves / $debt : null;
+                                       break;
                                 case 'biggest_deficit':
                                         $value = $deficit !== 0 ? $deficit : ( $spending - $income );
                                         break;
@@ -643,10 +643,10 @@ endforeach;
                         );
                 }
 
-                $desc = true;
-                if ( 'lowest_reserves' === $type ) {
-                        $desc = false;
-                }
+               $desc = true;
+               if ( in_array( $type, array( 'lowest_reserves', 'reserves_to_debt_ratio' ), true ) ) {
+                       $desc = false;
+               }
 
                 usort(
                         $rows,
@@ -671,7 +671,7 @@ endforeach;
                 if ( 'list' === $format ) {
                         echo '<ul class="list-group">';
                         foreach ( $rows as $row ) {
-                                $label = ( in_array( $type, array( 'debt_to_reserves_ratio' ), true ) ) ? number_format_i18n( $row['value'], 2 ) . '%' : '£' . number_format_i18n( $row['value'], 2 );
+                               $label = ( in_array( $type, array( 'reserves_to_debt_ratio' ), true ) ) ? number_format_i18n( $row['value'], 2 ) . '%' : '£' . number_format_i18n( $row['value'], 2 );
                                 echo '<li class="list-group-item d-flex justify-content-between align-items-center">';
                                 echo esc_html( $row['name'] );
                                 echo '<span class="badge bg-secondary">' . esc_html( $label ) . '</span>';
@@ -689,7 +689,7 @@ endforeach;
                         }
                         echo '</tr></thead><tbody>';
                         foreach ( $rows as $row ) {
-                                $label = ( in_array( $type, array( 'debt_to_reserves_ratio' ), true ) ) ? number_format_i18n( $row['value'], 2 ) . '%' : '£' . number_format_i18n( $row['value'], 2 );
+                               $label = ( in_array( $type, array( 'reserves_to_debt_ratio' ), true ) ) ? number_format_i18n( $row['value'], 2 ) . '%' : '£' . number_format_i18n( $row['value'], 2 );
                                 echo '<tr><td>' . esc_html( $row['name'] ) . '</td><td>' . esc_html( $label ) . '</td>';
                                 if ( $with_link ) {
                                         echo '<td><a href="' . esc_url( get_permalink( $row['id'] ) ) . '">' . esc_html__( 'View details', 'council-debt-counters' ) . '</a></td>';


### PR DESCRIPTION
## Summary
- update leaderboard type `reserves_to_debt_ratio`
- show councils with the lowest ratio first

## Testing
- `vendor/bin/phpunit`
- `vendor/bin/phpcs -q` *(fails: numerous existing style violations)*

------
https://chatgpt.com/codex/tasks/task_e_685728fb0e7883318a0d4cf0ac2df5b0