### PR TITLE
Council Management Screens UI and UX Improvements

### DIFF
--- a/admin/views/councils-page.php
+++ b/admin/views/councils-page.php
@@ -336,16 +336,13 @@ if ( 'edit' === $req_action ) {
 $status_param   = isset( $_GET['status'] ) ? sanitize_key( $_GET['status'] ) : 'publish';
 $valid_statuses = array( 'publish', 'draft', 'under_review' );
 if ( ! in_array( $status_param, $valid_statuses, true ) ) {
-		$status_param = 'publish';
+    $status_param = 'publish';
 }
-$councils = get_posts(
-	array(
-		'post_type'   => 'council',
-		'numberposts' => -1,
-		'post_status' => $status_param,
-	)
-);
-$counts   = wp_count_posts( 'council' );
+
+$table  = new \CouncilDebtCounters\Councils_Table( $status_param );
+$table->process_bulk_action();
+$table->prepare_items();
+$counts = wp_count_posts( 'council' );
 ?>
 <div class="wrap">
 	<h1><?php esc_html_e( 'Councils', 'council-debt-counters' ); ?></h1>
@@ -367,38 +364,10 @@ $counts   = wp_count_posts( 'council' );
 			</li>
 				<?php endforeach; ?>
 	</ul>
-	<table class="table table-striped">
-		<thead>
-			<tr>
-				<th><?php esc_html_e( 'Name', 'council-debt-counters' ); ?></th>
-				<th><?php esc_html_e( 'Debt Counter', 'council-debt-counters' ); ?></th>
-				<th><?php esc_html_e( 'Status', 'council-debt-counters' ); ?></th>
-				<th><?php esc_html_e( 'Actions', 'council-debt-counters' ); ?></th>
-			</tr>
-		</thead>
-		<tbody>
-			<?php if ( empty( $councils ) ) : ?>
-				<tr><td colspan="4"><?php esc_html_e( 'No councils found.', 'council-debt-counters' ); ?></td></tr>
-				<?php
-			else :
-				foreach ( $councils as $council ) :
-					?>
-				<tr>
-					<td><?php echo esc_html( get_the_title( $council ) ); ?></td>
-					<td>
-										<?php echo do_shortcode( '[council_counter id="' . $council->ID . '"]' ); ?>
-						<code>[council_counter id="<?php echo esc_attr( $council->ID ); ?>"]</code>
-					</td>
-					<td><?php echo esc_html( ucwords( str_replace( '_', ' ', $council->post_status ) ) ); ?></td>
-					<td>
-						<a href="<?php echo esc_url( admin_url( 'admin.php?page=cdc-manage-councils&action=edit&post=' . $council->ID ) ); ?>" class="btn btn-sm btn-secondary"><?php esc_html_e( 'Edit', 'council-debt-counters' ); ?></a>
-						<a href="<?php echo esc_url( wp_nonce_url( admin_url( 'admin.php?page=cdc-manage-councils&action=delete&post=' . $council->ID ), 'cdc_delete_council_' . $council->ID ) ); ?>" class="btn btn-sm btn-danger" onclick="return confirm('<?php esc_attr_e( 'Delete this council?', 'council-debt-counters' ); ?>');"><?php esc_html_e( 'Delete', 'council-debt-counters' ); ?></a>
-					</td>
-				</tr>
-							<?php
-			endforeach;
-endif;
-			?>
-		</tbody>
-	</table>
+        <form method="post">
+            <?php
+            settings_errors( 'cdc_messages' );
+            $table->display();
+            ?>
+        </form>
 </div>

--- a/council-debt-counters.php
+++ b/council-debt-counters.php
@@ -25,6 +25,7 @@ require_once plugin_dir_path( __FILE__ ) . 'includes/class-error-logger.php';
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-docs-manager.php';
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-license-manager.php';
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-council-post-type.php';
+require_once plugin_dir_path( __FILE__ ) . 'includes/class-councils-table.php';
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-council-admin-page.php';
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-custom-fields.php';
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-openai-helper.php';

--- a/includes/class-councils-table.php
+++ b/includes/class-councils-table.php
@@ -1,0 +1,117 @@
+<?php
+namespace CouncilDebtCounters;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+if ( ! class_exists( '\WP_List_Table' ) ) {
+    require_once ABSPATH . 'wp-admin/includes/class-wp-list-table.php';
+}
+
+class Councils_Table extends \WP_List_Table {
+    private $status;
+
+    public function __construct( string $status = 'publish' ) {
+        $this->status = $status;
+        parent::__construct(
+            [
+                'singular' => 'council',
+                'plural'   => 'councils',
+                'ajax'     => false,
+            ]
+        );
+    }
+
+    public function get_columns() {
+        return [
+            'cb'        => '<input type="checkbox" />',
+            'name'      => __( 'Name', 'council-debt-counters' ),
+            'shortcode' => __( 'Shortcode', 'council-debt-counters' ),
+            'status'    => __( 'Status', 'council-debt-counters' ),
+        ];
+    }
+
+    protected function get_sortable_columns() {
+        return [
+            'name'   => [ 'title', false ],
+            'status' => [ 'post_status', false ],
+        ];
+    }
+
+    protected function column_cb( $item ) {
+        return sprintf( '<input type="checkbox" name="council[]" value="%d" />', intval( $item->ID ) );
+    }
+
+    protected function column_name( $item ) {
+        $edit = admin_url( 'admin.php?page=' . Council_Admin_Page::PAGE_SLUG . '&action=edit&post=' . $item->ID );
+        $actions = [
+            'edit'   => sprintf( '<a href="%s">%s</a>', esc_url( $edit ), __( 'Edit', 'council-debt-counters' ) ),
+        ];
+        $del = wp_nonce_url( admin_url( 'admin.php?page=' . Council_Admin_Page::PAGE_SLUG . '&action=delete&post=' . $item->ID ), 'cdc_delete_council_' . $item->ID );
+        $actions['delete'] = sprintf( '<a href="%s" onclick="return confirm(\'%s\');">%s</a>', esc_url( $del ), esc_js( __( 'Delete this council?', 'council-debt-counters' ) ), __( 'Delete', 'council-debt-counters' ) );
+
+        return sprintf( '<strong><a class="row-title" href="%s">%s</a></strong>%s', esc_url( $edit ), esc_html( get_the_title( $item ) ), $this->row_actions( $actions ) );
+    }
+
+    protected function column_shortcode( $item ) {
+        $code = sprintf( '[council_counter id="%d"]', $item->ID );
+        $live = do_shortcode( $code );
+        return $live . '<code>' . esc_html( $code ) . '</code>';
+    }
+
+    protected function column_status( $item ) {
+        return esc_html( ucwords( str_replace( '_', ' ', $item->post_status ) ) );
+    }
+
+    public function get_bulk_actions() {
+        return [
+            'repair' => __( 'Repair', 'council-debt-counters' ),
+        ];
+    }
+
+    public function process_bulk_action() {
+        if ( 'repair' === $this->current_action() && ! empty( $_POST['council'] ) ) {
+            $ids = array_map( 'intval', (array) $_POST['council'] );
+            foreach ( $ids as $id ) {
+                $title = get_the_title( $id );
+                $meta  = Custom_Fields::get_value( $id, 'council_name' );
+                if ( empty( $title ) && ! empty( $meta ) ) {
+                    wp_update_post( [ 'ID' => $id, 'post_title' => $meta ] );
+                } elseif ( empty( $meta ) && ! empty( $title ) ) {
+                    Custom_Fields::update_value( $id, 'council_name', $title );
+                }
+            }
+            add_settings_error( 'cdc_messages', 'cdc_repair', __( 'Repair completed.', 'council-debt-counters' ), 'updated' );
+        }
+    }
+
+    public function prepare_items() {
+        $per_page = 20;
+        $paged    = $this->get_pagenum();
+
+        $orderby = sanitize_key( $_REQUEST['orderby'] ?? 'title' );
+        $order   = sanitize_key( $_REQUEST['order'] ?? 'asc' );
+        $allowed = [ 'title', 'post_status' ];
+        if ( ! in_array( $orderby, $allowed, true ) ) {
+            $orderby = 'title';
+        }
+        $order = 'desc' === strtolower( $order ) ? 'desc' : 'asc';
+
+        $query = new \WP_Query( [
+            'post_type'      => 'council',
+            'post_status'    => $this->status,
+            'posts_per_page' => $per_page,
+            'paged'          => $paged,
+            'orderby'        => $orderby,
+            'order'          => $order,
+        ] );
+
+        $this->items = $query->posts;
+
+        $this->set_pagination_args( [
+            'total_items' => $query->found_posts,
+            'per_page'    => $per_page,
+        ] );
+    }
+}


### PR DESCRIPTION
## Summary
- add Councils_Table class using WP_List_Table
- include the new table class in plugin bootstrap
- replace manual table on Manage Councils screen with WP_List_Table integration
- allow sorting and bulk "Repair" action to restore missing council names

## Testing
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6857f83e76b483318ec44e7d01b1bcb0