### PR TITLE
Fix Manage Councils screen not loading

### DIFF
--- a/includes/class-council-admin-page.php
+++ b/includes/class-council-admin-page.php
@@ -225,6 +225,6 @@ class Council_Admin_Page {
     }
 
     public static function render_page() {
-        include plugin_dir_path( __DIR__ ) . 'admin/views/councils-page.php';
+        include dirname( __DIR__ ) . '/admin/views/councils-page.php';
     }
 }


### PR DESCRIPTION
## Summary
- correct the include path to the councils page view

## Testing
- `composer install`
- `./vendor/bin/phpunit`
- `vendor/bin/phpcs --standard=phpcs.xml.dist -q` *(fails: coding standard violations)*

------
https://chatgpt.com/codex/tasks/task_e_6857fcefa3f883318014139d6c1adf00