### PR TITLE
Fix councils table headers

### DIFF
--- a/includes/class-councils-table.php
+++ b/includes/class-councils-table.php
@@ -120,6 +120,12 @@ class Councils_Table extends \WP_List_Table {
 
         $this->items = $query->posts;
 
+        // Set up the column headers so the table renders correctly.
+        $columns  = $this->get_columns();
+        $hidden   = [];
+        $sortable = $this->get_sortable_columns();
+        $this->_column_headers = [ $columns, $hidden, $sortable ];
+
         $this->set_pagination_args( [
             'total_items' => $query->found_posts,
             'per_page'    => $per_page,


### PR DESCRIPTION
## Summary
- ensure WP_List_Table has column headers by setting `_column_headers`

## Testing
- `./vendor/bin/phpunit --configuration phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_68580d5683708331be335541d817371f