### PR TITLE
Remove licence-based limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This WordPress plugin provides animated counters to display UK council debt figures. Counters can be embedded using a shortcode and configured through the WordPress admin interface.
 
-The plugin registers a custom **Council** post type where you can store detailed information about each local authority. The post type is hidden from the regular WordPress menu so users cannot manually add councils from the Posts screen. Councils are managed from the plugin's own **Debt Counters → Councils** submenu. The free version allows up to **two councils**; enter a valid license key on the settings page to create more.
+The plugin registers a custom **Council** post type where you can store detailed information about each local authority. The post type is hidden from the regular WordPress menu so users cannot manually add councils from the Posts screen. Councils are managed from the plugin's own **Debt Counters → Councils** submenu. You can optionally enter a licence key on the settings page, though all features are currently free.
 
 Version 0.2 replaces the dependency on Advanced Custom Fields with a built‑in custom field system. You can create your own fields (text, number or monetary) from **Debt Counters → Custom Fields** and capture the values for each council. Monetary fields display a £ symbol and store values to two decimal places.
 
@@ -68,7 +68,7 @@ Use `[council_status]` to display any status message you have recorded for a cou
 ## Installation
 1. Copy the plugin folder to your `wp-content/plugins` directory.
 2. Activate **Council Debt Counters** in the WordPress admin.
-3. Visit **Debt Counters** in the admin menu to enter your license key and start adding councils.
+3. Visit **Debt Counters** in the admin menu to configure settings or enter a licence key if you have one, then start adding councils.
 
 ## Asset loading and CDNs
 

--- a/admin/views/docs-manager-page.php
+++ b/admin/views/docs-manager-page.php
@@ -42,9 +42,7 @@ if ( isset( $_FILES['cdc_upload_doc'] ) && $_FILES['cdc_upload_doc']['size'] > 0
 <div class="wrap">
     <h1><?php esc_html_e( 'Manage Documents', 'council-debt-counters' ); ?></h1>
     <p><?php esc_html_e( 'Upload, replace, or delete financial documents. Only XLSX, CSV, and PDF files are allowed for security reasons.', 'council-debt-counters' ); ?></p>
-    <p><?php echo $is_pro
-        ? esc_html__( 'You have unlimited document uploads (Pro version).', 'council-debt-counters' )
-        : esc_html__( 'Free version: Maximum 10 documents allowed.', 'council-debt-counters' ); ?></p>
+    <p><?php esc_html_e( 'Document uploads are unlimited.', 'council-debt-counters' ); ?></p>
     <?php if ( $upload_error ) : ?>
         <div class="notice notice-error"><p><?php echo esc_html( $upload_error ); ?></p></div>
     <?php endif; ?>
@@ -57,7 +55,7 @@ if ( isset( $_FILES['cdc_upload_doc'] ) && $_FILES['cdc_upload_doc']['size'] > 0
         </select>
         <button type="submit" class="button button-primary" <?php if ( ! $can_upload ) echo 'disabled'; ?>><?php esc_html_e( 'Upload', 'council-debt-counters' ); ?></button>
         <?php if ( ! $can_upload ) : ?>
-            <p class="description" style="color:red;"><?php esc_html_e( 'Free version limit reached. Delete a document or upgrade to Pro.', 'council-debt-counters' ); ?></p>
+            <p class="description" style="color:red;"><?php esc_html_e( 'Upload limit reached.', 'council-debt-counters' ); ?></p>
         <?php endif; ?>
     </form>
     <h2><?php esc_html_e( 'Uploaded Documents', 'council-debt-counters' ); ?></h2>

--- a/admin/views/instructions-page.php
+++ b/admin/views/instructions-page.php
@@ -16,7 +16,5 @@ if ( ! defined( 'ABSPATH' ) ) exit;
     </div>
 </div>
 <?php
-if ( isset( $_GET['cdc_limit'] ) ) {
-    echo '<div class="notice notice-warning"><p>' . esc_html__( 'The free version is limited to two councils. Enter a license key to add more.', 'council-debt-counters' ) . '</p></div>';
-}
+// Limit notices are currently disabled while the plugin is free to use.
 ?>

--- a/includes/class-docs-manager.php
+++ b/includes/class-docs-manager.php
@@ -107,8 +107,8 @@ class Docs_Manager {
             return __( 'Invalid file type. Only XLSX, CSV, and PDF are allowed.', 'council-debt-counters' );
         }
         if ( ! self::can_upload() ) {
-            Error_Logger::log( 'Document upload blocked - free limit reached' );
-            return __( 'Free version limit reached. Upgrade to Pro for unlimited documents.', 'council-debt-counters' );
+            Error_Logger::log( 'Document upload blocked - limit reached' );
+            return __( 'Upload limit reached.', 'council-debt-counters' );
         }
         $filename = basename( $file['name'] );
         $target   = self::get_docs_path() . $filename;
@@ -153,8 +153,8 @@ class Docs_Manager {
         }
 
         if ( ! self::can_upload() ) {
-            Error_Logger::log( 'Document import blocked - free limit reached' );
-            return __( 'Free version limit reached. Upgrade to Pro for unlimited documents.', 'council-debt-counters' );
+            Error_Logger::log( 'Document import blocked - limit reached' );
+            return __( 'Upload limit reached.', 'council-debt-counters' );
         }
 
         if ( ! function_exists( 'download_url' ) ) {

--- a/includes/class-license-manager.php
+++ b/includes/class-license-manager.php
@@ -23,14 +23,9 @@ class License_Manager {
      * This is a placeholder for real validation logic.
      */
     public static function is_valid() {
-        $flag = get_option( self::OPTION_VALID );
-        $valid = (bool) $flag;
-        if ( ! $valid ) {
-            $key = self::get_license_key();
-            $prefix = $key ? substr( $key, 0, 8 ) . '…' : 'none';
-            Error_Logger::log_info( 'License invalid - key prefix: ' . $prefix . ' flag: ' . $flag );
-        }
-        return $valid;
+        // All features are currently free, so licences are treated as valid.
+        // This logic is retained for potential future use.
+        return true;
     }
 
     /**


### PR DESCRIPTION
## Summary
- drop restriction checks in `License_Manager::is_valid`
- clarify docs manager text that uploads are unlimited
- hide outdated limit notice on the instructions page
- update README to remove mention of free version limits

## Testing
- `composer install`
- `vendor/bin/phpunit --configuration phpunit.xml`
- `vendor/bin/phpcs -q` *(fails: various coding standard errors)*

------
https://chatgpt.com/codex/tasks/task_e_68581013f7488331b577b1925d02c54a