### PR TITLE
Update debt helper position

### DIFF
--- a/admin/js/council-form.js
+++ b/admin/js/council-form.js
@@ -125,12 +125,7 @@
         var adjustmentsField = document.querySelector('[data-cdc-field="debt_adjustments"]');
         var interestField = document.querySelector('[data-cdc-field="interest_paid_on_debt"]');
         var totalField = document.querySelector('[data-cdc-field="total_debt"]');
-        var ratesOutput = document.createElement('div');
-        ratesOutput.id = 'cdc-debt-rates';
-        ratesOutput.className = 'mt-2 alert alert-info';
-        if (shortField) {
-            shortField.parentElement.appendChild(ratesOutput);
-        }
+        var ratesOutput = document.getElementById('cdc-debt-rates');
 
         var growthPerSecond = 0;
 

--- a/admin/views/councils-page.php
+++ b/admin/views/councils-page.php
@@ -199,10 +199,13 @@ if ( 'edit' === $req_action ) {
 			foreach ( $enabled as $tab_key ) :
 				if ( empty( $groups[ $tab_key ] ) ) {
 								continue;}
-				?>
-						<div class="tab-pane fade" id="tab-<?php echo esc_attr( $tab_key ); ?>" role="tabpanel">
-								<p class="description"><code>[council_counter id="<?php echo esc_attr( $council_id ); ?>" type="<?php echo esc_attr( $tab_key ); ?>"]</code></p>
-								<table class="form-table" role="presentation">
+                               ?>
+                                               <div class="tab-pane fade" id="tab-<?php echo esc_attr( $tab_key ); ?>" role="tabpanel">
+                                                               <p class="description"><code>[council_counter id="<?php echo esc_attr( $council_id ); ?>" type="<?php echo esc_attr( $tab_key ); ?>"]</code></p>
+                                                               <?php if ( 'debt' === $tab_key ) : ?>
+                                                                       <div id="cdc-debt-rates" class="alert alert-info mb-2"></div>
+                                                               <?php endif; ?>
+                                                               <table class="form-table" role="presentation">
 								<?php
 								foreach ( $groups[ $tab_key ] as $field ) :
 										$val         = $council_id ? \CouncilDebtCounters\Custom_Fields::get_value( $council_id, $field->name ) : '';


### PR DESCRIPTION
## Summary
- move `#cdc-debt-rates` helper markup to the top of the Debt tab
- update JS to use the pre-rendered helper element instead of inserting one

## Testing
- `vendor/bin/phpunit`
- `vendor/bin/phpcs -q --report=summary`

------
https://chatgpt.com/codex/tasks/task_e_685810bc83208331b0f37bdded61f8d4