### PR TITLE
Add draft/audited statement types

### DIFF
--- a/admin/js/council-form.js
+++ b/admin/js/council-form.js
@@ -60,6 +60,7 @@
                 var url=form.querySelector('input[name="statement_of_accounts_url"]');
                 var year=document.getElementById('cdc-soa-year');
                 var existing=form.querySelector('select[name="statement_of_accounts_existing"]');
+                var typeSel=form.querySelector('select[name="statement_of_accounts_type"]');
                 var d=new FormData();
                 d.append('action','cdc_upload_doc');
                 d.append('nonce', cdcToolbarData.nonce);
@@ -68,6 +69,7 @@
                 if(file && file.files.length){ d.append('file', file.files[0]); }
                 if(url && url.value){ d.append('url', url.value); }
                 if(existing && existing.value){ d.append('existing', existing.value); }
+                if(typeSel){ d.append('doc_type', typeSel.value); }
                 fetch(ajaxurl,{method:'POST',credentials:'same-origin',body:d})
                     .then(function(r){return r.json();})
                     .then(function(res){

--- a/admin/views/councils-page.php
+++ b/admin/views/councils-page.php
@@ -97,8 +97,8 @@ if ( 'edit' === $req_action ) {
 				?>
 								<li class="nav-item"><button class="nav-link" data-bs-toggle="tab" data-bs-target="#tab-<?php echo esc_attr( $tab_key ); ?>" type="button" role="tab"><?php echo esc_html( ucfirst( $tab_key ) ); ?></button></li>
 						<?php endforeach; ?>
-			<?php if ( $docs_field ) : ?>
-				<li class="nav-item"><button class="nav-link" data-bs-toggle="tab" data-bs-target="#tab-docs" type="button" role="tab"><?php esc_html_e( 'Documents', 'council-debt-counters' ); ?></button></li>
+                        <?php if ( $docs_field ) : ?>
+                                <li class="nav-item"><button class="nav-link" data-bs-toggle="tab" data-bs-target="#tab-docs" type="button" role="tab"><?php esc_html_e( 'Statement of Accounts', 'council-debt-counters' ); ?></button></li>
 			<?php endif; ?>
 						<?php if ( $council_id ) : ?>
 				<!-- Whistleblower reports moved to dedicated admin page -->
@@ -259,28 +259,39 @@ if ( 'edit' === $req_action ) {
 						<th scope="row"><label for="cdc-soa"><?php echo esc_html( $docs_field->label ); ?></label></th>
 						<td>
 														<?php $val = $council_id ? \CouncilDebtCounters\Custom_Fields::get_value( $council_id, 'statement_of_accounts' ) : ''; ?>
-							<?php if ( $val ) : ?>
-								<p><a href="<?php echo esc_url( plugins_url( 'docs/' . $val, dirname( __DIR__, 2 ) . '/council-debt-counters.php' ) ); ?>" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'View current document', 'council-debt-counters' ); ?></a></p>
-							<?php endif; ?>
-							<input type="file" id="cdc-soa" name="statement_of_accounts_file" accept="application/pdf">
-							<p class="description"><?php esc_html_e( 'or import from URL', 'council-debt-counters' ); ?></p>
+                                                        <?php if ( $val ) : ?>
+                                                                <p><a href="<?php echo esc_url( plugins_url( 'docs/' . $val, dirname( __DIR__, 2 ) . '/council-debt-counters.php' ) ); ?>" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'View selected statement', 'council-debt-counters' ); ?></a></p>
+                                                        <?php endif; ?>
+                                                        <input type="file" id="cdc-soa" name="statement_of_accounts_file" accept="application/pdf">
+                                                        <p class="description"><?php esc_html_e( 'or import from URL', 'council-debt-counters' ); ?></p>
                                                         <input type="url" name="statement_of_accounts_url" class="form-control" placeholder="https://example.com/file.pdf">
-							<p class="description mt-2">
-								<label for="cdc-soa-year" class="form-label"><?php esc_html_e( 'Financial Year', 'council-debt-counters' ); ?></label>
+                                                        <p class="description mt-2">
+                                                                <label for="cdc-soa-type" class="form-label"><?php esc_html_e( 'Statement Type', 'council-debt-counters' ); ?></label>
+                                                                <select id="cdc-soa-type" name="statement_of_accounts_type" class="form-select">
+                                                                        <option value="draft_statement_of_accounts"><?php esc_html_e( 'Draft', 'council-debt-counters' ); ?></option>
+                                                                        <option value="audited_statement_of_accounts"><?php esc_html_e( 'Audited', 'council-debt-counters' ); ?></option>
+                                                                </select>
+                                                        </p>
+                                                        <p class="description mt-2">
+                                                                <label for="cdc-soa-year" class="form-label"><?php esc_html_e( 'Financial Year', 'council-debt-counters' ); ?></label>
                                                                 <select id="cdc-soa-year" name="statement_of_accounts_year" class="form-select">
-									<?php foreach ( \CouncilDebtCounters\Docs_Manager::financial_years() as $y ) : ?>
-										<option value="<?php echo esc_attr( $y ); ?>" <?php selected( \CouncilDebtCounters\Docs_Manager::current_financial_year(), $y ); ?>><?php echo esc_html( $y ); ?></option>
-									<?php endforeach; ?>
-								</select>
-							</p>
+                                                                        <?php foreach ( \CouncilDebtCounters\Docs_Manager::financial_years() as $y ) : ?>
+                                                                                <option value="<?php echo esc_attr( $y ); ?>" <?php selected( \CouncilDebtCounters\Docs_Manager::current_financial_year(), $y ); ?>><?php echo esc_html( $y ); ?></option>
+                                                                        <?php endforeach; ?>
+                                                                </select>
+                                                        </p>
 							<?php $orphans = \CouncilDebtCounters\Docs_Manager::list_orphan_documents(); ?>
 							<?php if ( ! empty( $orphans ) ) : ?>
 								<p class="description mt-2"><?php esc_html_e( 'Or attach an existing document', 'council-debt-counters' ); ?></p>
                                                                 <select name="statement_of_accounts_existing">
-									<option value=""><?php esc_html_e( 'Select document', 'council-debt-counters' ); ?></option>
-									<?php foreach ( $orphans as $doc ) : ?>
-										<option value="<?php echo esc_attr( $doc->filename ); ?>"><?php echo esc_html( $doc->filename ); ?></option>
-									<?php endforeach; ?>
+                                                                        <option value=""><?php esc_html_e( 'Select document', 'council-debt-counters' ); ?></option>
+                                                                        <?php foreach ( $orphans as $doc ) : ?>
+                                                                                <option value="<?php echo esc_attr( $doc->filename ); ?>"><?php echo esc_html( $doc->filename ); ?></option>
+                                                                        <?php endforeach; ?>
+                                                                </select>
+                                                                <select name="statement_of_accounts_type" class="ms-2">
+                                                                        <option value="draft_statement_of_accounts"><?php esc_html_e( 'Draft', 'council-debt-counters' ); ?></option>
+                                                                        <option value="audited_statement_of_accounts"><?php esc_html_e( 'Audited', 'council-debt-counters' ); ?></option>
                                                                 </select>
                                                                 <button type="button" id="cdc-upload-doc" class="button button-secondary mt-2"><?php esc_html_e( 'Add Document', 'council-debt-counters' ); ?></button>
                                                         <?php endif; ?>
@@ -288,7 +299,7 @@ if ( 'edit' === $req_action ) {
                                         </tr>
                                 </table>
 				<?php if ( ! empty( $docs ) ) : ?>
-				<h2><?php esc_html_e( 'Existing Documents', 'council-debt-counters' ); ?></h2>
+                                <h2><?php esc_html_e( 'Uploaded Statements', 'council-debt-counters' ); ?></h2>
                                 <table id="cdc-docs-table" class="widefat">
 					<thead>
 						<tr>
@@ -310,9 +321,10 @@ if ( 'edit' === $req_action ) {
 								</select>
 							</td>
 							<td>
-								<select name="docs[<?php echo esc_attr( $d->id ); ?>][doc_type]">
-									<option value="statement_of_accounts" <?php selected( $d->doc_type, 'statement_of_accounts' ); ?>><?php esc_html_e( 'Statement of Accounts', 'council-debt-counters' ); ?></option>
-								</select>
+                                                                <select name="docs[<?php echo esc_attr( $d->id ); ?>][doc_type]">
+                                                                        <option value="draft_statement_of_accounts" <?php selected( $d->doc_type, 'draft_statement_of_accounts' ); ?>><?php esc_html_e( 'Draft', 'council-debt-counters' ); ?></option>
+                                                                        <option value="audited_statement_of_accounts" <?php selected( $d->doc_type, 'audited_statement_of_accounts' ); ?>><?php esc_html_e( 'Audited', 'council-debt-counters' ); ?></option>
+                                                                </select>
 							</td>
 							<td>
 								<button type="button" value="<?php echo esc_attr( $d->id ); ?>" class="button cdc-extract-ai"><span class="dashicons dashicons-lightbulb"></span> <?php esc_html_e( 'Extract Figures', 'council-debt-counters' ); ?></button>

--- a/admin/views/docs-manager-page.php
+++ b/admin/views/docs-manager-page.php
@@ -15,7 +15,7 @@ if ( isset( $_POST['cdc_assign_doc'], $_POST['cdc_doc_name'], $_POST['cdc_counci
     $type = sanitize_key( $_POST['cdc_doc_type'] );
     $year = sanitize_text_field( $_POST['cdc_doc_year'] );
     Docs_Manager::assign_document( $file, $council, $type, $year );
-    if ( $type === 'statement_of_accounts' ) {
+    if ( in_array( $type, [ 'draft_statement_of_accounts', 'audited_statement_of_accounts' ], true ) ) {
         \CouncilDebtCounters\Custom_Fields::update_value( $council, 'statement_of_accounts', $file );
     }
     echo '<div class="notice notice-success"><p>' . esc_html__( 'Document assigned.', 'council-debt-counters' ) . '</p></div>';
@@ -81,7 +81,7 @@ if ( isset( $_FILES['cdc_upload_doc'] ) && $_FILES['cdc_upload_doc']['size'] > 0
                         <?php echo $doc->council_id ? esc_html( get_the_title( $doc->council_id ) ) : esc_html__( 'Unassigned', 'council-debt-counters' ); ?>
                     </td>
                     <td><?php echo esc_html( $doc->financial_year ); ?></td>
-                    <td><?php echo esc_html( $doc->doc_type ); ?></td>
+                    <td><?php echo esc_html( Docs_Manager::doc_type_labels()[ $doc->doc_type ] ?? $doc->doc_type ); ?></td>
                     <td>
                         <form method="post" style="display:inline;">
                             <input type="hidden" name="cdc_doc_name" value="<?php echo esc_attr( $doc->filename ); ?>" />
@@ -99,7 +99,8 @@ if ( isset( $_FILES['cdc_upload_doc'] ) && $_FILES['cdc_upload_doc']['size'] > 0
                                     <?php endforeach; ?>
                                 </select>
                                 <select name="cdc_doc_type">
-                                    <option value="statement_of_accounts"><?php esc_html_e( 'Statement of Accounts', 'council-debt-counters' ); ?></option>
+                                    <option value="draft_statement_of_accounts"><?php esc_html_e( 'Draft Statement', 'council-debt-counters' ); ?></option>
+                                    <option value="audited_statement_of_accounts"><?php esc_html_e( 'Audited Statement', 'council-debt-counters' ); ?></option>
                                 </select>
                                 <select name="cdc_doc_year">
                                     <?php foreach ( Docs_Manager::financial_years() as $y ) : ?>

--- a/includes/class-council-admin-page.php
+++ b/includes/class-council-admin-page.php
@@ -137,21 +137,25 @@ class Council_Admin_Page {
 
         $soa_value = Custom_Fields::get_value( $post_id, 'statement_of_accounts' );
         $soa_year  = sanitize_text_field( $_POST['statement_of_accounts_year'] ?? Docs_Manager::current_financial_year() );
+        $soa_type  = sanitize_key( $_POST['statement_of_accounts_type'] ?? 'draft_statement_of_accounts' );
+        if ( ! in_array( $soa_type, Docs_Manager::DOC_TYPES, true ) ) {
+            $soa_type = 'draft_statement_of_accounts';
+        }
 
         if ( ! empty( $_FILES['statement_of_accounts_file']['name'] ) ) {
-            $result = Docs_Manager::upload_document( $_FILES['statement_of_accounts_file'], 'statement_of_accounts', $post_id, $soa_year );
+            $result = Docs_Manager::upload_document( $_FILES['statement_of_accounts_file'], $soa_type, $post_id, $soa_year );
             if ( $result === true ) {
                 $soa_value = sanitize_file_name( $_FILES['statement_of_accounts_file']['name'] );
             }
         } elseif ( ! empty( $_POST['statement_of_accounts_url'] ) ) {
             $url = esc_url_raw( $_POST['statement_of_accounts_url'] );
-            $result = Docs_Manager::import_from_url( $url, 'statement_of_accounts', $post_id, $soa_year );
+            $result = Docs_Manager::import_from_url( $url, $soa_type, $post_id, $soa_year );
             if ( $result === true ) {
                 $soa_value = sanitize_file_name( basename( parse_url( $url, PHP_URL_PATH ) ) );
             }
         } elseif ( ! empty( $_POST['statement_of_accounts_existing'] ) ) {
             $existing = sanitize_file_name( $_POST['statement_of_accounts_existing'] );
-            Docs_Manager::assign_document( $existing, $post_id, 'statement_of_accounts', $soa_year );
+            Docs_Manager::assign_document( $existing, $post_id, $soa_type, $soa_year );
             $soa_value = $existing;
         }
 


### PR DESCRIPTION
## Summary
- rename Documents tab to **Statement of Accounts**
- support `draft_statement_of_accounts` and `audited_statement_of_accounts`
- let admins pick the statement type when uploading
- show type labels in document tables
- keep Extract Figures button

## Testing
- `./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_68581227e4b483318b5937593a309d05