### PR TITLE
Fix AI figure acceptance bug

### DIFF
--- a/council-debt-counters.php
+++ b/council-debt-counters.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Council Debt Counters
  * Description: Animated counters visualising council debt figures.
- * Version: 0.2.5
+ * Version: 0.2.6
  * Author: Mike Rouse using OpenAI Codex
  * Author URI: https://www.mikerouse.co.uk
  * Text Domain: council-debt-counters

--- a/includes/class-docs-manager.php
+++ b/includes/class-docs-manager.php
@@ -334,6 +334,9 @@ class Docs_Manager {
         foreach ( $figures as $field => $value ) {
             Custom_Fields::update_value( $cid, sanitize_key( $field ), sanitize_text_field( $value ) );
         }
+        if ( method_exists( '\\CouncilDebtCounters\\Council_Post_Type', 'calculate_total_debt' ) ) {
+            Council_Post_Type::calculate_total_debt( $cid );
+        }
         $all = get_option( 'cdc_ai_suggestions', [] );
         unset( $all[ $cid ] );
         update_option( 'cdc_ai_suggestions', $all );


### PR DESCRIPTION
## Summary
- recalculate total debt when AI-suggested figures are saved
- bump plugin version to 0.2.6

## Testing
- `vendor/bin/phpunit`
- `vendor/bin/phpcs --standard=phpcs.xml.dist --runtime-set ignore_warnings_on_exit true --runtime-set ignore_errors_on_exit true`

------
https://chatgpt.com/codex/tasks/task_e_68581d679cf083318ed3af78ab2ac30b