### PR TITLE
Add figure submission system

### DIFF
--- a/council-debt-counters.php
+++ b/council-debt-counters.php
@@ -10,11 +10,11 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit; // Exit if accessed directly.
+	exit; // Exit if accessed directly.
 }
 
 if ( file_exists( __DIR__ . '/vendor/autoload.php' ) ) {
-    require_once __DIR__ . '/vendor/autoload.php';
+	require_once __DIR__ . '/vendor/autoload.php';
 }
 
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-settings-page.php';
@@ -33,59 +33,75 @@ require_once plugin_dir_path( __FILE__ ) . 'includes/class-ai-extractor.php';
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-debt-adjustments-page.php';
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-whistleblower-reports-page.php';
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-whistleblower-form.php';
+require_once plugin_dir_path( __FILE__ ) . 'includes/class-figure-submission-form.php';
+require_once plugin_dir_path( __FILE__ ) . 'includes/class-figure-submissions-page.php';
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-admin-dashboard-widget.php';
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-shortcode-playground.php';
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-council-search.php';
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-stats-page.php';
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-sharing-meta.php';
 
-register_activation_hook( __FILE__, function() {
-    \CouncilDebtCounters\Custom_Fields::install();
-    \CouncilDebtCounters\Docs_Manager::install();
-} );
+register_activation_hook(
+	__FILE__,
+	function () {
+		\CouncilDebtCounters\Custom_Fields::install();
+		\CouncilDebtCounters\Docs_Manager::install();
+	}
+);
 
 // Ensure custom error handling does not persist after deactivation.
-register_deactivation_hook( __FILE__, function() {
-    \CouncilDebtCounters\Error_Logger::cleanup();
-} );
+register_deactivation_hook(
+	__FILE__,
+	function () {
+		\CouncilDebtCounters\Error_Logger::cleanup();
+	}
+);
 
 
-add_action( 'plugins_loaded', function() {
-    // Initialise error logging; Error_Logger::cleanup() will restore
-    // the previous handlers on plugin deactivation.
-    \CouncilDebtCounters\Error_Logger::init();
-    \CouncilDebtCounters\Settings_Page::init();
-    \CouncilDebtCounters\Council_Post_Type::init();
-    \CouncilDebtCounters\Council_Admin_Page::init();
-    \CouncilDebtCounters\Custom_Fields::init();
-    \CouncilDebtCounters\Docs_Manager::init();
-    \CouncilDebtCounters\Shortcode_Renderer::init();
-    \CouncilDebtCounters\Debt_Adjustments_Page::init();
-    \CouncilDebtCounters\Data_Loader::init();
-    \CouncilDebtCounters\License_Manager::init();
-    \CouncilDebtCounters\OpenAI_Helper::init();
-    \CouncilDebtCounters\Whistleblower_Form::init();
-    \CouncilDebtCounters\Whistleblower_Reports_Page::init();
-    \CouncilDebtCounters\Admin_Dashboard_Widget::init();
-    \CouncilDebtCounters\Shortcode_Playground::init();
-    \CouncilDebtCounters\Council_Search::init();
-    \CouncilDebtCounters\Stats_Page::init();
-    \CouncilDebtCounters\Sharing_Meta::init();
-} );
+add_action(
+	'plugins_loaded',
+	function () {
+		// Initialise error logging; Error_Logger::cleanup() will restore
+		// the previous handlers on plugin deactivation.
+		\CouncilDebtCounters\Error_Logger::init();
+		\CouncilDebtCounters\Settings_Page::init();
+		\CouncilDebtCounters\Council_Post_Type::init();
+		\CouncilDebtCounters\Council_Admin_Page::init();
+		\CouncilDebtCounters\Custom_Fields::init();
+		\CouncilDebtCounters\Docs_Manager::init();
+		\CouncilDebtCounters\Shortcode_Renderer::init();
+		\CouncilDebtCounters\Debt_Adjustments_Page::init();
+		\CouncilDebtCounters\Data_Loader::init();
+		\CouncilDebtCounters\License_Manager::init();
+		\CouncilDebtCounters\OpenAI_Helper::init();
+		\CouncilDebtCounters\Whistleblower_Form::init();
+		\CouncilDebtCounters\Whistleblower_Reports_Page::init();
+		\CouncilDebtCounters\Admin_Dashboard_Widget::init();
+		\CouncilDebtCounters\Shortcode_Playground::init();
+		\CouncilDebtCounters\Council_Search::init();
+		\CouncilDebtCounters\Stats_Page::init();
+		\CouncilDebtCounters\Figure_Submission_Form::init();
+		\CouncilDebtCounters\Figure_Submissions_Page::init();
+		\CouncilDebtCounters\Sharing_Meta::init();
+	}
+);
 
 /**
  * Git Updater support
  * @link https://git-updater.com/knowledge-base/
  */
-add_filter( 'git_updater_plugin_config', function( $config ) {
-    $config['council-debt-counters/council-debt-counters.php'] = [
-        'slug'       => 'council-debt-counters',
-        'repo'       => 'council-debt-counters',
-        'owner'      => 'mikerouse', // Change to your GitHub username or org
-        'branch'     => 'main', // Or 'master' or your default branch
-        'uri'        => 'https://github.com/mikerouse/council-debt-counters',
-        'remote_url' => 'https://github.com/mikerouse/council-debt-counters.git',
-        'type'       => 'github',
-    ];
-    return $config;
-} );
+add_filter(
+	'git_updater_plugin_config',
+	function ( $config ) {
+		$config['council-debt-counters/council-debt-counters.php'] = array(
+			'slug'       => 'council-debt-counters',
+			'repo'       => 'council-debt-counters',
+			'owner'      => 'mikerouse', // Change to your GitHub username or org
+			'branch'     => 'main', // Or 'master' or your default branch
+			'uri'        => 'https://github.com/mikerouse/council-debt-counters',
+			'remote_url' => 'https://github.com/mikerouse/council-debt-counters.git',
+			'type'       => 'github',
+		);
+		return $config;
+	}
+);

--- a/includes/class-figure-submission-form.php
+++ b/includes/class-figure-submission-form.php
@@ -1,0 +1,223 @@
+<?php
+namespace CouncilDebtCounters;
+
+use CouncilDebtCounters\Error_Logger;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class Figure_Submission_Form {
+	const CPT = 'figure_submission';
+
+	public static function init() {
+		add_action( 'init', array( __CLASS__, 'register_cpt' ) );
+		add_action( 'init', array( __CLASS__, 'maybe_handle_submission' ) );
+		add_shortcode( 'council_data_form', array( __CLASS__, 'render_form' ) );
+	}
+
+	public static function register_cpt() {
+		register_post_type(
+			self::CPT,
+			array(
+				'labels'   => array(
+					'name'          => __( 'Figure Submissions', 'council-debt-counters' ),
+					'singular_name' => __( 'Figure Submission', 'council-debt-counters' ),
+				),
+				'public'   => false,
+				'show_ui'  => false,
+				'supports' => array( 'title', 'editor', 'custom-fields' ),
+			)
+		);
+	}
+
+	private static function get_council_id_from_atts( array $atts ): int {
+		$id = isset( $atts['id'] ) ? intval( $atts['id'] ) : 0;
+		if ( 0 === $id && isset( $atts['council_id'] ) ) {
+			$id = intval( $atts['council_id'] );
+		}
+		if ( 0 === $id && ! empty( $atts['council'] ) ) {
+			$post = get_page_by_title( sanitize_text_field( $atts['council'] ), OBJECT, 'council' );
+			if ( ! $post ) {
+				$post = get_page_by_path( sanitize_title( $atts['council'] ), OBJECT, 'council' );
+			}
+			if ( $post ) {
+				$id = $post->ID;
+			}
+		}
+		if ( 0 === $id && is_singular( 'council' ) ) {
+			$id = get_the_ID();
+		}
+		return $id;
+	}
+
+	private static function process_submission() {
+		if ( empty( $_POST['cdc_fig_nonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['cdc_fig_nonce'] ) ), 'cdc_fig' ) ) {
+			return new \WP_Error( 'invalid', __( 'Security check failed.', 'council-debt-counters' ) );
+		}
+		$ip        = sanitize_text_field( wp_unslash( $_SERVER['REMOTE_ADDR'] ?? '' ) );
+		$limit_key = 'cdc_fig_limit_' . md5( $ip );
+		$last      = get_transient( $limit_key );
+		if ( $last && ( time() - (int) $last ) < 300 ) {
+			return new \WP_Error( 'rate_limited', __( "Whoa there! You're submitting too quickly. Please wait before trying again.", 'council-debt-counters' ) );
+		}
+		$site_key   = get_option( 'cdc_recaptcha_site_key', '' );
+		$secret_key = get_option( 'cdc_recaptcha_secret_key', '' );
+		if ( $site_key && $secret_key ) {
+			$token = sanitize_text_field( wp_unslash( $_POST['g-recaptcha-response'] ?? '' ) );
+			if ( empty( $token ) ) {
+				return new \WP_Error( 'recaptcha', __( 'reCAPTCHA verification failed.', 'council-debt-counters' ) );
+			}
+			$verify = wp_remote_post(
+				'https://www.google.com/recaptcha/api/siteverify',
+				array(
+					'body'    => array(
+						'secret'   => $secret_key,
+						'response' => $token,
+						'remoteip' => $ip,
+					),
+					'timeout' => 15,
+				)
+			);
+			$body   = json_decode( wp_remote_retrieve_body( $verify ), true );
+			if ( empty( $body['success'] ) ) {
+				return new \WP_Error( 'recaptcha', __( 'reCAPTCHA verification failed.', 'council-debt-counters' ) );
+			}
+		}
+		$cid     = isset( $_POST['cdc_council_id'] ) ? intval( $_POST['cdc_council_id'] ) : 0;
+		$note    = sanitize_textarea_field( wp_unslash( $_POST['cdc_note'] ?? '' ) );
+		$email   = sanitize_email( wp_unslash( $_POST['cdc_email'] ?? '' ) );
+		$figures = $_POST['cdc_figures'] ?? array();
+		$clean   = array();
+		foreach ( $figures as $key => $val ) {
+				$val = str_replace( array( ',', '£', '$' ), '', $val );
+			if ( '' === $val ) {
+						continue;
+			}
+				$clean[ sanitize_key( $key ) ] = floatval( $val );
+		}
+		if ( empty( $clean ) || 0 === $cid ) {
+				return new \WP_Error( 'invalid', __( 'Submission incomplete.', 'council-debt-counters' ) );
+		}
+
+		$post_id = wp_insert_post(
+			array(
+				'post_type'    => self::CPT,
+				'post_status'  => 'private',
+				'post_title'   => get_the_title( $cid ),
+				'post_content' => $note,
+			)
+		);
+		if ( is_wp_error( $post_id ) ) {
+			return $post_id;
+		}
+		update_post_meta( $post_id, 'council_id', $cid );
+		update_post_meta( $post_id, 'figures', $clean );
+		if ( $email ) {
+			update_post_meta( $post_id, 'contact_email', $email );
+		}
+		update_post_meta( $post_id, 'ip_address', $ip );
+		set_transient( $limit_key, time(), 300 );
+
+		$admins  = get_option( 'admin_email' );
+		$subject = __( 'New figure submission', 'council-debt-counters' );
+				/* translators: %s: Council title */
+				$message = sprintf( __( 'New figures submitted for %s', 'council-debt-counters' ), get_the_title( $cid ) );
+		wp_mail( $admins, $subject, $message );
+		Error_Logger::log_info( 'Figure submission saved with ID ' . $post_id );
+		return $post_id;
+	}
+
+	public static function maybe_handle_submission() {
+		if ( empty( $_POST['cdc_fig_nonce'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing
+			return;
+		}
+		if ( defined( 'DOING_AJAX' ) && DOING_AJAX ) {
+			return;
+		}
+		$result = self::process_submission();
+		if ( is_wp_error( $result ) ) {
+			wp_die( esc_html( $result->get_error_message() ) );
+		}
+		wp_safe_redirect( add_query_arg( 'submitted', '1', wp_get_referer() ) );
+		exit;
+	}
+
+	public static function render_form( $atts = array() ) {
+		$council_id = self::get_council_id_from_atts( $atts );
+		if ( isset( $_GET['submitted'] ) ) {
+			return '<div class="alert alert-success">' . esc_html__( 'Thank you for your submission.', 'council-debt-counters' ) . '</div>';
+		}
+		$site_key = get_option( 'cdc_recaptcha_site_key', '' );
+		if ( $site_key ) {
+				wp_enqueue_script( 'google-recaptcha', 'https://www.google.com/recaptcha/enterprise.js?render=' . $site_key, array(), '1.0', true );
+		}
+		wp_enqueue_style( 'bootstrap-5' );
+		wp_enqueue_script( 'bootstrap-5' );
+		ob_start();
+		$fields = Custom_Fields::get_fields();
+		$inputs = array();
+		if ( $council_id ) {
+			foreach ( $fields as $f ) {
+				if ( in_array( $f->type, array( 'number', 'money' ), true ) ) {
+					$na  = get_post_meta( $council_id, 'cdc_na_' . $f->name, true );
+					$val = Custom_Fields::get_value( $council_id, $f->name );
+					if ( $na || '' === $val ) {
+						$inputs[] = $f;
+					}
+				}
+			}
+		} else {
+			foreach ( $fields as $f ) {
+				if ( in_array( $f->type, array( 'number', 'money' ), true ) ) {
+					$inputs[] = $f;
+				}
+			}
+		}
+		?>
+		<form method="post" class="cdc-fig-form">
+			<?php wp_nonce_field( 'cdc_fig', 'cdc_fig_nonce' ); ?>
+			<div class="mb-3">
+				<label for="cdc_council_id" class="form-label"><?php esc_html_e( 'Council', 'council-debt-counters' ); ?></label>
+				<select class="form-select" id="cdc_council_id" name="cdc_council_id" required>
+					<option value=""><?php esc_html_e( 'Select council', 'council-debt-counters' ); ?></option>
+					<?php
+					$councils = get_posts(
+						array(
+							'post_type'   => 'council',
+							'numberposts' => -1,
+							'post_status' => array( 'publish', 'draft' ),
+						)
+					);
+					foreach ( $councils as $c ) {
+						echo '<option value="' . esc_attr( $c->ID ) . '"' . selected( $council_id, $c->ID, false ) . '>' . esc_html( get_the_title( $c ) ) . '</option>';
+					}
+					?>
+				</select>
+			</div>
+			<?php foreach ( $inputs as $field ) : ?>
+				<div class="mb-3">
+					<label for="fig-<?php echo esc_attr( $field->name ); ?>" class="form-label"><?php echo esc_html( $field->label ); ?></label>
+					<input type="number" step="0.01" class="form-control" id="fig-<?php echo esc_attr( $field->name ); ?>" name="cdc_figures[<?php echo esc_attr( $field->name ); ?>]" />
+				</div>
+			<?php endforeach; ?>
+			<div class="mb-3">
+				<label for="cdc_note" class="form-label"><?php esc_html_e( 'Note (optional)', 'council-debt-counters' ); ?></label>
+				<textarea class="form-control" id="cdc_note" name="cdc_note"></textarea>
+			</div>
+			<div class="mb-3">
+				<label for="cdc_email" class="form-label"><?php esc_html_e( 'Email (optional)', 'council-debt-counters' ); ?></label>
+				<input type="email" class="form-control" id="cdc_email" name="cdc_email" />
+			</div>
+			<?php if ( $site_key ) : ?>
+				<input type="hidden" name="g-recaptcha-response" />
+			<?php endif; ?>
+			<button type="submit" class="btn btn-primary"><?php esc_html_e( 'Submit', 'council-debt-counters' ); ?></button>
+		</form>
+		<p class="small text-muted mt-2">
+			<?php esc_html_e( 'This site is protected by reCAPTCHA and the Google Privacy Policy and Terms of Service apply.', 'council-debt-counters' ); ?>
+		</p>
+		<?php
+		return ob_get_clean();
+	}
+}

--- a/includes/class-figure-submissions-page.php
+++ b/includes/class-figure-submissions-page.php
@@ -1,0 +1,125 @@
+<?php
+namespace CouncilDebtCounters;
+
+use CouncilDebtCounters\Figure_Submission_Form;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class Figure_Submissions_Page {
+	const SLUG = 'cdc-figure-submissions';
+
+	public static function init() {
+		add_action( 'admin_menu', array( __CLASS__, 'add_menu' ) );
+		add_action( 'admin_post_cdc_fig_approve', array( __CLASS__, 'handle_approve' ) );
+		add_action( 'admin_post_cdc_fig_reject', array( __CLASS__, 'handle_reject' ) );
+	}
+
+	public static function add_menu() {
+		add_submenu_page(
+			'council-debt-counters',
+			__( 'Figure Submissions', 'council-debt-counters' ),
+			__( 'Figure Submissions', 'council-debt-counters' ),
+			'manage_options',
+			self::SLUG,
+			array( __CLASS__, 'render' )
+		);
+	}
+
+	public static function handle_approve() {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_die( esc_html__( 'Permission denied.', 'council-debt-counters' ) );
+		}
+		check_admin_referer( 'cdc_fig_action' );
+		$id   = isset( $_GET['id'] ) ? intval( $_GET['id'] ) : 0;
+		$post = get_post( $id );
+		if ( ! $post || Figure_Submission_Form::CPT !== $post->post_type ) {
+				wp_die( esc_html__( 'Submission not found.', 'council-debt-counters' ) );
+		}
+		$cid     = (int) get_post_meta( $id, 'council_id', true );
+		$figures = get_post_meta( $id, 'figures', true );
+		if ( is_array( $figures ) && 0 !== $cid ) {
+			foreach ( $figures as $key => $val ) {
+					Custom_Fields::update_value( $cid, $key, $val );
+			}
+			wp_update_post(
+				array(
+					'ID'          => $id,
+					'post_status' => 'publish',
+				)
+			);
+		}
+		wp_safe_redirect( admin_url( 'admin.php?page=' . self::SLUG ) );
+		exit;
+	}
+
+	public static function handle_reject() {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_die( esc_html__( 'Permission denied.', 'council-debt-counters' ) );
+		}
+		check_admin_referer( 'cdc_fig_action' );
+		$id = isset( $_GET['id'] ) ? intval( $_GET['id'] ) : 0;
+		if ( get_post_type( $id ) === Figure_Submission_Form::CPT ) {
+			wp_trash_post( $id );
+		}
+		wp_safe_redirect( admin_url( 'admin.php?page=' . self::SLUG ) );
+		exit;
+	}
+
+	public static function render() {
+		$subs = get_posts(
+			array(
+				'post_type'   => Figure_Submission_Form::CPT,
+				'numberposts' => -1,
+				'post_status' => array( 'private', 'publish' ),
+			)
+		);
+		?>
+		<div class="wrap">
+			<h1><?php esc_html_e( 'Figure Submissions', 'council-debt-counters' ); ?></h1>
+			<?php if ( empty( $subs ) ) : ?>
+				<p><?php esc_html_e( 'No submissions found.', 'council-debt-counters' ); ?></p>
+			<?php else : ?>
+			<table class="widefat fixed striped">
+				<thead>
+					<tr>
+						<th><?php esc_html_e( 'Date', 'council-debt-counters' ); ?></th>
+						<th><?php esc_html_e( 'Council', 'council-debt-counters' ); ?></th>
+						<th><?php esc_html_e( 'Figures', 'council-debt-counters' ); ?></th>
+						<th><?php esc_html_e( 'Actions', 'council-debt-counters' ); ?></th>
+					</tr>
+				</thead>
+				<tbody>
+				<?php foreach ( $subs as $s ) : ?>
+					<?php $cid = (int) get_post_meta( $s->ID, 'council_id', true ); ?>
+					<?php $figs = get_post_meta( $s->ID, 'figures', true ); ?>
+					<tr>
+						<td><?php echo esc_html( get_the_date( '', $s ) ); ?></td>
+						<td><?php echo $cid ? esc_html( get_the_title( $cid ) ) : ''; ?></td>
+						<td>
+							<?php
+							if ( is_array( $figs ) ) {
+								foreach ( $figs as $k => $v ) {
+									echo '<div>' . esc_html( $k . ': ' . $v ) . '</div>';
+								}
+							}
+							?>
+						</td>
+						<td>
+							<?php if ( 'publish' !== $s->post_status ) : ?>
+								<a href="<?php echo esc_url( wp_nonce_url( admin_url( 'admin-post.php?action=cdc_fig_approve&id=' . $s->ID ), 'cdc_fig_action' ) ); ?>" class="button"><?php esc_html_e( 'Approve', 'council-debt-counters' ); ?></a>
+								<a href="<?php echo esc_url( wp_nonce_url( admin_url( 'admin-post.php?action=cdc_fig_reject&id=' . $s->ID ), 'cdc_fig_action' ) ); ?>" class="button"><?php esc_html_e( 'Reject', 'council-debt-counters' ); ?></a>
+							<?php else : ?>
+								<?php esc_html_e( 'Approved', 'council-debt-counters' ); ?>
+							<?php endif; ?>
+						</td>
+					</tr>
+				<?php endforeach; ?>
+				</tbody>
+			</table>
+			<?php endif; ?>
+		</div>
+		<?php
+	}
+}


### PR DESCRIPTION
## Summary
- register figure_submission post type and form shortcode
- add admin page for approving or rejecting figure submissions
- initialise new features in main plugin bootstrap

## Testing
- `vendor/bin/phpcs includes/class-figure-submission-form.php includes/class-figure-submissions-page.php council-debt-counters.php`
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6858849f3350833184d9a7dd2217e32b