### PR TITLE
Fix null reference in council-form.js

### DIFF
--- a/admin/js/council-form.js
+++ b/admin/js/council-form.js
@@ -166,7 +166,9 @@
             var perDay = total / 365;
             var perHour = perDay / 24;
             var perSecond = perHour / 3600;
-            ratesOutput.textContent = 'Debt per day: £' + perDay.toFixed(2) + ', per hour: £' + perHour.toFixed(2) + ', per second: £' + perSecond.toFixed(2);
+            if(ratesOutput){
+                ratesOutput.textContent = 'Debt per day: £' + perDay.toFixed(2) + ', per hour: £' + perHour.toFixed(2) + ', per second: £' + perSecond.toFixed(2);
+            }
 
             growthPerSecond = interest / (365 * 24 * 60 * 60);
         }


### PR DESCRIPTION
## Summary
- prevent null reference when updating debt rate totals

## Testing
- `vendor/bin/phpunit -c phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_6859c3da4250833183c1744d6bfbbb45