### PR TITLE
Implement IP limits & SoA uploads

### DIFF
--- a/admin/views/settings-page.php
+++ b/admin/views/settings-page.php
@@ -127,6 +127,14 @@ $types = [
                     <input type="checkbox" id="cdc_use_cdn_assets" name="cdc_use_cdn_assets" value="1" <?php checked( $cdn, 1 ); ?> />
                 </td>
             </tr>
+            <tr>
+                <th scope="row"><label for="cdc_blocked_ips"><?php esc_html_e( 'Blocked IPs', 'council-debt-counters' ); ?></label></th>
+                <td>
+                    <?php $ips = get_option( 'cdc_blocked_ips', '' ); ?>
+                    <textarea name="cdc_blocked_ips" id="cdc_blocked_ips" rows="5" class="large-text code"><?php echo esc_textarea( $ips ); ?></textarea>
+                    <p class="description"><?php esc_html_e( 'One IP or CIDR range per line.', 'council-debt-counters' ); ?></p>
+                </td>
+            </tr>
         </table>
         <?php submit_button(); ?>
     </form>

--- a/council-debt-counters.php
+++ b/council-debt-counters.php
@@ -37,6 +37,7 @@ require_once plugin_dir_path( __FILE__ ) . 'includes/class-whistleblower-reports
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-whistleblower-form.php';
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-figure-submission-form.php';
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-figure-submissions-page.php';
+require_once plugin_dir_path( __FILE__ ) . 'includes/class-figure-submission-ips-page.php';
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-admin-dashboard-widget.php';
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-shortcode-playground.php';
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-council-search.php';

--- a/council-debt-counters.php
+++ b/council-debt-counters.php
@@ -81,10 +81,11 @@ add_action(
 		\CouncilDebtCounters\Admin_Dashboard_Widget::init();
 		\CouncilDebtCounters\Shortcode_Playground::init();
 		\CouncilDebtCounters\Council_Search::init();
-		\CouncilDebtCounters\Stats_Page::init();
-		\CouncilDebtCounters\Figure_Submission_Form::init();
-		\CouncilDebtCounters\Figure_Submissions_Page::init();
-		\CouncilDebtCounters\Sharing_Meta::init();
+                \CouncilDebtCounters\Stats_Page::init();
+                \CouncilDebtCounters\Figure_Submission_Form::init();
+                \CouncilDebtCounters\Figure_Submissions_Page::init();
+                \CouncilDebtCounters\Figure_Submission_IPs_Page::init();
+                \CouncilDebtCounters\Sharing_Meta::init();
 	}
 );
 

--- a/includes/class-figure-submission-form.php
+++ b/includes/class-figure-submission-form.php
@@ -2,6 +2,7 @@
 namespace CouncilDebtCounters;
 
 use CouncilDebtCounters\Error_Logger;
+use CouncilDebtCounters\Docs_Manager;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -57,12 +58,15 @@ class Figure_Submission_Form {
 		if ( empty( $_POST['cdc_fig_nonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['cdc_fig_nonce'] ) ), 'cdc_fig' ) ) {
 			return new \WP_Error( 'invalid', __( 'Security check failed.', 'council-debt-counters' ) );
 		}
-		$ip        = sanitize_text_field( wp_unslash( $_SERVER['REMOTE_ADDR'] ?? '' ) );
-		$limit_key = 'cdc_fig_limit_' . md5( $ip );
-		$last      = get_transient( $limit_key );
-		if ( $last && ( time() - (int) $last ) < 300 ) {
-			return new \WP_Error( 'rate_limited', __( "Whoa there! You're submitting too quickly. Please wait before trying again.", 'council-debt-counters' ) );
-		}
+                $ip        = sanitize_text_field( wp_unslash( $_SERVER['REMOTE_ADDR'] ?? '' ) );
+                if ( self::ip_blocked( $ip ) ) {
+                        return new \WP_Error( 'blocked', __( 'Submissions from your IP address are blocked.', 'council-debt-counters' ) );
+                }
+                $limit_key = 'cdc_fig_limit_' . md5( $ip );
+                $last      = get_transient( $limit_key );
+                if ( $last && ( time() - (int) $last ) < MINUTE_IN_SECONDS * 2 ) {
+                        return new \WP_Error( 'rate_limited', __( 'Your IP address submitted a correction recently. Please wait two minutes before trying again.', 'council-debt-counters' ) );
+                }
 		$site_key   = get_option( 'cdc_recaptcha_site_key', '' );
 		$secret_key = get_option( 'cdc_recaptcha_secret_key', '' );
 		if ( $site_key && $secret_key ) {
@@ -86,7 +90,23 @@ class Figure_Submission_Form {
 				return new \WP_Error( 'recaptcha', __( 'reCAPTCHA verification failed.', 'council-debt-counters' ) );
 			}
 		}
-		$cid                   = isset( $_POST['cdc_council_id'] ) ? intval( $_POST['cdc_council_id'] ) : 0;
+                $cid                   = isset( $_POST['cdc_council_id'] ) ? intval( $_POST['cdc_council_id'] ) : 0;
+                if ( $cid ) {
+                        $existing = get_posts(
+                                array(
+                                        'post_type'   => self::CPT,
+                                        'numberposts' => -1,
+                                        'post_status' => array( 'private', 'publish' ),
+                                        'meta_query'  => array(
+                                                array( 'key' => 'ip_address', 'value' => $ip ),
+                                                array( 'key' => 'council_id', 'value' => $cid ),
+                                        ),
+                                )
+                        );
+                        if ( count( $existing ) >= 5 ) {
+                                return new \WP_Error( 'limit_reached', __( 'Thanks for your help! Please contact us to become a registered data contributor.', 'council-debt-counters' ) );
+                        }
+                }
 		$note                  = sanitize_textarea_field( wp_unslash( $_POST['cdc_note'] ?? '' ) );
 		$email                 = sanitize_email( wp_unslash( $_POST['cdc_email'] ?? '' ) );
 				$figures       = $_POST['cdc_figures'] ?? array();
@@ -123,11 +143,18 @@ class Figure_Submission_Form {
 		if ( ! empty( $clean_sources ) ) {
 				update_post_meta( $post_id, 'sources', $clean_sources );
 		}
-		if ( $email ) {
-				update_post_meta( $post_id, 'contact_email', $email );
-		}
-		update_post_meta( $post_id, 'ip_address', $ip );
-		set_transient( $limit_key, time(), 300 );
+                if ( $email ) {
+                                update_post_meta( $post_id, 'contact_email', $email );
+                }
+                update_post_meta( $post_id, 'ip_address', $ip );
+                if ( ! empty( $_FILES['cdc_soa_file']['name'] ) && $cid ) {
+                        $year = sanitize_text_field( wp_unslash( $_POST['cdc_soa_year'] ?? \CouncilDebtCounters\Docs_Manager::current_financial_year() ) );
+                        $type = sanitize_key( wp_unslash( $_POST['cdc_soa_type'] ?? 'draft_statement_of_accounts' ) );
+                        if ( in_array( $type, \CouncilDebtCounters\Docs_Manager::DOC_TYPES, true ) ) {
+                                \CouncilDebtCounters\Docs_Manager::upload_document( $_FILES['cdc_soa_file'], $type, $cid, $year );
+                        }
+                }
+                set_transient( $limit_key, time(), MINUTE_IN_SECONDS * 2 );
 
 		$admins  = get_option( 'admin_email' );
 		$subject = __( 'New figure submission', 'council-debt-counters' );
@@ -165,12 +192,12 @@ class Figure_Submission_Form {
 			wp_send_json_success( __( 'Thank you for your submission. Your figures will be reviewed by a moderator before going live.', 'council-debt-counters' ) );
 	}
 
-	public static function render_form( $atts = array() ) {
-		$council_id = self::get_council_id_from_atts( $atts );
-		if ( isset( $_GET['submitted'] ) ) {
-			return '<div class="alert alert-success">' . esc_html__( 'Thank you for your submission.', 'council-debt-counters' ) . '</div>';
-		}
-		$site_key = get_option( 'cdc_recaptcha_site_key', '' );
+        public static function render_form( $atts = array() ) {
+                $council_id = self::get_council_id_from_atts( $atts );
+                if ( isset( $_GET['submitted'] ) ) {
+                        return '<div class="alert alert-success">' . esc_html__( 'Thank you for your submission.', 'council-debt-counters' ) . '</div>';
+                }
+                $site_key = get_option( 'cdc_recaptcha_site_key', '' );
 		if ( $site_key ) {
 				wp_enqueue_script( 'google-recaptcha', 'https://www.google.com/recaptcha/enterprise.js?render=' . $site_key, array(), '1.0', true );
 		}
@@ -188,9 +215,25 @@ class Figure_Submission_Form {
 						'submitting' => __( 'Submitting', 'council-debt-counters' ),
 					)
 				);
-				ob_start();
-				$fields = Custom_Fields::get_fields();
-				$inputs = array();
+                                ob_start();
+                                $fields = Custom_Fields::get_fields();
+                $show_upload = false;
+                if ( $council_id ) {
+                        $docs = Docs_Manager::list_documents( $council_id );
+                        if ( empty( $docs ) ) {
+                                $show_upload = true;
+                        } else {
+                                $recent = Docs_Manager::financial_years( 2 );
+                                foreach ( $docs as $d ) {
+                                        if ( in_array( $d->doc_type, Docs_Manager::DOC_TYPES, true ) && in_array( $d->financial_year, $recent, true ) ) {
+                                                $show_upload = false;
+                                                break;
+                                        }
+                                        $show_upload = true;
+                                }
+                        }
+                }
+                                $inputs = array();
 		foreach ( $fields as $f ) {
 			if ( in_array( $f->type, array( 'number', 'money' ), true ) ) {
 						$tab = Custom_Fields::get_field_tab( $f->name );
@@ -220,13 +263,34 @@ class Figure_Submission_Form {
 								<label for="cdc_note" class="form-label"><?php esc_html_e( 'Note (optional)', 'council-debt-counters' ); ?></label>
 								<textarea class="form-control" id="cdc_note" name="cdc_note"></textarea>
 						</div>
-			<div class="mb-3">
-				<label for="cdc_email" class="form-label"><?php esc_html_e( 'Email (optional)', 'council-debt-counters' ); ?></label>
-				<input type="email" class="form-control" id="cdc_email" name="cdc_email" />
-			</div>
-						<?php if ( $site_key ) : ?>
-								<input type="hidden" name="g-recaptcha-response" />
-						<?php endif; ?>
+                        <div class="mb-3">
+                                <label for="cdc_email" class="form-label"><?php esc_html_e( 'Email (optional)', 'council-debt-counters' ); ?></label>
+                                <input type="email" class="form-control" id="cdc_email" name="cdc_email" />
+                        </div>
+                        <?php if ( $show_upload ) : ?>
+                        <div class="mb-3">
+                                <label for="cdc_soa_file" class="form-label"><?php esc_html_e( 'Upload Statement of Accounts (PDF)', 'council-debt-counters' ); ?></label>
+                                <input type="file" id="cdc_soa_file" name="cdc_soa_file" accept="application/pdf" class="form-control" />
+                                <div class="row mt-2">
+                                        <div class="col">
+                                                <select name="cdc_soa_type" class="form-select">
+                                                        <option value="draft_statement_of_accounts"><?php esc_html_e( 'Draft', 'council-debt-counters' ); ?></option>
+                                                        <option value="audited_statement_of_accounts"><?php esc_html_e( 'Audited', 'council-debt-counters' ); ?></option>
+                                                </select>
+                                        </div>
+                                        <div class="col">
+                                                <select name="cdc_soa_year" class="form-select">
+                                                        <?php foreach ( Docs_Manager::financial_years( 5 ) as $y ) : ?>
+                                                                <option value="<?php echo esc_attr( $y ); ?>" <?php selected( Docs_Manager::current_financial_year(), $y ); ?>><?php echo esc_html( $y ); ?></option>
+                                                        <?php endforeach; ?>
+                                                </select>
+                                        </div>
+                                </div>
+                        </div>
+                        <?php endif; ?>
+                        <?php if ( $site_key ) : ?>
+                                        <input type="hidden" name="g-recaptcha-response" />
+                        <?php endif; ?>
 						<button type="submit" class="btn btn-primary">
 								<?php esc_html_e( 'Submit', 'council-debt-counters' ); ?>
 						</button>
@@ -246,6 +310,35 @@ class Figure_Submission_Form {
 						?>
 				</p>
 				<?php
-				return ob_get_clean();
-	}
+                                return ob_get_clean();
+        }
+
+        private static function ip_blocked( string $ip ): bool {
+                $list = explode( "\n", (string) get_option( 'cdc_blocked_ips', '' ) );
+                $ip    = trim( $ip );
+                foreach ( $list as $item ) {
+                        $item = trim( $item );
+                        if ( '' === $item ) {
+                                continue;
+                        }
+                        if ( $item === $ip ) {
+                                return true;
+                        }
+                        if ( strpos( $item, '/' ) !== false && filter_var( $ip, FILTER_VALIDATE_IP ) ) {
+                                if ( self::ip_in_range( $ip, $item ) ) {
+                                        return true;
+                                }
+                        }
+                }
+                return false;
+        }
+
+        private static function ip_in_range( string $ip, string $range ): bool {
+                list( $subnet, $bits ) = explode( '/', $range, 2 );
+                $ip = ip2long( $ip );
+                $subnet = ip2long( $subnet );
+                $mask = -1 << ( 32 - (int) $bits );
+                $subnet &= $mask;
+                return ( $ip & $mask ) === $subnet;
+        }
 }

--- a/includes/class-figure-submission-ips-page.php
+++ b/includes/class-figure-submission-ips-page.php
@@ -1,0 +1,43 @@
+<?php
+namespace CouncilDebtCounters;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class Figure_Submission_IPs_Page {
+    const SLUG = 'cdc-figure-ips';
+
+    public static function init() {
+        add_action( 'admin_menu', array( __CLASS__, 'add_menu' ) );
+    }
+
+    public static function add_menu() {
+        add_submenu_page(
+            'council-debt-counters',
+            __( 'Submission IPs', 'council-debt-counters' ),
+            __( 'Submission IPs', 'council-debt-counters' ),
+            'manage_options',
+            self::SLUG,
+            array( __CLASS__, 'render' )
+        );
+    }
+
+    public static function render() {
+        global $wpdb;
+        $results = $wpdb->get_results( $wpdb->prepare( "SELECT pm.meta_value AS ip, COUNT(*) AS cnt FROM {$wpdb->postmeta} pm JOIN {$wpdb->posts} p ON pm.post_id = p.ID WHERE p.post_type = %s AND pm.meta_key = 'ip_address' GROUP BY pm.meta_value ORDER BY cnt DESC", Figure_Submission_Form::CPT ) );
+        echo '<div class="wrap">';
+        echo '<h1>' . esc_html__( 'Submission IPs', 'council-debt-counters' ) . '</h1>';
+        if ( empty( $results ) ) {
+            echo '<p>' . esc_html__( 'No submissions found.', 'council-debt-counters' ) . '</p>';
+        } else {
+            echo '<table class="widefat fixed striped"><thead><tr><th>' . esc_html__( 'IP Address', 'council-debt-counters' ) . '</th><th>' . esc_html__( 'Count', 'council-debt-counters' ) . '</th></tr></thead><tbody>';
+            foreach ( $results as $row ) {
+                $link = admin_url( 'admin.php?page=' . Figure_Submissions_Page::SLUG . '&ip=' . rawurlencode( $row->ip ) );
+                echo '<tr><td><a href="' . esc_url( $link ) . '">' . esc_html( $row->ip ) . '</a></td><td>' . intval( $row->cnt ) . '</td></tr>';
+            }
+            echo '</tbody></table>';
+        }
+        echo '</div>';
+    }
+}

--- a/includes/class-figure-submissions-page.php
+++ b/includes/class-figure-submissions-page.php
@@ -104,24 +104,35 @@ class Figure_Submissions_Page {
 			exit;
 	}
 
-	public static function render() {
-			$sub_id = isset( $_GET['submission'] ) ? intval( $_GET['submission'] ) : 0;
-		if ( $sub_id ) {
-				self::render_detail( $sub_id );
-				return;
-		}
+        public static function render() {
+                        $sub_id = isset( $_GET['submission'] ) ? intval( $_GET['submission'] ) : 0;
+            $filter_ip = isset( $_GET['ip'] ) ? sanitize_text_field( wp_unslash( $_GET['ip'] ) ) : '';
+            if ( $sub_id ) {
+                                self::render_detail( $sub_id );
+                                return;
+                }
 
-			$subs = get_posts(
-				array(
-					'post_type'   => Figure_Submission_Form::CPT,
-					'numberposts' => -1,
-					'post_status' => array( 'private', 'publish' ),
-				)
-			);
+                        $query_args = array(
+                                'post_type'   => Figure_Submission_Form::CPT,
+                                'numberposts' => -1,
+                                'post_status' => array( 'private', 'publish' ),
+                        );
+            if ( $filter_ip ) {
+                $query_args['meta_query'] = array(
+                        array(
+                                'key'   => 'ip_address',
+                                'value' => $filter_ip,
+                        ),
+                );
+            }
+                        $subs = get_posts( $query_args );
 		?>
-		<div class="wrap">
-			<h1><?php esc_html_e( 'Figure Submissions', 'council-debt-counters' ); ?></h1>
-		<?php if ( empty( $subs ) ) : ?>
+                <div class="wrap">
+                        <h1><?php esc_html_e( 'Figure Submissions', 'council-debt-counters' ); ?></h1>
+            <?php if ( $filter_ip ) : ?>
+                <p><?php printf( esc_html__( 'Filtering submissions from IP %s', 'council-debt-counters' ), esc_html( $filter_ip ) ); ?></p>
+            <?php endif; ?>
+                <?php if ( empty( $subs ) ) : ?>
 				<p><?php esc_html_e( 'No submissions found.', 'council-debt-counters' ); ?></p>
 			<?php else : ?>
 			<table class="widefat fixed striped">

--- a/includes/class-settings-page.php
+++ b/includes/class-settings-page.php
@@ -161,6 +161,15 @@ class Settings_Page {
                                 'default' => 0,
                         )
                 );
+                register_setting(
+                        'cdc_settings',
+                        'cdc_blocked_ips',
+                        array(
+                                'type'              => 'string',
+                                'sanitize_callback' => array( __CLASS__, 'sanitize_blocked_ips' ),
+                                'default'           => '',
+                        )
+                );
         }
 
         public static function enqueue_assets( $hook ) {
@@ -234,6 +243,18 @@ class Settings_Page {
                         $clean[ sanitize_key( $k ) ] = sanitize_text_field( $v );
                 }
                 return $clean;
+        }
+
+        public static function sanitize_blocked_ips( $value ) {
+                $lines = explode( "\n", (string) $value );
+                $clean = array();
+                foreach ( $lines as $line ) {
+                        $line = trim( $line );
+                        if ( $line !== '' ) {
+                                $clean[] = $line;
+                        }
+                }
+                return implode( "\n", $clean );
         }
 
 	public static function render_page() {

--- a/includes/class-shortcode-renderer.php
+++ b/includes/class-shortcode-renderer.php
@@ -124,7 +124,7 @@ class Shortcode_Renderer {
                 $counter_class = 'cdc-counter-' . sanitize_html_class( $field );
                 $obj           = Custom_Fields::get_field_by_name( $field );
                 $label         = $obj && ! empty( $obj->label ) ? $obj->label : ucwords( str_replace( '_', ' ', $field ) );
-               $title         = self::total_counter_title( $type ?: $field );
+               $title         = self::counter_title( $type ?: $field );
                 $collapse_id   = 'cdc-detail-' . $id . '-' . sanitize_html_class( $field );
                 ob_start();
                 ?>

--- a/includes/class-shortcode-renderer.php
+++ b/includes/class-shortcode-renderer.php
@@ -288,6 +288,7 @@ class Shortcode_Renderer {
                 $details = array(
                         'interest'           => $interest,
                         'counter_start_date' => null,
+                        'total_debt'         => $total,
                 );
 
                 // Get band property counts
@@ -313,7 +314,12 @@ class Shortcode_Renderer {
                 $title       = self::counter_title( 'debt' );
                 ob_start();
                 ?>
-                <div class="cdc-counter-title text-center"><?php echo esc_html( $title ); ?></div>
+                <div class="cdc-counter-title text-center">
+                        <?php echo esc_html( $title ); ?>
+                        <button class="btn btn-link p-0 pb-1" type="button" data-bs-toggle="collapse" data-bs-target="#<?php echo esc_attr( $collapse_id ); ?>" aria-expanded="false" aria-controls="<?php echo esc_attr( $collapse_id ); ?>">
+                                <i class="fas fa-info-circle" aria-hidden="true"></i><span class="visually-hidden"><?php esc_html_e( 'View details', 'council-debt-counters' ); ?></span>
+                        </button>
+                </div>
                 <div class="cdc-counter-wrapper text-center mb-3 d-flex align-items-center justify-content-center">
                         <div id="<?php echo esc_attr( 'cdc-counter-' . $id . '-debt' ); ?>" class="cdc-counter cdc-counter-debt display-4 fw-bold" role="status" aria-live="polite" data-target="<?php echo esc_attr( $total + ( $growth_per_second * $elapsed_seconds ) ); ?>" data-growth="<?php echo esc_attr( $growth_per_second ); ?>" data-start="<?php echo esc_attr( $start_value ); ?>" data-prefix="£">
                                 &hellip;
@@ -321,50 +327,58 @@ class Shortcode_Renderer {
                         <noscript>
                                 <p class="cdc-no-js alert alert-warning mb-0"><?php esc_html_e( 'You must enable JavaScript to see the counters', 'council-debt-counters' ); ?></p>
                         </noscript>
-                        <button class="btn btn-link p-0 ms-2" type="button" data-bs-toggle="collapse" data-bs-target="#<?php echo esc_attr( $collapse_id ); ?>" aria-expanded="false" aria-controls="<?php echo esc_attr( $collapse_id ); ?>">
-                                <i class="fas fa-info-circle" aria-hidden="true"></i><span class="visually-hidden"><?php esc_html_e( 'View details', 'council-debt-counters' ); ?></span>
-                        </button>
-                        <div class="collapse" id="<?php echo esc_attr( $collapse_id ); ?>">
+                </div>
+                <div class="collapse text-center" id="<?php echo esc_attr( $collapse_id ); ?>">
+                        <ul class="mt-2 list-unstyled">
+                                        <li>
+                                                <?php esc_html_e( 'Total Reported Debt (Latest Annual Report):', 'council-debt-counters' ); ?> £<?php echo esc_html( number_format_i18n( (float) $details['total_debt'], 2 ) ); ?>
+                                        </li>
+                                        <li>
+                                                <?php esc_html_e( 'Total Reported Interest (Latest Annual Report):', 'council-debt-counters' ); ?> £<?php echo esc_html( number_format_i18n( (float) $details['interest'], 2 ) ); ?>
+                                        </li>
+                                        <li>
+                                                <?php esc_html_e( 'Growth (or reduction if -) per second:', 'council-debt-counters' ); ?> £<?php echo esc_html( number_format_i18n( $growth_per_second, 2 ) ); ?>
+                                        </li>
+                                        <?php if ( null !== $reserves_ratio ) : ?>
+                                                <li class="mt-2">
+                                                        <?php esc_html_e( 'Reserves to Debt Ratio:', 'council-debt-counters' ); ?> 
+                                                        <?php echo esc_html( number_format_i18n( $reserves_ratio, 1 ) ); ?>%
+                                                </li>
+                                                <li class="small text-muted">
+                                                        <?php esc_html_e( 'A lower ratio indicates a higher reliance on borrowing relative to savings.', 'council-debt-counters' ); ?>
+                                                </li>
+                                        <?php endif; ?>
+                        </ul>
+                        <?php if ( array_sum( $bands ) > 0 ) : ?>
+                                <h5><?php esc_html_e( 'Debt per property by Council Tax Band:', 'council-debt-counters' ); ?></h5>
                                 <ul class="mt-2 list-unstyled">
-                                                <li><?php esc_html_e( 'Interest Paid (annual):', 'council-debt-counters' ); ?> £<?php echo esc_html( number_format_i18n( (float) $details['interest'], 2 ) ); ?></li>
-                                                <li><?php esc_html_e( 'Net growth/reduction per second:', 'council-debt-counters' ); ?> £<?php echo esc_html( number_format_i18n( $growth_per_second, 6 ) ); ?></li>
-                                                <?php if ( null !== $reserves_ratio ) : ?>
-                                                <li><?php esc_html_e( 'Reserves to Debt Ratio:', 'council-debt-counters' ); ?> <?php echo esc_html( number_format_i18n( $reserves_ratio, 1 ) ); ?>%</li>
-                                                <li class="small text-muted"><?php esc_html_e( 'A lower ratio indicates a higher reliance on borrowing relative to savings.', 'council-debt-counters' ); ?></li>
-                                                <?php endif; ?>
+                                <?php
+                                foreach ( $bands as $band => $count ) :
+                                        if ( $count > 0 ) :
+                                                $debt_per_property = $total / $count;
+                                                ?>
+                                                <?php // translators: 1: Council tax band letter, 2: Debt per property ?>
+                                        <li><?php echo esc_html( sprintf( 'Band %s: £%s per property', $band, number_format_i18n( $debt_per_property, 2 ) ) ); ?></li>
+                                                <?php
+                                endif;
+        endforeach;
+                                ?>
                                 </ul>
-                                <?php if ( array_sum( $bands ) > 0 ) : ?>
-                                        <h5><?php esc_html_e( 'Debt per property by Council Tax Band:', 'council-debt-counters' ); ?></h5>
-                                        <ul class="mt-2 list-unstyled">
-                                        <?php
-                                        foreach ( $bands as $band => $count ) :
-                                                if ( $count > 0 ) :
-                                                        $debt_per_property = $total / $count;
-                                                        ?>
-                                                        <?php // translators: 1: Council tax band letter, 2: Debt per property ?>
-                                                <li><?php echo esc_html( sprintf( 'Band %s: £%s per property', $band, number_format_i18n( $debt_per_property, 2 ) ) ); ?></li>
-                                                        <?php
-                                        endif;
-endforeach;
-                                        ?>
-                                        </ul>
-                                <?php endif; ?>
-                                <?php if ( $population > 0 ) : ?>
-                                <h5><?php esc_html_e( 'Debt per person:', 'council-debt-counters' ); ?></h5>
+                        <?php endif; ?>
+                        <?php if ( $population > 0 ) : ?>
                                 <ul class="mt-2 list-unstyled">
                                         <?php // translators: %s: Debt per person ?>
-                                        <li><?php echo esc_html( sprintf( '£%s per person', number_format_i18n( $total / $population, 2 ) ) ); ?></li>
+                                        <li>
+                                                <?php esc_html_e( 'Debt per person:', 'council-debt-counters' ); ?>
+                                                <?php echo esc_html( sprintf( '£%s per person', number_format_i18n( $total / $population, 2 ) ) ); ?>
+                                        </li>
                                 </ul>
-                                <?php endif; ?>
-                                <?php if ( $debt_repayment_explainer ) : ?>
-                                <div class="alert alert-info mt-2">
-                                        <?php echo esc_html( $debt_repayment_explainer ); ?>
-                                </div>
-                                <?php endif; ?>
-                                <div class="alert alert-warning mt-2">
-                                        <?php esc_html_e( 'Total debt = Current Liabilities + Long Term Liabilities + Finance Lease/PFI Liabilities + Adjustments. Growth is estimated using the latest annual interest figure spread evenly across the year. Borrowing or repayments may change the real total, so treat this as a guide.', 'council-debt-counters' ); ?>
-                                </div>
+                        <?php endif; ?>
+                        <?php if ( $debt_repayment_explainer ) : ?>
+                        <div class="alert alert-info mt-2">
+                                <?php echo esc_html( $debt_repayment_explainer ); ?>
                         </div>
+                        <?php endif; ?>
                 </div>
                 <?php
                 return ob_get_clean();
@@ -488,6 +502,12 @@ endforeach;
                return sprintf( '<div class="alert alert-%1$s" role="status">%2$s</div>', esc_attr( $type ), wp_kses_post( $message ) );
        }
 
+        /**
+         * Renders a total annual counter for a specific field.
+         * @param string $field
+         * @param string $type
+         * @return bool|string
+         */
         private static function render_total_annual_counter( string $field, string $type = '' ) {
                 $enabled = (array) get_option( 'cdc_enabled_counters', array() );
                 if ( '' !== $type && ! in_array( $type, $enabled, true ) ) {
@@ -514,7 +534,12 @@ endforeach;
 
                 ob_start();
                 ?>
-                <div class="cdc-counter-title text-center"><?php echo esc_html( $title ); ?></div>
+                <div class="cdc-counter-title text-center">
+                        <?php echo esc_html( $title ); ?>
+                        <button class="btn btn-link p-0 ms-2" type="button" data-bs-toggle="collapse" data-bs-target="#<?php echo esc_attr( $collapse_id ); ?>" aria-expanded="false" aria-controls="<?php echo esc_attr( $collapse_id ); ?>">
+                                <i class="fas fa-info-circle" aria-hidden="true"></i><span class="visually-hidden"><?php esc_html_e( 'View details', 'council-debt-counters' ); ?></span>
+                        </button>
+                </div>
                 <div class="cdc-counter-wrapper text-center mb-3 d-flex align-items-center justify-content-center">
                         <div id="<?php echo esc_attr( $counter_id ); ?>" class="cdc-counter <?php echo esc_attr( $counter_class ); ?> display-6 fw-bold" role="status" aria-live="polite" data-target="<?php echo esc_attr( $current ); ?>" data-growth="<?php echo esc_attr( $rate ); ?>" data-start="<?php echo esc_attr( $current ); ?>" data-prefix="£">
                                 &hellip;
@@ -522,18 +547,16 @@ endforeach;
                         <noscript>
                                 <p class="cdc-no-js alert alert-warning mb-0"><?php esc_html_e( 'You must enable JavaScript to see the counters', 'council-debt-counters' ); ?></p>
                         </noscript>
-                        <button class="btn btn-link p-0 ms-2" type="button" data-bs-toggle="collapse" data-bs-target="#<?php echo esc_attr( $collapse_id ); ?>" aria-expanded="false" aria-controls="<?php echo esc_attr( $collapse_id ); ?>">
-                                <i class="fas fa-info-circle" aria-hidden="true"></i><span class="visually-hidden"><?php esc_html_e( 'View details', 'council-debt-counters' ); ?></span>
-                        </button>
-                        <div class="collapse" id="<?php echo esc_attr( $collapse_id ); ?>">
-                                <ul class="mt-2 list-unstyled">
-                                        <?php // translators: %s: Field label ?>
-                                        <li><?php echo esc_html( sprintf( __( 'Annual %s:', 'council-debt-counters' ), $label ) ); ?> £<?php echo esc_html( number_format_i18n( $annual, 2 ) ); ?></li>
-                                        <li><?php esc_html_e( 'Increase per second:', 'council-debt-counters' ); ?> £<?php echo esc_html( number_format_i18n( $rate, 6 ) ); ?></li>
-                                </ul>
-                                <div class="alert alert-warning mt-2">
-                                        <?php esc_html_e( 'This counter assumes the annual figure is spread evenly from 1 April.', 'council-debt-counters' ); ?>
-                                </div>
+                        
+                </div>
+                <div class="collapse" id="<?php echo esc_attr( $collapse_id ); ?>">
+                        <ul class="mt-2 list-unstyled">
+                                <?php // translators: %s: Field label ?>
+                                <li><?php echo esc_html( sprintf( __( 'Annual %s:', 'council-debt-counters' ), $label ) ); ?> £<?php echo esc_html( number_format_i18n( $annual, 2 ) ); ?></li>
+                                <li><?php esc_html_e( 'Increase per second:', 'council-debt-counters' ); ?> £<?php echo esc_html( number_format_i18n( $rate, 6 ) ); ?></li>
+                        </ul>
+                        <div class="alert alert-warning mt-2">
+                                <?php esc_html_e( 'This counter assumes the annual figure is spread evenly from 1 April.', 'council-debt-counters' ); ?>
                         </div>
                 </div>
                 <?php
@@ -620,7 +643,12 @@ endforeach;
 
                 ob_start();
                 ?>
-                <div class="cdc-counter-title text-center"><?php echo esc_html( $title ); ?></div>
+                <div class="cdc-counter-title text-center">
+                        <?php echo esc_html( $title ); ?>
+                        <button class="btn btn-link p-0 pb-1" type="button" data-bs-toggle="collapse" data-bs-target="#<?php echo esc_attr( $collapse_id ); ?>" aria-expanded="false" aria-controls="<?php echo esc_attr( $collapse_id ); ?>">
+                                <i class="fas fa-info-circle" aria-hidden="true"></i><span class="visually-hidden"><?php esc_html_e( 'View details', 'council-debt-counters' ); ?></span>
+                        </button>
+                </div>
                 <div class="cdc-counter-wrapper text-center mb-3 d-flex align-items-center justify-content-center">
                         <div id="cdc-counter-total-debt" class="cdc-counter cdc-counter-debt display-4 fw-bold" role="status" aria-live="polite" data-target="<?php echo esc_attr( $total + ( $growth_per_second * $elapsed_seconds ) ); ?>" data-growth="<?php echo esc_attr( $growth_per_second ); ?>" data-start="<?php echo esc_attr( $start_value ); ?>" data-prefix="£">
                                 &hellip;
@@ -628,23 +656,20 @@ endforeach;
                         <noscript>
                                 <p class="cdc-no-js alert alert-warning mb-0"><?php esc_html_e( 'You must enable JavaScript to see the counters', 'council-debt-counters' ); ?></p>
                         </noscript>
-                        <button class="btn btn-link p-0 ms-2" type="button" data-bs-toggle="collapse" data-bs-target="#<?php echo esc_attr( $collapse_id ); ?>" aria-expanded="false" aria-controls="<?php echo esc_attr( $collapse_id ); ?>">
-                                <i class="fas fa-info-circle" aria-hidden="true"></i><span class="visually-hidden"><?php esc_html_e( 'View details', 'council-debt-counters' ); ?></span>
-                        </button>
-                        <div class="collapse" id="<?php echo esc_attr( $collapse_id ); ?>">
-                                <ul class="mt-2 list-unstyled">
-                                        <li><?php esc_html_e( 'Interest Paid (annual):', 'council-debt-counters' ); ?> £<?php echo esc_html( number_format_i18n( $interest, 2 ) ); ?></li>
-                                        <li><?php esc_html_e( 'Net growth/reduction per second:', 'council-debt-counters' ); ?> £<?php echo esc_html( number_format_i18n( $growth_per_second, 6 ) ); ?></li>
-                                </ul>
-                                <div class="text-muted">
-                                        <?php
-                                        printf(
-                                                /* translators: %s: number of councils */
-                                                esc_html__( 'Based on %s', 'council-debt-counters' ),
-                                                esc_html( sprintf( _n( '%d council', '%d councils', $count, 'council-debt-counters' ), $count ) )
-                                        );
-                                        ?>
-                                </div>
+                </div>
+                <div class="collapse" id="<?php echo esc_attr( $collapse_id ); ?>">
+                        <ul class="mt-2 list-unstyled">
+                                <li><?php esc_html_e( 'Interest Paid (annual):', 'council-debt-counters' ); ?> £<?php echo esc_html( number_format_i18n( $interest, 2 ) ); ?></li>
+                                <li><?php esc_html_e( 'Net growth/reduction per second:', 'council-debt-counters' ); ?> £<?php echo esc_html( number_format_i18n( $growth_per_second, 6 ) ); ?></li>
+                        </ul>
+                        <div class="text-muted">
+                                <?php
+                                printf(
+                                        /* translators: %s: number of councils */
+                                        esc_html__( 'Based on %s', 'council-debt-counters' ),
+                                        esc_html( sprintf( _n( '%d council', '%d councils', $count, 'council-debt-counters' ), $count ) )
+                                );
+                                ?>
                         </div>
                 </div>
                 <?php

--- a/public/js/figure-form.js
+++ b/public/js/figure-form.js
@@ -31,7 +31,8 @@
             form.reset();
             box.className='alert alert-success mt-3';
             box.textContent=res.data||cdcFig.success;
-            document.cookie='cdcFigSubmitted=1; path=/';
+            const path=window.location.pathname||'/';
+            document.cookie='cdcFigSubmitted=1; path='+path;
             form.style.display='none';
           }else{
             box.className='alert alert-danger mt-3';


### PR DESCRIPTION
## Summary
- add new admin page to list figure submission IPs
- limit correction submissions per IP and council
- allow uploading Statement of Accounts if none exist for recent years
- support IP blocking via settings page

## Testing
- `composer install`
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_685af0e37f5883318d42f4195f320be3