### PR TITLE
Add financial year column to custom field values

### DIFF
--- a/includes/class-cdc-utils.php
+++ b/includes/class-cdc-utils.php
@@ -36,4 +36,14 @@ class CDC_Utils {
 
         return $id;
     }
+
+    /**
+     * Return the current financial year in the format YYYY/YY.
+     */
+    public static function current_financial_year(): string {
+        $year  = (int) date( 'Y' );
+        $start = ( date( 'n' ) < 4 ) ? $year - 1 : $year;
+        $end   = $start + 1;
+        return sprintf( '%d/%02d', $start, $end % 100 );
+    }
 }

--- a/includes/class-custom-fields.php
+++ b/includes/class-custom-fields.php
@@ -111,6 +111,7 @@ class Custom_Fields {
             council_id bigint(20) NOT NULL,
             field_id mediumint(9) NOT NULL,
             value longtext NULL,
+            financial_year varchar(9) NOT NULL DEFAULT '" . CDC_Utils::current_financial_year() . "',
             PRIMARY KEY  (id),
             KEY council_id (council_id),
             KEY field_id (field_id)
@@ -139,6 +140,16 @@ class Custom_Fields {
             $columns = $wpdb->get_col( 'DESC ' . $fields_table, 0 );
             if ( ! in_array( 'required', $columns, true ) ) {
                 $wpdb->query( 'ALTER TABLE ' . $fields_table . ' ADD required tinyint(1) NOT NULL DEFAULT 0' );
+            }
+        }
+
+        $values_table = $wpdb->prefix . self::TABLE_VALUES;
+        if ( $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $values_table ) ) === $values_table ) {
+            $v_columns = $wpdb->get_col( 'DESC ' . $values_table, 0 );
+            if ( ! in_array( 'financial_year', $v_columns, true ) ) {
+                $year = CDC_Utils::current_financial_year();
+                $wpdb->query( "ALTER TABLE $values_table ADD financial_year varchar(9) NOT NULL DEFAULT '$year'" );
+                $wpdb->query( "UPDATE $values_table SET financial_year = '2023/24'" );
             }
         }
 

--- a/uninstall.php
+++ b/uninstall.php
@@ -26,10 +26,15 @@ foreach ( $option_names as $option ) {
 
 // Drop custom tables.
 global $wpdb;
+$values_table = $wpdb->prefix . 'cdc_field_values';
+$columns      = $wpdb->get_col( "DESC $values_table", 0 );
+if ( in_array( 'financial_year', $columns, true ) ) {
+        $wpdb->query( "ALTER TABLE $values_table DROP COLUMN financial_year" ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+}
 $tables = array(
-	$wpdb->prefix . 'cdc_fields',
-	$wpdb->prefix . 'cdc_field_values',
-	$wpdb->prefix . 'cdc_documents',
+        $wpdb->prefix . 'cdc_fields',
+        $wpdb->prefix . 'cdc_field_values',
+        $wpdb->prefix . 'cdc_documents',
 );
 
 foreach ( $tables as $table ) {


### PR DESCRIPTION
## Summary
- support computing current financial year via `CDC_Utils`
- store `financial_year` for custom field values
- auto add the column if missing and backfill
- drop the column during uninstall

## Testing
- `composer install`
- `./vendor/bin/phpunit`
- `./vendor/bin/phpcs` *(fails: many coding standard errors)*

------
https://chatgpt.com/codex/tasks/task_e_685b38189db483318c00846259cba22c