### PR TITLE
Add financial year selector for council fields

### DIFF
--- a/admin/css/upload-progress.css
+++ b/admin/css/upload-progress.css
@@ -14,3 +14,16 @@
 #cdc-upload-overlay p { margin-top: 10px; font-size: 16px; }
 #cdc-upload-overlay .progress { width: 80%; height: 8px; margin-top: 8px; }
 #cdc-upload-overlay .progress-bar { transition: width 0.5s linear; }
+
+.cdc-loading-overlay {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(255,255,255,0.8);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 10;
+}

--- a/admin/js/council-form.js
+++ b/admin/js/council-form.js
@@ -29,6 +29,8 @@
         var statusSelect = document.getElementById('cdc-post-status');
         var assignee = document.querySelector('select[name="assigned_user"]');
         var uploadBtn = document.getElementById('cdc-upload-doc');
+        var yearInput = document.getElementById('cdc-financial-year');
+        var yearSelects = document.querySelectorAll('.cdc-year-select');
         var msgArea = document.getElementById('cdc-status-msg');
         function flash(msg){
             if(!msgArea) return;
@@ -178,6 +180,42 @@
         if (leaseField) leaseField.addEventListener('input', updateAll);
         if (interestField) interestField.addEventListener('input', updateAll);
         updateAll();
+
+        function loadYear(year){
+            if(!cdcToolbarData.id) return;
+            var overlay=document.createElement('div');
+            overlay.className='cdc-loading-overlay';
+            var content=document.querySelector('.tab-content');
+            if(content){ content.style.position='relative'; content.appendChild(overlay); }
+            var data=new FormData();
+            data.append('action','cdc_load_council_year');
+            data.append('nonce', cdcToolbarData.nonce);
+            data.append('council_id', cdcToolbarData.id);
+            data.append('year', year);
+            fetch(ajaxurl,{method:'POST',credentials:'same-origin',body:data})
+                .then(function(r){return r.json();})
+                .then(function(res){
+                    if(content) content.removeChild(overlay);
+                    if(res.success && res.data){
+                        for(var k in res.data){
+                            var inp=form.querySelector('[data-cdc-field="'+k+'"]');
+                            if(inp){ inp.value=res.data[k]; inp.dispatchEvent(new Event('input')); }
+                        }
+                        updateAll();
+                    }
+                })
+                .catch(function(){ if(content) content.removeChild(overlay); });
+        }
+
+        if(yearSelects){
+            yearSelects.forEach(function(sel){
+                sel.addEventListener('change',function(){
+                    yearSelects.forEach(function(s){ if(s!==sel) s.value=sel.value; });
+                    if(yearInput) yearInput.value=sel.value;
+                    loadYear(sel.value);
+                });
+            });
+        }
 
         function handleNaToggle(name){
             var input=document.querySelector('[data-cdc-field="'+name+'"]');

--- a/includes/class-cdc-utils.php
+++ b/includes/class-cdc-utils.php
@@ -36,4 +36,14 @@ class CDC_Utils {
 
         return $id;
     }
+
+    /**
+     * Return a list of financial years starting from the current year.
+     *
+     * @param int $count Number of past years to include.
+     * @return array<string>
+     */
+    public static function financial_years( int $count = 10 ): array {
+        return Docs_Manager::financial_years( $count );
+    }
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -24,6 +24,7 @@ $wpdb = new WPDBStub();
 
 require_once __DIR__ . '/../includes/class-counter-manager.php';
 require_once __DIR__ . '/../includes/class-custom-fields.php';
+require_once __DIR__ . '/../includes/class-docs-manager.php';
 
 function is_serialized($data, $strict = true) {
     if (!is_string($data)) return false;


### PR DESCRIPTION
## Summary
- add CDC_Utils::financial_years helper
- store and load council field values by financial year
- load yearly data via new `cdc_load_council_year` AJAX action
- sync year dropdowns in admin form and fetch values via JS
- keep phpunit bootstrap aware of Docs_Manager

## Testing
- `composer install`
- `vendor/bin/phpunit`
- `vendor/bin/phpcs --standard=phpcs.xml.dist` *(fails: many warnings/errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_685b382f8de08331a1a78d8c1c64432a