### PR TITLE
Support financial year data

### DIFF
--- a/admin/views/councils-page.php
+++ b/admin/views/councils-page.php
@@ -96,7 +96,7 @@ if ( 'edit' === $req_action ) {
 $council_locations = array( 'England', 'Wales', 'Scotland', 'Northern Ireland' );
 $no_accounts       = $council_id ? get_post_meta( $council_id, 'cdc_no_accounts', true ) : '';
 foreach ( $groups['general'] as $field ) :
-                                                $val         = $council_id ? \CouncilDebtCounters\Custom_Fields::get_value( $council_id, $field->name ) : '';
+                                                $val         = $council_id ? \CouncilDebtCounters\Custom_Fields::get_value( $council_id, $field->name, \CouncilDebtCounters\CDC_Utils::current_financial_year() ) : '';
                                                 if ( ! $council_id && $field->required && in_array( $field->type, array( 'number', 'money' ), true ) ) {
                                                         $val = '0';
                                                 }
@@ -255,7 +255,7 @@ $readonly = true;
 						<tbody>
 							<?php
 							foreach ( $tab_fields as $field ) :
-								$val         = $council_id ? \CouncilDebtCounters\Custom_Fields::get_value( $council_id, $field->name ) : '';
+                                                                $val         = $council_id ? \CouncilDebtCounters\Custom_Fields::get_value( $council_id, $field->name, \CouncilDebtCounters\CDC_Utils::current_financial_year() ) : '';
 								$input_type  = 'text' === $field->type ? 'text' : 'number';
 								$is_required = (bool) $field->required;
 								$readonly    = in_array( $field->name, \CouncilDebtCounters\Custom_Fields::READONLY_FIELDS, true );
@@ -319,7 +319,7 @@ $readonly = true;
 					<tr>
 						<th scope="row"><label for="cdc-soa"><?php echo esc_html( $docs_field->label ); ?></label></th>
 						<td>
-														<?php $val = $council_id ? \CouncilDebtCounters\Custom_Fields::get_value( $council_id, 'statement_of_accounts' ) : ''; ?>
+                                               <?php $val = $council_id ? \CouncilDebtCounters\Custom_Fields::get_value( $council_id, 'statement_of_accounts', \CouncilDebtCounters\CDC_Utils::current_financial_year() ) : ''; ?>
 <?php if ( $val ) : ?>
         <p><a href="<?php echo esc_url( plugins_url( 'docs/' . $val, dirname( __DIR__, 2 ) . '/council-debt-counters.php' ) ); ?>" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'View selected statement', 'council-debt-counters' ); ?></a></p>
 <?php endif; ?>

--- a/admin/views/docs-manager-page.php
+++ b/admin/views/docs-manager-page.php
@@ -16,7 +16,7 @@ if ( isset( $_POST['cdc_assign_doc'], $_POST['cdc_doc_name'], $_POST['cdc_counci
     $year = sanitize_text_field( $_POST['cdc_doc_year'] );
     Docs_Manager::assign_document( $file, $council, $type, $year );
     if ( in_array( $type, [ 'draft_statement_of_accounts', 'audited_statement_of_accounts' ], true ) ) {
-        \CouncilDebtCounters\Custom_Fields::update_value( $council, 'statement_of_accounts', $file );
+        \CouncilDebtCounters\Custom_Fields::update_value( $council, 'statement_of_accounts', $file, \CouncilDebtCounters\CDC_Utils::current_financial_year() );
     }
     echo '<div class="notice notice-success"><p>' . esc_html__( 'Document assigned.', 'council-debt-counters' ) . '</p></div>';
     $docs = Docs_Manager::list_documents();

--- a/includes/class-admin-dashboard-widget.php
+++ b/includes/class-admin-dashboard-widget.php
@@ -22,8 +22,9 @@ class Admin_Dashboard_Widget {
         }
         echo '<table class="widefat"><thead><tr><th>' . esc_html__( 'Council', 'council-debt-counters' ) . '</th><th>' . esc_html__( 'Debt', 'council-debt-counters' ) . '</th><th>' . esc_html__( 'Deficit', 'council-debt-counters' ) . '</th></tr></thead><tbody>';
         foreach ( $councils as $c ) {
-            $debt = (float) Custom_Fields::get_value( $c->ID, 'total_debt' );
-            $def  = (float) Custom_Fields::get_value( $c->ID, 'annual_deficit' );
+            $year = CDC_Utils::current_financial_year();
+            $debt = (float) Custom_Fields::get_value( $c->ID, 'total_debt', $year );
+            $def  = (float) Custom_Fields::get_value( $c->ID, 'annual_deficit', $year );
             echo '<tr><td>' . esc_html( $c->post_title ) . '</td><td>' . esc_html( number_format_i18n( $debt, 2 ) ) . '</td><td>' . esc_html( number_format_i18n( $def, 2 ) ) . '</td></tr>';
         }
         echo '</tbody></table>';

--- a/includes/class-cdc-utils.php
+++ b/includes/class-cdc-utils.php
@@ -36,4 +36,17 @@ class CDC_Utils {
 
         return $id;
     }
+
+    /**
+     * Get the current financial year in YYYY/YY format.
+     */
+    public static function current_financial_year(): string {
+        if ( class_exists( '\\CouncilDebtCounters\\Docs_Manager' ) && method_exists( '\\CouncilDebtCounters\\Docs_Manager', 'current_financial_year' ) ) {
+            return Docs_Manager::current_financial_year();
+        }
+        $year  = (int) date( 'Y' );
+        $start = ( date( 'n' ) < 4 ) ? $year - 1 : $year;
+        $end   = $start + 1;
+        return sprintf( '%d/%02d', $start, $end % 100 );
+    }
 }

--- a/includes/class-council-admin-page.php
+++ b/includes/class-council-admin-page.php
@@ -140,7 +140,7 @@ class Council_Admin_Page {
                 continue;
             }
             $value = $_POST['cdc_fields'][ $field->id ] ?? '';
-            Custom_Fields::update_value( $post_id, $field->name, wp_unslash( $value ) );
+            Custom_Fields::update_value( $post_id, $field->name, wp_unslash( $value ), CDC_Utils::current_financial_year() );
             $meta_key = 'cdc_na_' . $field->name;
             if ( isset( $na_flags[ $field->name ] ) ) {
                 update_post_meta( $post_id, $meta_key, '1' );
@@ -160,7 +160,7 @@ class Council_Admin_Page {
             }
         }
 
-        $soa_value = Custom_Fields::get_value( $post_id, 'statement_of_accounts' );
+        $soa_value = Custom_Fields::get_value( $post_id, 'statement_of_accounts', CDC_Utils::current_financial_year() );
         $soa_year  = sanitize_text_field( $_POST['statement_of_accounts_year'] ?? Docs_Manager::current_financial_year() );
         $soa_type  = sanitize_key( $_POST['statement_of_accounts_type'] ?? 'draft_statement_of_accounts' );
         if ( ! in_array( $soa_type, Docs_Manager::DOC_TYPES, true ) ) {
@@ -185,7 +185,7 @@ class Council_Admin_Page {
         }
 
         if ( $soa_value ) {
-            Custom_Fields::update_value( $post_id, 'statement_of_accounts', $soa_value );
+            Custom_Fields::update_value( $post_id, 'statement_of_accounts', $soa_value, CDC_Utils::current_financial_year() );
         }
 
         if ( isset( $_POST['assigned_user'] ) ) {
@@ -208,8 +208,8 @@ class Council_Admin_Page {
                 $name = get_the_title( $parent );
                 $link = get_permalink( $parent );
                 $msg  = sprintf( __( 'This council is now part of <a href="%s">%s</a>', 'council-debt-counters' ), esc_url( $link ), $name );
-                Custom_Fields::update_value( $post_id, 'status_message', $msg );
-                Custom_Fields::update_value( $post_id, 'status_message_type', 'info' );
+                Custom_Fields::update_value( $post_id, 'status_message', $msg, CDC_Utils::current_financial_year() );
+                Custom_Fields::update_value( $post_id, 'status_message_type', 'info', CDC_Utils::current_financial_year() );
             } else {
                 delete_post_meta( $post_id, 'cdc_parent_council' );
             }
@@ -217,7 +217,7 @@ class Council_Admin_Page {
 
         if ( isset( $_POST['cdc_no_accounts'] ) ) {
             update_post_meta( $post_id, 'cdc_no_accounts', '1' );
-            Custom_Fields::update_value( $post_id, 'status_message_type', 'danger' );
+            Custom_Fields::update_value( $post_id, 'status_message_type', 'danger', CDC_Utils::current_financial_year() );
         } else {
             delete_post_meta( $post_id, 'cdc_no_accounts' );
         }

--- a/includes/class-council-post-type.php
+++ b/includes/class-council-post-type.php
@@ -73,10 +73,11 @@ class Council_Post_Type {
             return;
         }
         // Get all relevant fields
-        $current_liabilities = (float) Custom_Fields::get_value( $post_id, 'current_liabilities' );
-        $long_term  = (float) Custom_Fields::get_value( $post_id, 'long_term_liabilities' );
-        $lease_pfi  = (float) Custom_Fields::get_value( $post_id, 'finance_lease_pfi_liabilities' );
-        $manual     = (float) Custom_Fields::get_value( $post_id, 'manual_debt_entry' );
+        $year = CDC_Utils::current_financial_year();
+        $current_liabilities = (float) Custom_Fields::get_value( $post_id, 'current_liabilities', $year );
+        $long_term  = (float) Custom_Fields::get_value( $post_id, 'long_term_liabilities', $year );
+        $lease_pfi  = (float) Custom_Fields::get_value( $post_id, 'finance_lease_pfi_liabilities', $year );
+        $manual     = (float) Custom_Fields::get_value( $post_id, 'manual_debt_entry', $year );
         $adjust   = 0;
         $entries  = get_post_meta( $post_id, 'cdc_debt_adjustments', true );
         if ( is_array( $entries ) ) {
@@ -86,6 +87,6 @@ class Council_Post_Type {
         }
         // Total debt is current liabilities + long term liabilities + lease/PFI + manual + adjustments
         $total = $current_liabilities + $long_term + $lease_pfi + $manual + $adjust;
-        Custom_Fields::update_value( $post_id, 'total_debt', $total );
+        Custom_Fields::update_value( $post_id, 'total_debt', $total, $year );
     }
 }

--- a/includes/class-councils-table.php
+++ b/includes/class-councils-table.php
@@ -64,7 +64,7 @@ class Councils_Table extends \WP_List_Table {
     }
 
     protected function column_population( $item ) {
-        $pop = (int) Custom_Fields::get_value( $item->ID, 'population' );
+        $pop = (int) Custom_Fields::get_value( $item->ID, 'population', CDC_Utils::current_financial_year() );
         return $pop ? number_format_i18n( $pop ) : '&mdash;';
     }
 
@@ -88,11 +88,11 @@ class Councils_Table extends \WP_List_Table {
             $ids = array_map( 'intval', (array) $_POST['council'] );
             foreach ( $ids as $id ) {
                 $title = get_the_title( $id );
-                $meta  = Custom_Fields::get_value( $id, 'council_name' );
+                $meta  = Custom_Fields::get_value( $id, 'council_name', CDC_Utils::current_financial_year() );
                 if ( empty( $title ) && ! empty( $meta ) ) {
                     wp_update_post( [ 'ID' => $id, 'post_title' => $meta ] );
                 } elseif ( empty( $meta ) && ! empty( $title ) ) {
-                    Custom_Fields::update_value( $id, 'council_name', $title );
+                    Custom_Fields::update_value( $id, 'council_name', $title, CDC_Utils::current_financial_year() );
                 }
             }
             add_settings_error( 'cdc_messages', 'cdc_repair', __( 'Repair completed.', 'council-debt-counters' ), 'updated' );
@@ -156,8 +156,9 @@ class Councils_Table extends \WP_List_Table {
             usort(
                 $posts,
                 function ( $a, $b ) use ( $order ) {
-                    $val_a = (int) Custom_Fields::get_value( $a->ID, 'population' );
-                    $val_b = (int) Custom_Fields::get_value( $b->ID, 'population' );
+                    $year  = CDC_Utils::current_financial_year();
+                    $val_a = (int) Custom_Fields::get_value( $a->ID, 'population', $year );
+                    $val_b = (int) Custom_Fields::get_value( $b->ID, 'population', $year );
                     return 'asc' === $order ? $val_a <=> $val_b : $val_b <=> $val_a;
                 }
             );

--- a/includes/class-custom-fields.php
+++ b/includes/class-custom-fields.php
@@ -110,10 +110,12 @@ class Custom_Fields {
             id bigint(20) NOT NULL AUTO_INCREMENT,
             council_id bigint(20) NOT NULL,
             field_id mediumint(9) NOT NULL,
+            financial_year varchar(9) NOT NULL,
             value longtext NULL,
             PRIMARY KEY  (id),
             KEY council_id (council_id),
-            KEY field_id (field_id)
+            KEY field_id (field_id),
+            KEY financial_year (financial_year)
         ) $charset_collate;";
 
         require_once ABSPATH . 'wp-admin/includes/upgrade.php';
@@ -139,6 +141,15 @@ class Custom_Fields {
             $columns = $wpdb->get_col( 'DESC ' . $fields_table, 0 );
             if ( ! in_array( 'required', $columns, true ) ) {
                 $wpdb->query( 'ALTER TABLE ' . $fields_table . ' ADD required tinyint(1) NOT NULL DEFAULT 0' );
+            }
+        }
+
+        $values_table = $wpdb->prefix . self::TABLE_VALUES;
+        if ( $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $values_table ) ) === $values_table ) {
+            $columns = $wpdb->get_col( 'DESC ' . $values_table, 0 );
+            if ( ! in_array( 'financial_year', $columns, true ) ) {
+                $wpdb->query( "ALTER TABLE $values_table ADD financial_year varchar(9) NOT NULL DEFAULT '" . CDC_Utils::current_financial_year() . "'" );
+                $wpdb->query( "ALTER TABLE $values_table ADD KEY financial_year (financial_year)" );
             }
         }
 
@@ -305,32 +316,39 @@ class Custom_Fields {
         }
     }
 
-    public static function get_value( int $council_id, string $name ) {
+    public static function get_value( int $council_id, string $name, string $financial_year = '' ) {
+        if ( empty( $financial_year ) ) {
+            $financial_year = CDC_Utils::current_financial_year();
+        }
         $field = self::get_field_by_name( $name );
         if ( ! $field ) {
             return '';
         }
         global $wpdb;
-        $raw = $wpdb->get_var( $wpdb->prepare( 'SELECT value FROM ' . $wpdb->prefix . self::TABLE_VALUES . ' WHERE council_id = %d AND field_id = %d', $council_id, $field->id ) );
+        $raw = $wpdb->get_var( $wpdb->prepare( 'SELECT value FROM ' . $wpdb->prefix . self::TABLE_VALUES . ' WHERE council_id = %d AND field_id = %d AND financial_year = %s', $council_id, $field->id, $financial_year ) );
         return maybe_unserialize( $raw );
     }
 
-    public static function update_value( int $council_id, string $name, $value ) {
+    public static function update_value( int $council_id, string $name, $value, string $financial_year = '' ) {
+        if ( empty( $financial_year ) ) {
+            $financial_year = CDC_Utils::current_financial_year();
+        }
         $field = self::get_field_by_name( $name );
         if ( ! $field ) {
             return false;
         }
         global $wpdb;
         $table = $wpdb->prefix . self::TABLE_VALUES;
-        $existing = $wpdb->get_var( $wpdb->prepare( 'SELECT id FROM ' . $table . ' WHERE council_id = %d AND field_id = %d', $council_id, $field->id ) );
+        $existing = $wpdb->get_var( $wpdb->prepare( 'SELECT id FROM ' . $table . ' WHERE council_id = %d AND field_id = %d AND financial_year = %s', $council_id, $field->id, $financial_year ) );
         if ( $existing ) {
             $wpdb->update( $table, [ 'value' => maybe_serialize( $value ) ], [ 'id' => $existing ], [ '%s' ], [ '%d' ] );
         } else {
             $wpdb->insert( $table, [
                 'council_id' => $council_id,
                 'field_id'   => $field->id,
+                'financial_year' => $financial_year,
                 'value'      => maybe_serialize( $value ),
-            ], [ '%d', '%d', '%s' ] );
+            ], [ '%d', '%d', '%s', '%s' ] );
         }
         return true;
     }
@@ -338,7 +356,10 @@ class Custom_Fields {
     /**
      * Get the summed value of a field across all councils.
      */
-    public static function get_total_value( string $name ) : float {
+    public static function get_total_value( string $name, string $financial_year = '' ) : float {
+        if ( empty( $financial_year ) ) {
+            $financial_year = CDC_Utils::current_financial_year();
+        }
         $field = self::get_field_by_name( $name );
         if ( ! $field ) {
             return 0.0;
@@ -353,7 +374,7 @@ class Custom_Fields {
             if ( get_post_meta( (int) $id, 'cdc_parent_council', true ) ) {
                 continue;
             }
-            $val = self::get_value( (int) $id, $name );
+            $val = self::get_value( (int) $id, $name, $financial_year );
             if ( is_numeric( $val ) ) {
                 $total += (float) $val;
             }
@@ -386,7 +407,7 @@ class Custom_Fields {
                     self::add_field( $key, $label, $type );
                 }
 
-                self::update_value( $post->ID, $key, $value );
+                self::update_value( $post->ID, $key, $value, CDC_Utils::current_financial_year() );
             }
         }
     }

--- a/includes/class-data-loader.php
+++ b/includes/class-data-loader.php
@@ -93,7 +93,7 @@ class Data_Loader {
                                 if ( $info && in_array( $info->type, array( 'number', 'money' ), true ) ) {
                                         $value = str_replace( ',', '', $value );
                                 }
-                                \CouncilDebtCounters\Custom_Fields::update_value( $post_id, $field, $value );
+                                \CouncilDebtCounters\Custom_Fields::update_value( $post_id, $field, $value, CDC_Utils::current_financial_year() );
                         }
 
 			if ( method_exists( '\\CouncilDebtCounters\\Council_Post_Type', 'calculate_total_debt' ) ) {
@@ -161,7 +161,7 @@ class Data_Loader {
 				if ( '' === $value ) {
 					continue;
 				}
-				Custom_Fields::update_value( $post_id, $field, $value );
+                                Custom_Fields::update_value( $post_id, $field, $value, CDC_Utils::current_financial_year() );
 			}
 
 			if ( method_exists( '\\CouncilDebtCounters\\Council_Post_Type', 'calculate_total_debt' ) ) {
@@ -213,7 +213,7 @@ class Data_Loader {
 				if ( 'council_name' === $f->name ) {
 					continue;
 				}
-				$row[ $f->name ] = Custom_Fields::get_value( $c->ID, $f->name );
+                                $row[ $f->name ] = Custom_Fields::get_value( $c->ID, $f->name, CDC_Utils::current_financial_year() );
 			}
 			$rows[] = $row;
 		}
@@ -392,7 +392,7 @@ class Data_Loader {
                         if ( $info && in_array( $info->type, array( 'number', 'money' ), true ) ) {
                                 $value = str_replace( ',', '', $value );
                         }
-                        Custom_Fields::update_value( $post_id, $field, $value );
+                        Custom_Fields::update_value( $post_id, $field, $value, CDC_Utils::current_financial_year() );
                 }
 
 		if ( method_exists( '\\CouncilDebtCounters\\Council_Post_Type', 'calculate_total_debt' ) ) {

--- a/includes/class-docs-manager.php
+++ b/includes/class-docs-manager.php
@@ -344,8 +344,9 @@ class Docs_Manager {
         check_admin_referer( 'cdc_confirm_ai_figures' );
         $cid = intval( $_POST['council_id'] );
         $figures = (array) ( $_POST['figures'] ?? [] );
+        $year = CDC_Utils::current_financial_year();
         foreach ( $figures as $field => $value ) {
-            Custom_Fields::update_value( $cid, sanitize_key( $field ), sanitize_text_field( $value ) );
+            Custom_Fields::update_value( $cid, sanitize_key( $field ), sanitize_text_field( $value ), $year );
         }
         if ( method_exists( '\\CouncilDebtCounters\\Council_Post_Type', 'calculate_total_debt' ) ) {
             Council_Post_Type::calculate_total_debt( $cid );

--- a/includes/class-figure-submissions-page.php
+++ b/includes/class-figure-submissions-page.php
@@ -43,9 +43,10 @@ class Figure_Submissions_Page {
 		$cid     = (int) get_post_meta( $id, 'council_id', true );
 		$figures = get_post_meta( $id, 'figures', true );
 		if ( is_array( $figures ) && 0 !== $cid ) {
-			foreach ( $figures as $key => $val ) {
-					Custom_Fields::update_value( $cid, $key, $val );
-			}
+                        $year = CDC_Utils::current_financial_year();
+                        foreach ( $figures as $key => $val ) {
+                                        Custom_Fields::update_value( $cid, $key, $val, $year );
+                        }
 			wp_update_post(
 				array(
 					'ID'          => $id,
@@ -84,13 +85,14 @@ class Figure_Submissions_Page {
 			$figures = (array) get_post_meta( $id, 'figures', true );
 			$choices = $_POST['use'] ?? array();
 			$changed = array();
-		if ( $cid ) {
-			foreach ( $figures as $key => $val ) {
-				if ( isset( $choices[ $key ] ) && 'submitted' === $choices[ $key ] ) {
-					Custom_Fields::update_value( $cid, $key, $val );
-					$changed[] = $key;
-				}
-			}
+                if ( $cid ) {
+                        $year = CDC_Utils::current_financial_year();
+                        foreach ( $figures as $key => $val ) {
+                                if ( isset( $choices[ $key ] ) && 'submitted' === $choices[ $key ] ) {
+                                        Custom_Fields::update_value( $cid, $key, $val, $year );
+                                        $changed[] = $key;
+                                }
+                        }
 				wp_update_post(
 					array(
 						'ID'          => $id,
@@ -214,7 +216,7 @@ class Figure_Submissions_Page {
 										if ( $field ) {
 												$label = $field->label;
 										}
-											$current = $cid ? Custom_Fields::get_value( $cid, $key ) : '';
+                                                                               $current = $cid ? Custom_Fields::get_value( $cid, $key, CDC_Utils::current_financial_year() ) : '';
 											$source  = $sources[ $key ] ?? '';
 										?>
 												<tr>

--- a/includes/class-shortcode-renderer.php
+++ b/includes/class-shortcode-renderer.php
@@ -65,7 +65,7 @@ class Shortcode_Renderer {
                 if ( '' !== $type && ! in_array( $type, $enabled, true ) ) {
                         return '';
                 }
-               $raw_value = Custom_Fields::get_value( $id, $field );
+               $raw_value = Custom_Fields::get_value( $id, $field, CDC_Utils::current_financial_year() );
                $parent    = intval( get_post_meta( $id, 'cdc_parent_council', true ) );
                $na_tab    = $type ? get_post_meta( $id, 'cdc_na_tab_' . $type, true ) : '';
                $na_field  = get_post_meta( $id, 'cdc_na_' . $field, true );
@@ -251,12 +251,12 @@ class Shortcode_Renderer {
                        return '<div class="cdc-counter-static display-4 fw-bold">&pound;??.??</div>';
                }
 
-               $total  = Custom_Fields::get_value( $id, 'total_debt' );
+               $total  = Custom_Fields::get_value( $id, 'total_debt', CDC_Utils::current_financial_year() );
                if ( ! $total ) {
                        $total = 0;
                }
                $parent = intval( get_post_meta( $id, 'cdc_parent_council', true ) );
-            $interest          = (float) Custom_Fields::get_value( $id, 'interest_paid' );
+            $interest          = (float) Custom_Fields::get_value( $id, 'interest_paid', CDC_Utils::current_financial_year() );
                 $growth_per_second = $interest / ( 365 * 24 * 60 * 60 );
 
                 // Council balance sheets cover the year ending 31 March.
@@ -292,20 +292,21 @@ class Shortcode_Renderer {
                 );
 
                 // Get band property counts
+                $year  = CDC_Utils::current_financial_year();
                 $bands = array(
-                        'A' => (int) Custom_Fields::get_value( $id, 'band_a_properties' ),
-                        'B' => (int) Custom_Fields::get_value( $id, 'band_b_properties' ),
-                        'C' => (int) Custom_Fields::get_value( $id, 'band_c_properties' ),
-                        'D' => (int) Custom_Fields::get_value( $id, 'band_d_properties' ),
-                        'E' => (int) Custom_Fields::get_value( $id, 'band_e_properties' ),
-                        'F' => (int) Custom_Fields::get_value( $id, 'band_f_properties' ),
-                        'G' => (int) Custom_Fields::get_value( $id, 'band_g_properties' ),
-                        'H' => (int) Custom_Fields::get_value( $id, 'band_h_properties' ),
+                        'A' => (int) Custom_Fields::get_value( $id, 'band_a_properties', $year ),
+                        'B' => (int) Custom_Fields::get_value( $id, 'band_b_properties', $year ),
+                        'C' => (int) Custom_Fields::get_value( $id, 'band_c_properties', $year ),
+                        'D' => (int) Custom_Fields::get_value( $id, 'band_d_properties', $year ),
+                        'E' => (int) Custom_Fields::get_value( $id, 'band_e_properties', $year ),
+                        'F' => (int) Custom_Fields::get_value( $id, 'band_f_properties', $year ),
+                        'G' => (int) Custom_Fields::get_value( $id, 'band_g_properties', $year ),
+                        'H' => (int) Custom_Fields::get_value( $id, 'band_h_properties', $year ),
                 );
 
-                $population = (int) Custom_Fields::get_value( $id, 'population' );
+                $population = (int) Custom_Fields::get_value( $id, 'population', $year );
 
-                $reserves = (float) Custom_Fields::get_value( $id, 'usable_reserves' );
+                $reserves = (float) Custom_Fields::get_value( $id, 'usable_reserves', $year );
                 $reserves_ratio = ( $reserves > 0 && $total > 0 ) ? round( ( $reserves / $total ) * 100, 1 ) : null;
 
                 $debt_repayment_explainer = __( 'Growth uses the annual interest figure from the latest accounts. Actual borrowing and repayments may differ.', 'council-debt-counters' );
@@ -443,8 +444,9 @@ class Shortcode_Renderer {
                 }
 
                 $name     = get_the_title( $id );
-                $interest  = (float) Custom_Fields::get_value( $id, 'interest_paid' );
-                $debt      = (float) Custom_Fields::get_value( $id, 'total_debt' );
+                $year      = CDC_Utils::current_financial_year();
+                $interest  = (float) Custom_Fields::get_value( $id, 'interest_paid', $year );
+                $debt      = (float) Custom_Fields::get_value( $id, 'total_debt', $year );
                 $permalink = get_permalink( $id );
 
                 if ( $interest > 0 ) {
@@ -490,8 +492,9 @@ class Shortcode_Renderer {
                         return '';
                 }
 
-                $message = Custom_Fields::get_value( $id, 'status_message' );
-                $type    = Custom_Fields::get_value( $id, 'status_message_type' );
+                $year    = CDC_Utils::current_financial_year();
+                $message = Custom_Fields::get_value( $id, 'status_message', $year );
+                $type    = Custom_Fields::get_value( $id, 'status_message_type', $year );
 
                 if ( ! is_string( $message ) || '' === trim( $message ) ) {
                         return '';
@@ -514,7 +517,7 @@ class Shortcode_Renderer {
                         return '';
                 }
 
-                $annual  = Custom_Fields::get_total_value( $field );
+                $annual  = Custom_Fields::get_total_value( $field, CDC_Utils::current_financial_year() );
                 $rate    = Counter_Manager::per_second_rate( $annual );
                 $current = $rate * Counter_Manager::seconds_since_fy_start();
 
@@ -612,8 +615,9 @@ class Shortcode_Renderer {
                         if ( get_post_meta( (int) $id, 'cdc_parent_council', true ) ) {
                                 continue;
                         }
-                        $total    += (float) Custom_Fields::get_value( (int) $id, 'total_debt' );
-                        $interest += (float) Custom_Fields::get_value( (int) $id, 'interest_paid' );
+                        $year  = CDC_Utils::current_financial_year();
+                        $total    += (float) Custom_Fields::get_value( (int) $id, 'total_debt', $year );
+                        $interest += (float) Custom_Fields::get_value( (int) $id, 'interest_paid', $year );
                 }
           
                 $count = count( array_filter( $posts, function( $cid ) {
@@ -706,13 +710,14 @@ class Shortcode_Renderer {
                                 continue;
                         }
                         $data = array();
-                        $debt      = (float) Custom_Fields::get_value( $id, 'total_debt' );
-                        $population = (float) Custom_Fields::get_value( $id, 'population' );
-                        $reserves  = (float) Custom_Fields::get_value( $id, 'usable_reserves' );
-                        $spending  = (float) Custom_Fields::get_value( $id, 'annual_spending' );
-                        $income    = (float) Custom_Fields::get_value( $id, 'total_income' );
-                        $deficit   = (float) Custom_Fields::get_value( $id, 'annual_deficit' );
-                        $interest  = (float) Custom_Fields::get_value( $id, 'interest_paid' );
+                        $year      = CDC_Utils::current_financial_year();
+                        $debt      = (float) Custom_Fields::get_value( $id, 'total_debt', $year );
+                        $population = (float) Custom_Fields::get_value( $id, 'population', $year );
+                        $reserves  = (float) Custom_Fields::get_value( $id, 'usable_reserves', $year );
+                        $spending  = (float) Custom_Fields::get_value( $id, 'annual_spending', $year );
+                        $income    = (float) Custom_Fields::get_value( $id, 'total_income', $year );
+                        $deficit   = (float) Custom_Fields::get_value( $id, 'annual_deficit', $year );
+                        $interest  = (float) Custom_Fields::get_value( $id, 'interest_paid', $year );
 
                         switch ( $type ) {
                                 case 'highest_debt':

--- a/tests/CustomFieldsTest.php
+++ b/tests/CustomFieldsTest.php
@@ -60,10 +60,26 @@ class FakeWpdb {
     }
 
     public function get_var($query) {
+        if (preg_match('/SELECT id FROM \w*' . Custom_Fields::TABLE_VALUES . " WHERE council_id = (\d+) AND field_id = (\d+) AND financial_year = '([^']+)'/", $query, $m)) {
+            foreach ($this->values as $row) {
+                if ($row['council_id'] == $m[1] && $row['field_id'] == $m[2] && $row['financial_year'] === $m[3]) {
+                    return $row['id'];
+                }
+            }
+            return null;
+        }
         if (preg_match('/SELECT id FROM \w*' . Custom_Fields::TABLE_VALUES . ' WHERE council_id = (\d+) AND field_id = (\d+)/', $query, $m)) {
             foreach ($this->values as $row) {
                 if ($row['council_id'] == $m[1] && $row['field_id'] == $m[2]) {
                     return $row['id'];
+                }
+            }
+            return null;
+        }
+        if (preg_match('/SELECT value FROM \w*' . Custom_Fields::TABLE_VALUES . " WHERE council_id = (\d+) AND field_id = (\d+) AND financial_year = '([^']+)'/", $query, $m)) {
+            foreach ($this->values as $row) {
+                if ($row['council_id'] == $m[1] && $row['field_id'] == $m[2] && $row['financial_year'] === $m[3]) {
+                    return $row['value'];
                 }
             }
             return null;
@@ -95,10 +111,12 @@ class CustomFieldsTest extends TestCase {
         $array = ['foo' => 'bar'];
         $object = (object)['baz' => 123];
 
-        $this->assertTrue(Custom_Fields::update_value(1, 'test_field', $array));
-        $this->assertSame($array, Custom_Fields::get_value(1, 'test_field'));
+        $year = \CouncilDebtCounters\CDC_Utils::current_financial_year();
 
-        $this->assertTrue(Custom_Fields::update_value(1, 'test_field', $object));
-        $this->assertEquals($object, Custom_Fields::get_value(1, 'test_field'));
+        $this->assertTrue(Custom_Fields::update_value(1, 'test_field', $array, $year));
+        $this->assertSame($array, Custom_Fields::get_value(1, 'test_field', $year));
+
+        $this->assertTrue(Custom_Fields::update_value(1, 'test_field', $object, $year));
+        $this->assertEquals($object, Custom_Fields::get_value(1, 'test_field', $year));
     }
 }

--- a/tests/WPDBStub.php
+++ b/tests/WPDBStub.php
@@ -27,12 +27,34 @@ class WPDBStub {
     }
 
     public function get_var($query) {
+        if (preg_match("/SELECT id FROM {$this->prefix}" . \CouncilDebtCounters\Custom_Fields::TABLE_VALUES . " WHERE council_id = (\d+) AND field_id = (\d+) AND financial_year = '([^']+)'/i", $query, $m)) {
+            $cid = (int)$m[1];
+            $fid = (int)$m[2];
+            $fy  = $m[3];
+            foreach ($this->values as $v) {
+                if ($v['council_id'] == $cid && $v['field_id'] == $fid && $v['financial_year'] === $fy) {
+                    return $v['id'];
+                }
+            }
+            return null;
+        }
         if (preg_match("/SELECT id FROM {$this->prefix}" . \CouncilDebtCounters\Custom_Fields::TABLE_VALUES . " WHERE council_id = (\d+) AND field_id = (\d+)/i", $query, $m)) {
             $cid = (int)$m[1];
             $fid = (int)$m[2];
             foreach ($this->values as $v) {
                 if ($v['council_id'] == $cid && $v['field_id'] == $fid) {
                     return $v['id'];
+                }
+            }
+            return null;
+        }
+        if (preg_match("/SELECT value FROM {$this->prefix}" . \CouncilDebtCounters\Custom_Fields::TABLE_VALUES . " WHERE council_id = (\d+) AND field_id = (\d+) AND financial_year = '([^']+)'/i", $query, $m)) {
+            $cid = (int)$m[1];
+            $fid = (int)$m[2];
+            $fy  = $m[3];
+            foreach ($this->values as $v) {
+                if ($v['council_id'] == $cid && $v['field_id'] == $fid && $v['financial_year'] === $fy) {
+                    return $v['value'];
                 }
             }
             return null;

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -23,6 +23,7 @@ global $wpdb;
 $wpdb = new WPDBStub();
 
 require_once __DIR__ . '/../includes/class-counter-manager.php';
+require_once __DIR__ . '/../includes/class-cdc-utils.php';
 require_once __DIR__ . '/../includes/class-custom-fields.php';
 
 function is_serialized($data, $strict = true) {


### PR DESCRIPTION
## Summary
- add CDC_Utils::current_financial_year helper
- extend Custom_Fields with financial year support
- update admin pages and counter logic to pass year values
- adjust DB creation and install routines for year column
- update tests for new parameters

## Testing
- `vendor/bin/phpunit`
- `vendor/bin/phpcs -q` *(fails: found sniff violations)*

------
https://chatgpt.com/codex/tasks/task_e_685b3824feb88331ab837bb7c27a8a11