### PR TITLE
Allow public access to under review councils

### DIFF
--- a/includes/class-council-post-type.php
+++ b/includes/class-council-post-type.php
@@ -40,7 +40,9 @@ class Council_Post_Type {
 
         register_post_status( 'under_review', [
             'label'                     => _x( 'Under Review', 'post', 'council-debt-counters' ),
-            'public'                    => false,
+            'public'                    => true,
+            'publicly_queryable'        => true,
+            'exclude_from_search'       => false,
             'internal'                  => false,
             'show_in_admin_all_list'    => true,
             'show_in_admin_status_list' => true,

--- a/includes/class-council-search.php
+++ b/includes/class-council-search.php
@@ -55,7 +55,7 @@ class Council_Search {
         Stats_Page::log_search( $query );
         $args = [
             'post_type'      => 'council',
-            'post_status'    => 'publish',
+            'post_status'    => [ 'publish', 'under_review' ],
             'posts_per_page' => -1,
             's'              => $query,
             'orderby'        => 'title',


### PR DESCRIPTION
## Summary
- register `under_review` status as public so individual pages remain accessible
- return `under_review` councils in search results

## Testing
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_685c107f7c648331a779b63017fc575e