### PR TITLE
Fix yearly saving and NA for total debt

### DIFF
--- a/admin/js/council-form.js
+++ b/admin/js/council-form.js
@@ -134,6 +134,8 @@
         document.querySelectorAll('.cdc-year-select').forEach(function(sel){
             sel.addEventListener('change', function(){
                 var tab = sel.getAttribute('data-tab');
+                var hidden = document.querySelector('input[name="cdc_tab_year['+tab+']"]');
+                if(hidden){ hidden.value = sel.value; }
                 var overlay = document.createElement('div');
                 overlay.id = 'cdc-year-overlay';
                 overlay.innerHTML = '<span class="spinner is-active"></span>';

--- a/admin/views/councils-page.php
+++ b/admin/views/councils-page.php
@@ -155,15 +155,15 @@ $readonly = true;
 <div class="input-group">
     <span class="input-group-text">&pound;</span>
     <input data-cdc-field="<?php echo esc_attr( $field->name ); ?>" data-initial-required="<?php echo $is_required ? '1' : '0'; ?>" type="number" step="0.01" id="cdc-field-<?php echo esc_attr( $field->id ); ?>" value="<?php echo esc_attr( $val ); ?>" class="form-control" <?php echo $readonly ? 'readonly disabled' : 'name="cdc_fields[' . esc_attr( $field->id ) . ']"'; ?> <?php echo $is_required ? 'required' : ''; ?>>
-    <?php if ( ! $readonly ) : ?>
-    <button type="button" class="btn btn-outline-secondary cdc-ask-ai" data-field="<?php echo esc_attr( $field->name ); ?>"><span class="dashicons dashicons-lightbulb me-1"></span><?php esc_html_e( 'Ask AI', 'council-debt-counters' ); ?></button>
+    <?php if ( ! $readonly && $field->name !== 'total_debt' ) : ?>
+        <button type="button" class="btn btn-outline-secondary cdc-ask-ai" data-field="<?php echo esc_attr( $field->name ); ?>"><span class="dashicons dashicons-lightbulb me-1"></span><?php esc_html_e( 'Ask AI', 'council-debt-counters' ); ?></button>
         <div class="input-group-text">
-                <div class="form-check">
-                        <input type="checkbox" class="form-check-input" id="cdc-na-<?php echo esc_attr( $field->name ); ?>" name="cdc_na[<?php echo esc_attr( $field->name ); ?>]" value="1" <?php checked( $na_val, '1' ); ?>>
-                        <label class="form-check-label" for="cdc-na-<?php echo esc_attr( $field->name ); ?>"></label>
-                </div>
+            <div class="form-check">
+                <input type="checkbox" class="form-check-input" id="cdc-na-<?php echo esc_attr( $field->name ); ?>" name="cdc_na[<?php echo esc_attr( $field->name ); ?>]" value="1" <?php checked( $na_val, '1' ); ?>>
+                <label class="form-check-label" for="cdc-na-<?php echo esc_attr( $field->name ); ?>"></label>
+            </div>
         </div>
-    <span class="input-group-text"><?php esc_html_e( 'N/A', 'council-debt-counters' ); ?></span>
+        <span class="input-group-text"><?php esc_html_e( 'N/A', 'council-debt-counters' ); ?></span>
     <?php endif; ?>
     <?php if ( $is_required ) : ?>
         <div class="invalid-feedback"><?php esc_html_e( 'Required', 'council-debt-counters' ); ?></div>
@@ -173,15 +173,15 @@ $readonly = true;
 <?php $na_val = $council_id ? get_post_meta( $council_id, 'cdc_na_' . $field->name, true ) : ''; ?>
 <div class="input-group">
     <input data-cdc-field="<?php echo esc_attr( $field->name ); ?>" data-initial-required="<?php echo $is_required ? '1' : '0'; ?>" type="<?php echo esc_attr( $input_type ); ?>" id="cdc-field-<?php echo esc_attr( $field->id ); ?>" value="<?php echo esc_attr( $val ); ?>" class="form-control" <?php echo $readonly ? 'readonly disabled' : 'name="cdc_fields[' . esc_attr( $field->id ) . ']"'; ?> <?php echo $is_required ? 'required' : ''; ?>>
-    <?php if ( ! $readonly ) : ?>
-    <button type="button" class="btn btn-outline-secondary cdc-ask-ai" data-field="<?php echo esc_attr( $field->name ); ?>"><span class="dashicons dashicons-lightbulb me-1"></span><?php esc_html_e( 'Ask AI', 'council-debt-counters' ); ?></button>
+    <?php if ( ! $readonly && $field->name !== 'total_debt' ) : ?>
+        <button type="button" class="btn btn-outline-secondary cdc-ask-ai" data-field="<?php echo esc_attr( $field->name ); ?>"><span class="dashicons dashicons-lightbulb me-1"></span><?php esc_html_e( 'Ask AI', 'council-debt-counters' ); ?></button>
         <div class="input-group-text">
                 <div class="form-check">
                         <input type="checkbox" class="form-check-input" id="cdc-na-<?php echo esc_attr( $field->name ); ?>" name="cdc_na[<?php echo esc_attr( $field->name ); ?>]" value="1" <?php checked( $na_val, '1' ); ?>>
                         <label class="form-check-label" for="cdc-na-<?php echo esc_attr( $field->name ); ?>"></label>
                 </div>
         </div>
-    <span class="input-group-text"><?php esc_html_e( 'N/A', 'council-debt-counters' ); ?></span>
+        <span class="input-group-text"><?php esc_html_e( 'N/A', 'council-debt-counters' ); ?></span>
     <?php endif; ?>
     <?php if ( $is_required ) : ?>
         <div class="invalid-feedback"><?php esc_html_e( 'Required', 'council-debt-counters' ); ?></div>

--- a/admin/views/councils-page.php
+++ b/admin/views/councils-page.php
@@ -156,9 +156,6 @@ $readonly = true;
     <span class="input-group-text">&pound;</span>
     <input data-cdc-field="<?php echo esc_attr( $field->name ); ?>" data-initial-required="<?php echo $is_required ? '1' : '0'; ?>" type="number" step="0.01" id="cdc-field-<?php echo esc_attr( $field->id ); ?>" value="<?php echo esc_attr( $val ); ?>" class="form-control" <?php echo $readonly ? 'readonly disabled' : 'name="cdc_fields[' . esc_attr( $field->id ) . ']"'; ?> <?php echo $is_required ? 'required' : ''; ?>>
     <?php if ( ! $readonly ) : ?>
-    <?php if ( ! $readonly ) : ?>
-    <?php if ( ! $readonly ) : ?>
-    <?php if ( ! $readonly ) : ?>
     <button type="button" class="btn btn-outline-secondary cdc-ask-ai" data-field="<?php echo esc_attr( $field->name ); ?>"><span class="dashicons dashicons-lightbulb me-1"></span><?php esc_html_e( 'Ask AI', 'council-debt-counters' ); ?></button>
         <div class="input-group-text">
                 <div class="form-check">
@@ -167,9 +164,6 @@ $readonly = true;
                 </div>
         </div>
     <span class="input-group-text"><?php esc_html_e( 'N/A', 'council-debt-counters' ); ?></span>
-    <?php endif; ?>
-    <?php endif; ?>
-    <?php endif; ?>
     <?php endif; ?>
     <?php if ( $is_required ) : ?>
         <div class="invalid-feedback"><?php esc_html_e( 'Required', 'council-debt-counters' ); ?></div>

--- a/admin/views/councils-page.php
+++ b/admin/views/councils-page.php
@@ -155,14 +155,22 @@ $readonly = true;
 <div class="input-group">
     <span class="input-group-text">&pound;</span>
     <input data-cdc-field="<?php echo esc_attr( $field->name ); ?>" data-initial-required="<?php echo $is_required ? '1' : '0'; ?>" type="number" step="0.01" id="cdc-field-<?php echo esc_attr( $field->id ); ?>" value="<?php echo esc_attr( $val ); ?>" class="form-control" <?php echo $readonly ? 'readonly disabled' : 'name="cdc_fields[' . esc_attr( $field->id ) . ']"'; ?> <?php echo $is_required ? 'required' : ''; ?>>
+    <?php if ( ! $readonly ) : ?>
+    <?php if ( ! $readonly ) : ?>
+    <?php if ( ! $readonly ) : ?>
+    <?php if ( ! $readonly ) : ?>
     <button type="button" class="btn btn-outline-secondary cdc-ask-ai" data-field="<?php echo esc_attr( $field->name ); ?>"><span class="dashicons dashicons-lightbulb me-1"></span><?php esc_html_e( 'Ask AI', 'council-debt-counters' ); ?></button>
-	<div class="input-group-text">
-		<div class="form-check">
-			<input type="checkbox" class="form-check-input" id="cdc-na-<?php echo esc_attr( $field->name ); ?>" name="cdc_na[<?php echo esc_attr( $field->name ); ?>]" value="1" <?php checked( $na_val, '1' ); ?>>
-			<label class="form-check-label" for="cdc-na-<?php echo esc_attr( $field->name ); ?>"></label>
-		</div>
-	</div>
+        <div class="input-group-text">
+                <div class="form-check">
+                        <input type="checkbox" class="form-check-input" id="cdc-na-<?php echo esc_attr( $field->name ); ?>" name="cdc_na[<?php echo esc_attr( $field->name ); ?>]" value="1" <?php checked( $na_val, '1' ); ?>>
+                        <label class="form-check-label" for="cdc-na-<?php echo esc_attr( $field->name ); ?>"></label>
+                </div>
+        </div>
     <span class="input-group-text"><?php esc_html_e( 'N/A', 'council-debt-counters' ); ?></span>
+    <?php endif; ?>
+    <?php endif; ?>
+    <?php endif; ?>
+    <?php endif; ?>
     <?php if ( $is_required ) : ?>
         <div class="invalid-feedback"><?php esc_html_e( 'Required', 'council-debt-counters' ); ?></div>
     <?php endif; ?>
@@ -171,14 +179,16 @@ $readonly = true;
 <?php $na_val = $council_id ? get_post_meta( $council_id, 'cdc_na_' . $field->name, true ) : ''; ?>
 <div class="input-group">
     <input data-cdc-field="<?php echo esc_attr( $field->name ); ?>" data-initial-required="<?php echo $is_required ? '1' : '0'; ?>" type="<?php echo esc_attr( $input_type ); ?>" id="cdc-field-<?php echo esc_attr( $field->id ); ?>" value="<?php echo esc_attr( $val ); ?>" class="form-control" <?php echo $readonly ? 'readonly disabled' : 'name="cdc_fields[' . esc_attr( $field->id ) . ']"'; ?> <?php echo $is_required ? 'required' : ''; ?>>
+    <?php if ( ! $readonly ) : ?>
     <button type="button" class="btn btn-outline-secondary cdc-ask-ai" data-field="<?php echo esc_attr( $field->name ); ?>"><span class="dashicons dashicons-lightbulb me-1"></span><?php esc_html_e( 'Ask AI', 'council-debt-counters' ); ?></button>
-	<div class="input-group-text">
-		<div class="form-check">
-			<input type="checkbox" class="form-check-input" id="cdc-na-<?php echo esc_attr( $field->name ); ?>" name="cdc_na[<?php echo esc_attr( $field->name ); ?>]" value="1" <?php checked( $na_val, '1' ); ?>>
-			<label class="form-check-label" for="cdc-na-<?php echo esc_attr( $field->name ); ?>"></label>
-		</div>
-	</div>
+        <div class="input-group-text">
+                <div class="form-check">
+                        <input type="checkbox" class="form-check-input" id="cdc-na-<?php echo esc_attr( $field->name ); ?>" name="cdc_na[<?php echo esc_attr( $field->name ); ?>]" value="1" <?php checked( $na_val, '1' ); ?>>
+                        <label class="form-check-label" for="cdc-na-<?php echo esc_attr( $field->name ); ?>"></label>
+                </div>
+        </div>
     <span class="input-group-text"><?php esc_html_e( 'N/A', 'council-debt-counters' ); ?></span>
+    <?php endif; ?>
     <?php if ( $is_required ) : ?>
         <div class="invalid-feedback"><?php esc_html_e( 'Required', 'council-debt-counters' ); ?></div>
     <?php endif; ?>
@@ -273,6 +283,7 @@ $readonly = true;
                                                                         <option value="<?php echo esc_attr( $y ); ?>" <?php selected( \CouncilDebtCounters\CDC_Utils::current_financial_year(), $y ); ?>><?php echo esc_html( $y ); ?></option>
                                                                 <?php endforeach; ?>
                                                         </select>
+                                                        <input type="hidden" name="cdc_tab_year[<?php echo esc_attr( $tab_key ); ?>]" value="<?php echo esc_attr( \CouncilDebtCounters\CDC_Utils::current_financial_year() ); ?>" class="cdc-selected-year">
                                                 </div>
                                                 <div class="form-check">
                                                         <input class="form-check-input" type="checkbox" id="cdc-na-tab-<?php echo esc_attr( $tab_key ); ?>" name="cdc_na_tab[<?php echo esc_attr( $tab_key ); ?>]" value="1" <?php checked( $na_tab_val, '1' ); ?>>
@@ -300,14 +311,16 @@ $readonly = true;
 <div class="input-group">
     <span class="input-group-text">&pound;</span>
     <input data-cdc-field="<?php echo esc_attr( $field->name ); ?>" type="number" step="0.01" id="cdc-field-<?php echo esc_attr( $field->id ); ?>" value="<?php echo esc_attr( $val ); ?>" class="form-control" <?php echo $readonly ? 'readonly disabled' : 'name="cdc_fields[' . esc_attr( $field->id ) . ']"'; ?> <?php echo $is_required ? 'required' : ''; ?>>
+    <?php if ( ! $readonly ) : ?>
     <button type="button" class="btn btn-outline-secondary cdc-ask-ai" data-field="<?php echo esc_attr( $field->name ); ?>"><span class="dashicons dashicons-lightbulb me-1"></span><?php esc_html_e( 'Ask AI', 'council-debt-counters' ); ?></button>
-	<div class="input-group-text">
-		<div class="form-check">
-			<input type="checkbox" class="form-check-input" id="cdc-na-<?php echo esc_attr( $field->name ); ?>" name="cdc_na[<?php echo esc_attr( $field->name ); ?>]" value="1" <?php checked( $na_val, '1' ); ?>>
-			<label class="form-check-label" for="cdc-na-<?php echo esc_attr( $field->name ); ?>"></label>
-		</div>
-	</div>
+        <div class="input-group-text">
+                <div class="form-check">
+                        <input type="checkbox" class="form-check-input" id="cdc-na-<?php echo esc_attr( $field->name ); ?>" name="cdc_na[<?php echo esc_attr( $field->name ); ?>]" value="1" <?php checked( $na_val, '1' ); ?>>
+                        <label class="form-check-label" for="cdc-na-<?php echo esc_attr( $field->name ); ?>"></label>
+                </div>
+        </div>
     <span class="input-group-text"><?php esc_html_e( 'N/A', 'council-debt-counters' ); ?></span>
+    <?php endif; ?>
     <?php if ( $is_required ) : ?>
         <div class="invalid-feedback"><?php esc_html_e( 'Required', 'council-debt-counters' ); ?></div>
     <?php endif; ?>

--- a/admin/views/councils-page.php
+++ b/admin/views/councils-page.php
@@ -1,6 +1,6 @@
 <?php
 if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+        exit;
 }
 
 
@@ -8,10 +8,10 @@ $req_action = isset( $_GET['action'] ) ? sanitize_text_field( $_GET['action'] ) 
 $council_id = isset( $_GET['post'] ) ? intval( $_GET['post'] ) : 0;
 
 if ( 'delete' === $req_action && $council_id ) {
-		check_admin_referer( 'cdc_delete_council_' . $council_id );
-		wp_delete_post( $council_id, true );
-		echo '<div class="alert alert-success"><p>' . esc_html__( 'Council deleted.', 'council-debt-counters' ) . '</p></div>';
-		$req_action = '';
+                check_admin_referer( 'cdc_delete_council_' . $council_id );
+                wp_delete_post( $council_id, true );
+                echo '<div class="alert alert-success"><p>' . esc_html__( 'Council deleted.', 'council-debt-counters' ) . '</p></div>';
+                $req_action = '';
 }
 
 if ( 'edit' === $req_action ) {
@@ -48,10 +48,10 @@ if ( 'edit' === $req_action ) {
         $fields  = \CouncilDebtCounters\Custom_Fields::get_fields();
         $enabled = (array) get_option( 'cdc_enabled_counters', array() );
         $groups  = array( 'general' => array() );
-	foreach ( $enabled as $e ) {
-		$groups[ $e ] = array();
-	}
-	$docs_field = null;
+        foreach ( $enabled as $e ) {
+                $groups[ $e ] = array();
+        }
+        $docs_field = null;
         foreach ( $fields as $field ) {
                 if ( 'statement_of_accounts' === $field->name ) {
                         $docs_field = $field;
@@ -62,32 +62,32 @@ if ( 'edit' === $req_action ) {
                 } else {
                         $groups['general'][] = $field; }
         }
-		$docs = $council_id ? \CouncilDebtCounters\Docs_Manager::list_documents( $council_id ) : array();
-	?>
-	<form method="post" enctype="multipart/form-data" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
-		<input type="hidden" name="action" value="cdc_save_council">
-		<?php wp_nonce_field( 'cdc_save_council' ); ?>
-				<input type="hidden" name="post_id" value="<?php echo esc_attr( $council_id ); ?>">
-		<ul class="nav nav-tabs" role="tablist">
-			<li class="nav-item"><button class="nav-link active" data-bs-toggle="tab" data-bs-target="#tab-general" type="button" role="tab"><?php esc_html_e( 'General', 'council-debt-counters' ); ?></button></li>
-			<?php
-			foreach ( $enabled as $tab_key ) :
-				if ( empty( $groups[ $tab_key ] ) ) {
-								continue;}
-				?>
-								<li class="nav-item"><button class="nav-link" data-bs-toggle="tab" data-bs-target="#tab-<?php echo esc_attr( $tab_key ); ?>" type="button" role="tab"><?php echo esc_html( ucfirst( $tab_key ) ); ?></button></li>
-						<?php endforeach; ?>
+                $docs = $council_id ? \CouncilDebtCounters\Docs_Manager::list_documents( $council_id ) : array();
+        ?>
+        <form method="post" enctype="multipart/form-data" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
+                <input type="hidden" name="action" value="cdc_save_council">
+                <?php wp_nonce_field( 'cdc_save_council' ); ?>
+                                <input type="hidden" name="post_id" value="<?php echo esc_attr( $council_id ); ?>">
+                <ul class="nav nav-tabs" role="tablist">
+                        <li class="nav-item"><button class="nav-link active" data-bs-toggle="tab" data-bs-target="#tab-general" type="button" role="tab"><?php esc_html_e( 'General', 'council-debt-counters' ); ?></button></li>
+                        <?php
+                        foreach ( $enabled as $tab_key ) :
+                                if ( empty( $groups[ $tab_key ] ) ) {
+                                                                continue;}
+                                ?>
+                                                                <li class="nav-item"><button class="nav-link" data-bs-toggle="tab" data-bs-target="#tab-<?php echo esc_attr( $tab_key ); ?>" type="button" role="tab"><?php echo esc_html( ucfirst( $tab_key ) ); ?></button></li>
+                                                <?php endforeach; ?>
 <?php if ( $docs_field ) : ?>
 <li class="nav-item"><button class="nav-link" data-bs-toggle="tab" data-bs-target="#tab-docs" type="button" role="tab"><?php esc_html_e( 'Statement of Accounts', 'council-debt-counters' ); ?></button></li>
 <?php endif; ?>
 <?php if ( $council_id ) : ?>
-				<!-- Whistleblower reports moved to dedicated admin page -->
-		</ul>
-		<div class="tab-content pt-3">
-			<div class="tab-pane fade show active" id="tab-general" role="tabpanel">
-				<table class="form-table" role="presentation">
-				<?php
-				$council_types     = array( 'Unitary', 'County', 'District', 'Metropolitan Borough', 'London Borough', 'Parish', 'Town', 'Combined Authority' );
+                                <!-- Whistleblower reports moved to dedicated admin page -->
+                </ul>
+                <div class="tab-content pt-3">
+                        <div class="tab-pane fade show active" id="tab-general" role="tabpanel">
+                                <table class="form-table" role="presentation">
+                                <?php
+                                $council_types     = array( 'Unitary', 'County', 'District', 'Metropolitan Borough', 'London Borough', 'Parish', 'Town', 'Combined Authority' );
 $council_locations = array( 'England', 'Wales', 'Scotland', 'Northern Ireland' );
 $no_accounts       = $council_id ? get_post_meta( $council_id, 'cdc_no_accounts', true ) : '';
 foreach ( $groups['general'] as $field ) :
@@ -105,29 +105,29 @@ if ( 'status_message_type' === $field->name && $no_accounts ) {
 $val      = 'danger';
 $readonly = true;
 }
-					?>
-					<tr>
-						<th scope="row"><label for="cdc-field-<?php echo esc_attr( $field->id ); ?>"><?php echo esc_html( $field->label ); ?>
-					<?php
+                                        ?>
+                                        <tr>
+                                                <th scope="row"><label for="cdc-field-<?php echo esc_attr( $field->id ); ?>"><?php echo esc_html( $field->label ); ?>
+                                        <?php
                                                                        if ( $is_required ) {
                                                                                echo ' <span class="text-danger cdc-required-indicator">*</span>';}
-					?>
-						</label></th>
-						<td>
-										<?php if ( 'council_type' === $field->name ) : ?>
+                                        ?>
+                                                </label></th>
+                                                <td>
+                                                                                <?php if ( 'council_type' === $field->name ) : ?>
                                                                        <select id="cdc-field-<?php echo esc_attr( $field->id ); ?>" name="cdc_fields[<?php echo esc_attr( $field->id ); ?>]" class="form-select" <?php echo $is_required ? 'required' : ''; ?> <?php echo $readonly ? 'disabled' : ''; ?>>
-											<?php foreach ( $council_types as $t ) : ?>
-										<option value="<?php echo esc_attr( $t ); ?>" <?php selected( $val, $t ); ?>><?php echo esc_html( $t ); ?></option>
-									<?php endforeach; ?>
+                                                                                        <?php foreach ( $council_types as $t ) : ?>
+                                                                                <option value="<?php echo esc_attr( $t ); ?>" <?php selected( $val, $t ); ?>><?php echo esc_html( $t ); ?></option>
+                                                                        <?php endforeach; ?>
                                                                 </select>
                                                                 <?php if ( $is_required ) : ?>
                                                                         <div class="invalid-feedback"><?php esc_html_e( 'Required', 'council-debt-counters' ); ?></div>
                                                                 <?php endif; ?>
 <?php elseif ( 'council_location' === $field->name ) : ?>
                                                                        <select id="cdc-field-<?php echo esc_attr( $field->id ); ?>" name="cdc_fields[<?php echo esc_attr( $field->id ); ?>]" class="form-select" <?php echo $is_required ? 'required' : ''; ?> <?php echo $readonly ? 'disabled' : ''; ?>>
-															<?php foreach ( $council_locations as $t ) : ?>
-										<option value="<?php echo esc_attr( $t ); ?>" <?php selected( $val, $t ); ?>><?php echo esc_html( $t ); ?></option>
-									<?php endforeach; ?>
+                                                                                                                        <?php foreach ( $council_locations as $t ) : ?>
+                                                                                <option value="<?php echo esc_attr( $t ); ?>" <?php selected( $val, $t ); ?>><?php echo esc_html( $t ); ?></option>
+                                                                        <?php endforeach; ?>
                                                                 </select>
                                                                 <?php if ( $is_required ) : ?>
                                                                         <div class="invalid-feedback"><?php esc_html_e( 'Required', 'council-debt-counters' ); ?></div>
@@ -156,14 +156,7 @@ $readonly = true;
     <span class="input-group-text">&pound;</span>
     <input data-cdc-field="<?php echo esc_attr( $field->name ); ?>" data-initial-required="<?php echo $is_required ? '1' : '0'; ?>" type="number" step="0.01" id="cdc-field-<?php echo esc_attr( $field->id ); ?>" value="<?php echo esc_attr( $val ); ?>" class="form-control" <?php echo $readonly ? 'readonly disabled' : 'name="cdc_fields[' . esc_attr( $field->id ) . ']"'; ?> <?php echo $is_required ? 'required' : ''; ?>>
     <?php if ( ! $readonly && $field->name !== 'total_debt' ) : ?>
-        <button type="button" class="btn btn-outline-secondary cdc-ask-ai" data-field="<?php echo esc_attr( $field->name ); ?>"><span class="dashicons dashicons-lightbulb me-1"></span><?php esc_html_e( 'Ask AI', 'council-debt-counters' ); ?></button>
-        <div class="input-group-text">
-            <div class="form-check">
-                <input type="checkbox" class="form-check-input" id="cdc-na-<?php echo esc_attr( $field->name ); ?>" name="cdc_na[<?php echo esc_attr( $field->name ); ?>]" value="1" <?php checked( $na_val, '1' ); ?>>
-                <label class="form-check-label" for="cdc-na-<?php echo esc_attr( $field->name ); ?>"></label>
-            </div>
-        </div>
-        <span class="input-group-text"><?php esc_html_e( 'N/A', 'council-debt-counters' ); ?></span>
+        <!-- Ask AI and N/A controls excluded for total_debt -->
     <?php endif; ?>
     <?php if ( $is_required ) : ?>
         <div class="invalid-feedback"><?php esc_html_e( 'Required', 'council-debt-counters' ); ?></div>
@@ -260,15 +253,15 @@ $readonly = true;
 </div>
 <?php endif; ?>
 <?php
-			foreach ( $enabled as $tab_key ) :
-				$tab = $tab_key; // using tab key directly, no get_tab_by_key method exists
-				if ( empty( $groups[ $tab_key ] ) ) {
-					continue;
-				}
-				$tab_fields = $groups[ $tab_key ] ?? array();
-				$na_tab_val = $council_id ? get_post_meta( $council_id, 'cdc_na_tab_' . $tab_key, true ) : '';
-				?>
-				<div class="tab-pane" id="tab-<?php echo esc_attr( $tab_key ); ?>" role="tabpanel">
+                        foreach ( $enabled as $tab_key ) :
+                                $tab = $tab_key; // using tab key directly, no get_tab_by_key method exists
+                                if ( empty( $groups[ $tab_key ] ) ) {
+                                        continue;
+                                }
+                                $tab_fields = $groups[ $tab_key ] ?? array();
+                                $na_tab_val = $council_id ? get_post_meta( $council_id, 'cdc_na_tab_' . $tab_key, true ) : '';
+                                ?>
+                                <div class="tab-pane" id="tab-<?php echo esc_attr( $tab_key ); ?>" role="tabpanel">
                                         <div class="d-flex justify-content-between align-items-center mb-2">
                                                 <div>
                                                         <label for="cdc-year-<?php echo esc_attr( $tab_key ); ?>" class="form-label me-2"><?php esc_html_e( 'Financial Year', 'council-debt-counters' ); ?></label>
@@ -285,27 +278,27 @@ $readonly = true;
                                                 </div>
                                         </div>
                                         <table class="form-table">
-						<tbody>
-							<?php
-							foreach ( $tab_fields as $field ) :
+                                                <tbody>
+                                                        <?php
+                                                        foreach ( $tab_fields as $field ) :
                                                                 $val         = $council_id ? \CouncilDebtCounters\Custom_Fields::get_value( $council_id, $field->name, \CouncilDebtCounters\CDC_Utils::current_financial_year() ) : '';
-								$input_type  = 'text' === $field->type ? 'text' : 'number';
-								$is_required = (bool) $field->required;
-								$readonly    = in_array( $field->name, \CouncilDebtCounters\Custom_Fields::READONLY_FIELDS, true );
-								?>
-								<tr>
-									<th scope="row"><label for="cdc-field-<?php echo esc_attr( $field->id ); ?>"><?php echo esc_html( $field->label ); ?>
-										<?php if ( $is_required ) : ?>
-											<span class="cdc-required-indicator text-danger">*</span>
-										<?php endif; ?>
-									</label></th>
-									<td>
-										<?php if ( 'money' === $field->type ) : ?>
-											<?php $na_val = $council_id ? get_post_meta( $council_id, 'cdc_na_' . $field->name, true ) : ''; ?>
+                                                                $input_type  = 'text' === $field->type ? 'text' : 'number';
+                                                                $is_required = (bool) $field->required;
+                                                                $readonly    = in_array( $field->name, \CouncilDebtCounters\Custom_Fields::READONLY_FIELDS, true );
+                                                                ?>
+                                                                <tr>
+                                                                        <th scope="row"><label for="cdc-field-<?php echo esc_attr( $field->id ); ?>"><?php echo esc_html( $field->label ); ?>
+                                                                                <?php if ( $is_required ) : ?>
+                                                                                        <span class="cdc-required-indicator text-danger">*</span>
+                                                                                <?php endif; ?>
+                                                                        </label></th>
+                                                                        <td>
+                                                                                <?php if ( 'money' === $field->type ) : ?>
+                                                                                        <?php $na_val = $council_id ? get_post_meta( $council_id, 'cdc_na_' . $field->name, true ) : ''; ?>
 <div class="input-group">
     <span class="input-group-text">&pound;</span>
     <input data-cdc-field="<?php echo esc_attr( $field->name ); ?>" type="number" step="0.01" id="cdc-field-<?php echo esc_attr( $field->id ); ?>" value="<?php echo esc_attr( $val ); ?>" class="form-control" <?php echo $readonly ? 'readonly disabled' : 'name="cdc_fields[' . esc_attr( $field->id ) . ']"'; ?> <?php echo $is_required ? 'required' : ''; ?>>
-    <?php if ( ! $readonly ) : ?>
+    <?php if ( ! $readonly && $field->name !== 'total_debt' ) : ?>
     <button type="button" class="btn btn-outline-secondary cdc-ask-ai" data-field="<?php echo esc_attr( $field->name ); ?>"><span class="dashicons dashicons-lightbulb me-1"></span><?php esc_html_e( 'Ask AI', 'council-debt-counters' ); ?></button>
         <div class="input-group-text">
                 <div class="form-check">
@@ -319,41 +312,41 @@ $readonly = true;
         <div class="invalid-feedback"><?php esc_html_e( 'Required', 'council-debt-counters' ); ?></div>
     <?php endif; ?>
 </div>
-										<?php else : ?>
-											<?php $na_val = $council_id ? get_post_meta( $council_id, 'cdc_na_' . $field->name, true ) : ''; ?>
+                                                                                <?php else : ?>
+                                                                                        <?php $na_val = $council_id ? get_post_meta( $council_id, 'cdc_na_' . $field->name, true ) : ''; ?>
 <div class="input-group">
     <input data-cdc-field="<?php echo esc_attr( $field->name ); ?>" type="<?php echo esc_attr( $input_type ); ?>" id="cdc-field-<?php echo esc_attr( $field->id ); ?>" value="<?php echo esc_attr( $val ); ?>" class="form-control" <?php echo $readonly ? 'readonly disabled' : 'name="cdc_fields[' . esc_attr( $field->id ) . ']"'; ?> <?php echo $is_required ? 'required' : ''; ?>>
     <button type="button" class="btn btn-outline-secondary cdc-ask-ai" data-field="<?php echo esc_attr( $field->name ); ?>"><span class="dashicons dashicons-lightbulb me-1"></span><?php esc_html_e( 'Ask AI', 'council-debt-counters' ); ?></button>
-	<div class="input-group-text">
-		<div class="form-check">
-			<input type="checkbox" class="form-check-input" id="cdc-na-<?php echo esc_attr( $field->name ); ?>" name="cdc_na[<?php echo esc_attr( $field->name ); ?>]" value="1" <?php checked( $na_val, '1' ); ?>>
-			<label class="form-check-label" for="cdc-na-<?php echo esc_attr( $field->name ); ?>"></label>
-		</div>
-	</div>
+        <div class="input-group-text">
+                <div class="form-check">
+                        <input type="checkbox" class="form-check-input" id="cdc-na-<?php echo esc_attr( $field->name ); ?>" name="cdc_na[<?php echo esc_attr( $field->name ); ?>]" value="1" <?php checked( $na_val, '1' ); ?>>
+                        <label class="form-check-label" for="cdc-na-<?php echo esc_attr( $field->name ); ?>"></label>
+                </div>
+        </div>
     <span class="input-group-text"><?php esc_html_e( 'N/A', 'council-debt-counters' ); ?></span>
     <?php if ( $is_required ) : ?>
         <div class="invalid-feedback"><?php esc_html_e( 'Required', 'council-debt-counters' ); ?></div>
     <?php endif; ?>
 </div>
-										<?php endif; ?>
-										<?php if ( 'council_name' !== $field->name ) : ?>
-											<div class="cdc-ai-source mt-1"></div>
-										<?php endif; ?>
-									</td>
-								</tr>
-							<?php endforeach; ?>
-						</tbody>
-					</table>
-				</div>
-				<?php
-			endforeach;
-			?>
-			<?php if ( $docs_field ) : ?>
-			<div class="tab-pane fade" id="tab-docs" role="tabpanel">
-				<table class="form-table" role="presentation">
-					<tr>
-						<th scope="row"><label for="cdc-soa"><?php echo esc_html( $docs_field->label ); ?></label></th>
-						<td>
+                                                                                <?php endif; ?>
+                                                                                <?php if ( 'council_name' !== $field->name ) : ?>
+                                                                                        <div class="cdc-ai-source mt-1"></div>
+                                                                                <?php endif; ?>
+                                                                        </td>
+                                                                </tr>
+                                                        <?php endforeach; ?>
+                                                </tbody>
+                                        </table>
+                                </div>
+                                <?php
+                        endforeach;
+                        ?>
+                        <?php if ( $docs_field ) : ?>
+                        <div class="tab-pane fade" id="tab-docs" role="tabpanel">
+                                <table class="form-table" role="presentation">
+                                        <tr>
+                                                <th scope="row"><label for="cdc-soa"><?php echo esc_html( $docs_field->label ); ?></label></th>
+                                                <td>
                                                <?php $val = $council_id ? \CouncilDebtCounters\Custom_Fields::get_value( $council_id, 'statement_of_accounts', \CouncilDebtCounters\CDC_Utils::current_financial_year() ) : ''; ?>
 <?php if ( $val ) : ?>
         <p><a href="<?php echo esc_url( plugins_url( 'docs/' . $val, dirname( __DIR__, 2 ) . '/council-debt-counters.php' ) ); ?>" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'View selected statement', 'council-debt-counters' ); ?></a></p>
@@ -378,7 +371,7 @@ $readonly = true;
         </p>
                                                         <?php $orphans = \CouncilDebtCounters\Docs_Manager::list_orphan_documents(); ?>
                                                         <?php if ( ! empty( $orphans ) ) : ?>
-								<p class="description mt-2"><?php esc_html_e( 'Or attach an existing document', 'council-debt-counters' ); ?></p>
+                                                                <p class="description mt-2"><?php esc_html_e( 'Or attach an existing document', 'council-debt-counters' ); ?></p>
                                                                 <select name="statement_of_accounts_existing">
                                                                         <option value=""><?php esc_html_e( 'Select document', 'council-debt-counters' ); ?></option>
                                                                         <?php foreach ( $orphans as $doc ) : ?>
@@ -394,43 +387,43 @@ $readonly = true;
                                                 </td>
                                         </tr>
                                 </table>
-				<?php if ( ! empty( $docs ) ) : ?>
+                                <?php if ( ! empty( $docs ) ) : ?>
                                 <h2><?php esc_html_e( 'Uploaded Statements', 'council-debt-counters' ); ?></h2>
                                 <table id="cdc-docs-table" class="widefat">
-					<thead>
-						<tr>
-							<th><?php esc_html_e( 'File', 'council-debt-counters' ); ?></th>
-							<th><?php esc_html_e( 'Year', 'council-debt-counters' ); ?></th>
-							<th><?php esc_html_e( 'Type', 'council-debt-counters' ); ?></th>
-							<th><?php esc_html_e( 'Actions', 'council-debt-counters' ); ?></th>
-						</tr>
-					</thead>
-					<tbody>
-					<?php foreach ( $docs as $d ) : ?>
-						<tr>
-							<td><?php echo esc_html( $d->filename ); ?></td>
-							<td>
-								<select name="docs[<?php echo esc_attr( $d->id ); ?>][financial_year]">
+                                        <thead>
+                                                <tr>
+                                                        <th><?php esc_html_e( 'File', 'council-debt-counters' ); ?></th>
+                                                        <th><?php esc_html_e( 'Year', 'council-debt-counters' ); ?></th>
+                                                        <th><?php esc_html_e( 'Type', 'council-debt-counters' ); ?></th>
+                                                        <th><?php esc_html_e( 'Actions', 'council-debt-counters' ); ?></th>
+                                                </tr>
+                                        </thead>
+                                        <tbody>
+                                        <?php foreach ( $docs as $d ) : ?>
+                                                <tr>
+                                                        <td><?php echo esc_html( $d->filename ); ?></td>
+                                                        <td>
+                                                                <select name="docs[<?php echo esc_attr( $d->id ); ?>][financial_year]">
                                                                     <?php foreach ( \CouncilDebtCounters\CDC_Utils::council_years( $council_id ) as $y ) : ?>
                                                                         <option value="<?php echo esc_attr( $y ); ?>" <?php selected( $d->financial_year, $y ); ?>><?php echo esc_html( $y ); ?></option>
                                                                     <?php endforeach; ?>
-								</select>
-							</td>
-							<td>
+                                                                </select>
+                                                        </td>
+                                                        <td>
                                                                 <select name="docs[<?php echo esc_attr( $d->id ); ?>][doc_type]">
                                                                         <option value="draft_statement_of_accounts" <?php selected( $d->doc_type, 'draft_statement_of_accounts' ); ?>><?php esc_html_e( 'Draft', 'council-debt-counters' ); ?></option>
                                                                         <option value="audited_statement_of_accounts" <?php selected( $d->doc_type, 'audited_statement_of_accounts' ); ?>><?php esc_html_e( 'Audited', 'council-debt-counters' ); ?></option>
                                                                 </select>
-							</td>
-							<td>
-								<button type="button" value="<?php echo esc_attr( $d->id ); ?>" class="button cdc-extract-ai"><span class="dashicons dashicons-lightbulb"></span> <?php esc_html_e( 'Extract Figures', 'council-debt-counters' ); ?></button>
+                                                        </td>
+                                                        <td>
+                                                                <button type="button" value="<?php echo esc_attr( $d->id ); ?>" class="button cdc-extract-ai"><span class="dashicons dashicons-lightbulb"></span> <?php esc_html_e( 'Extract Figures', 'council-debt-counters' ); ?></button>
 
-								<button type="submit" name="update_doc" value="<?php echo esc_attr( $d->id ); ?>" class="button button-secondary"><?php esc_html_e( 'Update', 'council-debt-counters' ); ?></button>
-								<button type="submit" name="delete_doc" value="<?php echo esc_attr( $d->id ); ?>" class="button button-link-delete" onclick="return confirm('<?php esc_attr_e( 'Delete this document?', 'council-debt-counters' ); ?>');"><?php esc_html_e( 'Delete', 'council-debt-counters' ); ?></button>
-							</td>
-						</tr>
-					<?php endforeach; ?>
-					</tbody>
+                                                                <button type="submit" name="update_doc" value="<?php echo esc_attr( $d->id ); ?>" class="button button-secondary"><?php esc_html_e( 'Update', 'council-debt-counters' ); ?></button>
+                                                                <button type="submit" name="delete_doc" value="<?php echo esc_attr( $d->id ); ?>" class="button button-link-delete" onclick="return confirm('<?php esc_attr_e( 'Delete this document?', 'council-debt-counters' ); ?>');"><?php esc_html_e( 'Delete', 'council-debt-counters' ); ?></button>
+                                                        </td>
+                                                </tr>
+                                        <?php endforeach; ?>
+                                        </tbody>
                                 </table>
                         </div>
                         <?php endif; ?>
@@ -439,11 +432,11 @@ $readonly = true;
                 </div>
                 <?php endif; ?>
                 <?php submit_button( __( 'Save Council', 'council-debt-counters' ) ); ?>
-	</form>
+        </form>
 </div>
 <?php endif; ?>
 <?php
-	return;
+        return;
 }
 
 $status_param   = isset( $_GET['status'] ) ? sanitize_key( $_GET['status'] ) : 'publish';
@@ -458,30 +451,30 @@ $table->prepare_items();
 $counts = wp_count_posts( 'council' );
 ?>
 <div class="wrap">
-	<h1><?php esc_html_e( 'Councils', 'council-debt-counters' ); ?></h1>
-	<a href="<?php echo esc_url( admin_url( 'admin.php?page=cdc-manage-councils&action=edit' ) ); ?>" class="page-title-action"><?php esc_html_e( 'Add New', 'council-debt-counters' ); ?></a>
-	<ul class="subsubsub">
-		<?php
-		$statuses = [
-			'publish'      => __( 'Active', 'council-debt-counters' ),
-			'draft'        => __( 'Draft', 'council-debt-counters' ),
-			'under_review' => __( 'Under Review', 'council-debt-counters' ),
-		];
-		$links = [];
-		foreach ( $statuses as $status => $label ) {
-			$url   = admin_url( 'admin.php?page=cdc-manage-councils&status=' . $status );
-			$count = $counts->$status ?? 0;
-			$class = ( $status_param === $status ) ? 'current' : '';
-			$links[] = sprintf( '<li><a href="%s" class="%s">%s <span class="count">(%d)</span></a></li>', esc_url( $url ), esc_attr( $class ), esc_html( $label ), intval( $count ) );
-		}
-		echo implode( ' | ', $links );
-		?>
-	</ul>
-	<form method="post">
-		<?php
-		$table->search_box( __( 'Search Councils', 'council-debt-counters' ), 'council-search' );
-		$table->display();
-		?>
-	</form>
+        <h1><?php esc_html_e( 'Councils', 'council-debt-counters' ); ?></h1>
+        <a href="<?php echo esc_url( admin_url( 'admin.php?page=cdc-manage-councils&action=edit' ) ); ?>" class="page-title-action"><?php esc_html_e( 'Add New', 'council-debt-counters' ); ?></a>
+        <ul class="subsubsub">
+                <?php
+                $statuses = [
+                        'publish'      => __( 'Active', 'council-debt-counters' ),
+                        'draft'        => __( 'Draft', 'council-debt-counters' ),
+                        'under_review' => __( 'Under Review', 'council-debt-counters' ),
+                ];
+                $links = [];
+                foreach ( $statuses as $status => $label ) {
+                        $url   = admin_url( 'admin.php?page=cdc-manage-councils&status=' . $status );
+                        $count = $counts->$status ?? 0;
+                        $class = ( $status_param === $status ) ? 'current' : '';
+                        $links[] = sprintf( '<li><a href="%s" class="%s">%s <span class="count">(%d)</span></a></li>', esc_url( $url ), esc_attr( $class ), esc_html( $label ), intval( $count ) );
+                }
+                echo implode( ' | ', $links );
+                ?>
+        </ul>
+        <form method="post">
+                <?php
+                $table->search_box( __( 'Search Councils', 'council-debt-counters' ), 'council-search' );
+                $table->display();
+                ?>
+        </form>
 </div>
 ?>

--- a/includes/class-council-admin-page.php
+++ b/includes/class-council-admin-page.php
@@ -163,6 +163,12 @@ class Council_Admin_Page {
         $debt_year = isset( $tab_years['debt'] ) ? sanitize_text_field( $tab_years['debt'] ) : CDC_Utils::current_financial_year();
         Council_Post_Type::calculate_total_debt( $post_id, $debt_year );
 
+        $default_year  = get_post_meta( $post_id, 'cdc_default_financial_year', true );
+        $current_total = (float) Custom_Fields::get_value( $post_id, 'total_debt', $default_year );
+        if ( ! $default_year || $current_total <= 0 ) {
+            update_post_meta( $post_id, 'cdc_default_financial_year', $debt_year );
+        }
+
         $na_tabs = $_POST['cdc_na_tab'] ?? array();
         $enabled = (array) get_option( 'cdc_enabled_counters', array() );
         foreach ( $enabled as $tab_key ) {

--- a/includes/class-council-post-type.php
+++ b/includes/class-council-post-type.php
@@ -70,12 +70,14 @@ class Council_Post_Type {
     }
 
 
-    public static function calculate_total_debt( $post_id ) {
+    public static function calculate_total_debt( $post_id, string $year = '' ) {
         if ( get_post_type( $post_id ) !== 'council' ) {
             return;
         }
         // Get all relevant fields
-        $year = CDC_Utils::current_financial_year();
+        if ( empty( $year ) ) {
+            $year = CDC_Utils::current_financial_year();
+        }
         $current_liabilities = (float) Custom_Fields::get_value( $post_id, 'current_liabilities', $year );
         $long_term  = (float) Custom_Fields::get_value( $post_id, 'long_term_liabilities', $year );
         $lease_pfi  = (float) Custom_Fields::get_value( $post_id, 'finance_lease_pfi_liabilities', $year );

--- a/includes/class-council-post-type.php
+++ b/includes/class-council-post-type.php
@@ -74,22 +74,41 @@ class Council_Post_Type {
         if ( get_post_type( $post_id ) !== 'council' ) {
             return;
         }
-        // Get all relevant fields
+
         if ( empty( $year ) ) {
             $year = CDC_Utils::current_financial_year();
         }
-        $current_liabilities = (float) Custom_Fields::get_value( $post_id, 'current_liabilities', $year );
-        $long_term  = (float) Custom_Fields::get_value( $post_id, 'long_term_liabilities', $year );
-        $lease_pfi  = (float) Custom_Fields::get_value( $post_id, 'finance_lease_pfi_liabilities', $year );
-        $manual     = (float) Custom_Fields::get_value( $post_id, 'manual_debt_entry', $year );
-        $adjust   = 0;
-        $entries  = get_post_meta( $post_id, 'cdc_debt_adjustments', true );
+
+        $current_liabilities = Custom_Fields::get_value( $post_id, 'current_liabilities', $year );
+        $long_term           = Custom_Fields::get_value( $post_id, 'long_term_liabilities', $year );
+        $lease_pfi           = Custom_Fields::get_value( $post_id, 'finance_lease_pfi_liabilities', $year );
+        $manual              = Custom_Fields::get_value( $post_id, 'manual_debt_entry', $year );
+        $entries             = get_post_meta( $post_id, 'cdc_debt_adjustments', true );
+
+        // If we have no data for this year, don't overwrite any existing total with zero.
+        $has_data = false;
+        foreach ( array( $current_liabilities, $long_term, $lease_pfi, $manual ) as $val ) {
+            if ( '' !== $val && null !== $val ) {
+                $has_data = true;
+                break;
+            }
+        }
+        if ( ! $has_data && empty( $entries ) ) {
+            return;
+        }
+
+        $current_liabilities = (float) $current_liabilities;
+        $long_term           = (float) $long_term;
+        $lease_pfi           = (float) $lease_pfi;
+        $manual              = (float) $manual;
+
+        $adjust = 0;
         if ( is_array( $entries ) ) {
             foreach ( $entries as $e ) {
                 $adjust += (float) $e['amount'];
             }
         }
-        // Total debt is current liabilities + long term liabilities + lease/PFI + manual + adjustments
+
         $total = $current_liabilities + $long_term + $lease_pfi + $manual + $adjust;
         Custom_Fields::update_value( $post_id, 'total_debt', $total, $year );
     }

--- a/includes/class-data-loader.php
+++ b/includes/class-data-loader.php
@@ -96,9 +96,9 @@ class Data_Loader {
                                 \CouncilDebtCounters\Custom_Fields::update_value( $post_id, $field, $value, CDC_Utils::current_financial_year() );
                         }
 
-			if ( method_exists( '\\CouncilDebtCounters\\Council_Post_Type', 'calculate_total_debt' ) ) {
-				Council_Post_Type::calculate_total_debt( $post_id );
-			}
+                        if ( method_exists( '\\CouncilDebtCounters\\Council_Post_Type', 'calculate_total_debt' ) ) {
+                                Council_Post_Type::calculate_total_debt( $post_id, CDC_Utils::current_financial_year() );
+                        }
 
 			++$count;
 		}
@@ -164,9 +164,9 @@ class Data_Loader {
                                 Custom_Fields::update_value( $post_id, $field, $value, CDC_Utils::current_financial_year() );
 			}
 
-			if ( method_exists( '\\CouncilDebtCounters\\Council_Post_Type', 'calculate_total_debt' ) ) {
-				Council_Post_Type::calculate_total_debt( $post_id );
-			}
+                        if ( method_exists( '\\CouncilDebtCounters\\Council_Post_Type', 'calculate_total_debt' ) ) {
+                                Council_Post_Type::calculate_total_debt( $post_id, CDC_Utils::current_financial_year() );
+                        }
 
 			++$count;
 		}
@@ -395,9 +395,9 @@ class Data_Loader {
                         Custom_Fields::update_value( $post_id, $field, $value, CDC_Utils::current_financial_year() );
                 }
 
-		if ( method_exists( '\\CouncilDebtCounters\\Council_Post_Type', 'calculate_total_debt' ) ) {
-			Council_Post_Type::calculate_total_debt( $post_id );
-		}
+                if ( method_exists( '\\CouncilDebtCounters\\Council_Post_Type', 'calculate_total_debt' ) ) {
+                        Council_Post_Type::calculate_total_debt( $post_id, CDC_Utils::current_financial_year() );
+                }
 
 		wp_send_json_success( array( 'id' => $post_id ) );
 	}

--- a/includes/class-docs-manager.php
+++ b/includes/class-docs-manager.php
@@ -353,7 +353,7 @@ class Docs_Manager {
             Custom_Fields::update_value( $cid, sanitize_key( $field ), sanitize_text_field( $value ), $year );
         }
         if ( method_exists( '\\CouncilDebtCounters\\Council_Post_Type', 'calculate_total_debt' ) ) {
-            Council_Post_Type::calculate_total_debt( $cid );
+            Council_Post_Type::calculate_total_debt( $cid, $year );
         }
         $all = get_option( 'cdc_ai_suggestions', [] );
         unset( $all[ $cid ] );

--- a/public/js/counter-animations.js
+++ b/public/js/counter-animations.js
@@ -99,6 +99,25 @@
             debugLog('Counter animation complete', {target}, 'verbose');
         });
 
+        if (window.cdcCounters && el.dataset.cid && el.dataset.field && el.dataset.year){
+            const data = new FormData();
+            data.append('action','cdc_get_counter_value');
+            data.append('id', el.dataset.cid);
+            data.append('field', el.dataset.field);
+            data.append('year', el.dataset.year);
+            fetch(window.cdcCounters.ajaxUrl,{method:'POST',credentials:'same-origin',body:data})
+                .then(r=>r.json())
+                .then(res=>{
+                    if(res.success && res.data){
+                        const val = parseFloat(res.data.value);
+                        if(!isNaN(val) && Math.abs(val - target) > 0.01){
+                            counter.update(val);
+                        }
+                    }
+                })
+                .catch(()=>{});
+        }
+
         if (growth !== 0) {
             setInterval(() => {
                 start += growth;

--- a/tests/CouncilPostTypeTest.php
+++ b/tests/CouncilPostTypeTest.php
@@ -1,0 +1,36 @@
+<?php
+use PHPUnit\Framework\TestCase;
+use CouncilDebtCounters\Custom_Fields;
+use CouncilDebtCounters\Council_Post_Type;
+use CouncilDebtCounters\CDC_Utils;
+
+require_once __DIR__ . '/../includes/class-custom-fields.php';
+require_once __DIR__ . '/../includes/class-council-post-type.php';
+require_once __DIR__ . '/../includes/class-cdc-utils.php';
+
+class CouncilPostTypeTest extends TestCase {
+    protected function setUp(): void {
+        global $wpdb;
+        $wpdb = new WPDBStub();
+        Custom_Fields::add_field('current_liabilities','Current','money');
+        Custom_Fields::add_field('long_term_liabilities','Long','money');
+        Custom_Fields::add_field('finance_lease_pfi_liabilities','Lease','money');
+        Custom_Fields::add_field('manual_debt_entry','Manual','money');
+        Custom_Fields::add_field('total_debt','Total Debt','money');
+    }
+
+    public function test_calculate_total_debt_skips_if_no_data() {
+        $year = CDC_Utils::current_financial_year();
+        Custom_Fields::update_value(1,'total_debt',123.0,$year);
+        Council_Post_Type::calculate_total_debt(1,$year);
+        $this->assertSame(123.0, Custom_Fields::get_value(1,'total_debt',$year));
+    }
+
+    public function test_calculate_total_debt_sums_values() {
+        $year = CDC_Utils::current_financial_year();
+        Custom_Fields::update_value(1,'current_liabilities',100,$year);
+        Custom_Fields::update_value(1,'long_term_liabilities',50,$year);
+        Council_Post_Type::calculate_total_debt(1,$year);
+        $this->assertSame(150.0, Custom_Fields::get_value(1,'total_debt',$year));
+    }
+}

--- a/tests/ShortcodeRenderTest.php
+++ b/tests/ShortcodeRenderTest.php
@@ -1,0 +1,32 @@
+<?php
+use PHPUnit\Framework\TestCase;
+use CouncilDebtCounters\Custom_Fields;
+use CouncilDebtCounters\Shortcode_Renderer;
+use CouncilDebtCounters\CDC_Utils;
+
+require_once __DIR__ . '/../includes/class-custom-fields.php';
+require_once __DIR__ . '/../includes/class-shortcode-renderer.php';
+require_once __DIR__ . '/../includes/class-cdc-utils.php';
+require_once __DIR__ . '/../includes/class-counter-manager.php';
+
+class ShortcodeRenderTest extends TestCase {
+    protected function setUp(): void {
+        global $wpdb;
+        $wpdb = new WPDBStub();
+        Custom_Fields::add_field('interest_paid','Interest','money');
+        Custom_Fields::add_field('total_debt','Total Debt','money');
+        update_option('cdc_enabled_counters',['debt','interest']);
+    }
+
+    public function test_render_interest_missing_shows_alert(){
+        $html = Shortcode_Renderer::render_interest_counter(['id'=>1]);
+        $this->assertStringContainsString('alert', $html);
+    }
+
+    public function test_render_debt_counter_uses_value(){
+        $year = CDC_Utils::current_financial_year();
+        Custom_Fields::update_value(1,'total_debt',200,$year);
+        $html = Shortcode_Renderer::render_debt_counter(['id'=>1]);
+        $this->assertStringNotContainsString('No Total Debt figure found', $html);
+    }
+}

--- a/tests/WPDBStub.php
+++ b/tests/WPDBStub.php
@@ -8,8 +8,14 @@ class WPDBStub {
 
     public function prepare($query, ...$args) {
         foreach ($args as $arg) {
-            $query = preg_replace('/%d/', (int)$arg, $query, 1);
-            $query = preg_replace('/%s/', "'" . $arg . "'", $query, 1);
+            if (strpos($query, '%d') !== false) {
+                $query = preg_replace('/%d/', (int)$arg, $query, 1);
+                continue;
+            }
+            if (strpos($query, '%s') !== false) {
+                $safe = str_replace("'", "''", $arg);
+                $query = preg_replace('/%s/', "'" . $safe . "'", $query, 1);
+            }
         }
         return $query;
     }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -79,3 +79,59 @@ function update_option($option, $value) {
     $options_store[$option] = $value;
     return true;
 }
+
+// Minimal WordPress function stubs used by the plugin during tests.
+function get_post_type($post = null) {
+    return 'council';
+}
+function get_post_status($post = null) {
+    return 'publish';
+}
+function get_post($id) {
+    return (object) ['ID' => $id, 'post_type' => 'council'];
+}
+function get_permalink($id = 0) {
+    return '';
+}
+function wp_enqueue_style() {}
+function wp_enqueue_script() {}
+function wp_register_style() {}
+function wp_register_script() {}
+function wp_add_inline_style() {}
+function wp_localize_script() {}
+function add_action() {}
+function add_shortcode() {}
+function esc_html($t){return $t;}
+function esc_attr($t){return $t;}
+function esc_html_e($t,$d=null){echo $t;}
+function __($t,$d=null){return $t;}
+function sanitize_key($t){return $t;}
+function sanitize_text_field($t){return $t;}
+function sanitize_html_class($t){return $t;}
+function check_ajax_referer($a,$b=null,$die=true){}
+function wp_send_json_success($data=null){return $data;}
+function wp_send_json_error($data=null,$code=400){return $data;}
+function wp_create_nonce($action){return 'nonce';}
+function admin_url($path=''){return $path;}
+// Simple storage for post meta used in tests.
+$post_meta_store = [];
+function get_post_meta($id, $key = '', $single = false){
+    global $post_meta_store;
+    if($key === ''){ return $post_meta_store[$id] ?? []; }
+    $val = $post_meta_store[$id][$key] ?? null;
+    if($single){ return $val; }
+    return [$val];
+}
+function update_post_meta($id,$key,$value){
+    global $post_meta_store;
+    $post_meta_store[$id][$key] = $value;
+    return true;
+}
+function delete_post_meta($id,$key){
+    global $post_meta_store;
+    unset($post_meta_store[$id][$key]);
+    return true;
+}
+function number_format_i18n($number, $decimals = 0){
+    return number_format($number, $decimals);
+}


### PR DESCRIPTION
## Summary
- track selected year per tab when editing councils
- save field values for the chosen financial year
- prevent `total_debt` field being marked N/A and calculate for the correct year
- hide N/A toggle for read-only fields

## Testing
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_685c5699fc408331810e6d00818d874d