### PR TITLE
Add council visit stats to admin

### DIFF
--- a/includes/class-councils-table.php
+++ b/includes/class-councils-table.php
@@ -27,7 +27,9 @@ class Councils_Table extends \WP_List_Table {
         return [
             'cb'           => '<input type="checkbox" />',
             'name'         => __( 'Name', 'council-debt-counters' ),
+            'id'           => __( 'ID', 'council-debt-counters' ),
             'population'   => __( 'Population', 'council-debt-counters' ),
+            'visits'       => __( 'Visits Last Hour', 'council-debt-counters' ),
             'last_updated' => __( 'Last Updated', 'council-debt-counters' ),
             'status'       => __( 'Status', 'council-debt-counters' ),
         ];
@@ -55,6 +57,15 @@ class Councils_Table extends \WP_List_Table {
         $actions['delete'] = sprintf( '<a href="%s" onclick="return confirm(\'%s\');">%s</a>', esc_url( $del ), esc_js( __( 'Delete this council?', 'council-debt-counters' ) ), __( 'Delete', 'council-debt-counters' ) );
 
         return sprintf( '<strong><a class="row-title" href="%s">%s</a></strong>%s', esc_url( $edit ), esc_html( get_the_title( $item ) ), $this->row_actions( $actions ) );
+    }
+
+    protected function column_id( $item ) {
+        return intval( $item->ID );
+    }
+
+    protected function column_visits( $item ) {
+        $counts = Stats_Page::get_visit_counts( $item->ID );
+        return sprintf( '%d human / %d AI', $counts['human'], $counts['ai'] );
     }
 
     protected function column_shortcode( $item ) {

--- a/includes/class-stats-page.php
+++ b/includes/class-stats-page.php
@@ -6,13 +6,20 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 class Stats_Page {
-    const PAGE_SLUG = 'cdc-stats';
-    const OPTION_KEY = 'cdc_search_stats';
-    const SHARE_KEY = 'cdc_share_stats';
+    const PAGE_SLUG   = 'cdc-stats';
+    const OPTION_KEY  = 'cdc_search_stats';
+    const SHARE_KEY   = 'cdc_share_stats';
+    const VISIT_KEY   = 'cdc_visit_stats';
     const MAX_ENTRIES = 1000;
+
+    /** Number of minutes for alert threshold window. */
+    const ALERT_WINDOW = 15;
+    /** Number of visits in ALERT_WINDOW needed to trigger an alert email. */
+    const ALERT_THRESHOLD = 50;
 
     public static function init() {
         add_action( 'admin_menu', [ __CLASS__, 'add_menu' ] );
+        add_action( 'template_redirect', [ __CLASS__, 'maybe_log_visit' ] );
     }
 
     public static function add_menu() {
@@ -78,5 +85,107 @@ class Stats_Page {
             $shares = array_slice( $shares, -self::MAX_ENTRIES, null, true );
         }
         update_option( self::SHARE_KEY, $shares, false );
+    }
+
+    /**
+     * Determine if the current request is likely from a bot or automated system.
+     */
+    protected static function is_bot() : bool {
+        $ua = $_SERVER['HTTP_USER_AGENT'] ?? '';
+        if ( '' === $ua ) {
+            return true;
+        }
+        $patterns = 'bot|crawl|slurp|spider|curl|python|ai|scrapy|fetch';
+        return (bool) preg_match( '/(' . $patterns . ')/i', $ua );
+    }
+
+    /**
+     * Hook into template_redirect and log visits to council pages.
+     */
+    public static function maybe_log_visit() {
+        if ( is_admin() ) {
+            return;
+        }
+        if ( is_singular( 'council' ) ) {
+            $id  = get_queried_object_id();
+            $bot = self::is_bot();
+            self::log_visit( $id, $bot );
+        }
+    }
+
+    /**
+     * Record a visit event.
+     */
+    public static function log_visit( int $id, bool $ai ) {
+        $visits = get_option( self::VISIT_KEY, [] );
+        if ( ! isset( $visits[ $id ] ) ) {
+            $visits[ $id ] = [];
+        }
+
+        $now = time();
+        // Remove entries older than one hour to keep array size manageable.
+        $visits[ $id ] = array_values( array_filter(
+            $visits[ $id ],
+            static function ( $v ) use ( $now ) {
+                return isset( $v['t'] ) && ( $v['t'] >= $now - HOUR_IN_SECONDS );
+            }
+        ) );
+
+        $visits[ $id ][] = [ 't' => $now, 'ai' => $ai ? 1 : 0 ];
+        if ( count( $visits[ $id ] ) > self::MAX_ENTRIES ) {
+            $visits[ $id ] = array_slice( $visits[ $id ], -self::MAX_ENTRIES );
+        }
+
+        update_option( self::VISIT_KEY, $visits, false );
+
+        // Alert admin if threshold exceeded within ALERT_WINDOW minutes.
+        $recent = array_filter(
+            $visits[ $id ],
+            static function ( $v ) use ( $now ) {
+                return $v['t'] >= $now - ( self::ALERT_WINDOW * MINUTE_IN_SECONDS );
+            }
+        );
+
+        if ( count( $recent ) > self::ALERT_THRESHOLD ) {
+            $key = 'cdc_alert_' . $id;
+            if ( false === get_transient( $key ) ) {
+                $title  = get_the_title( $id );
+                $email  = get_option( 'admin_email' );
+                $subject = sprintf( __( 'High traffic alert for %s', 'council-debt-counters' ), $title );
+                $message = sprintf( __( 'More than %d visits to "%s" in the last %d minutes.', 'council-debt-counters' ), self::ALERT_THRESHOLD, $title, self::ALERT_WINDOW );
+                wp_mail( $email, $subject, $message );
+                set_transient( $key, 1, self::ALERT_WINDOW * MINUTE_IN_SECONDS );
+            }
+        }
+    }
+
+    /**
+     * Get visit counts in the last hour for a council.
+     */
+    public static function get_visit_counts( int $id ) : array {
+        $visits = get_option( self::VISIT_KEY, [] );
+        $now    = time();
+        $human  = 0;
+        $ai     = 0;
+        if ( isset( $visits[ $id ] ) ) {
+            $filtered = array_filter(
+                $visits[ $id ],
+                static function ( $v ) use ( $now ) {
+                    return isset( $v['t'] ) && ( $v['t'] >= $now - HOUR_IN_SECONDS );
+                }
+            );
+            foreach ( $filtered as $v ) {
+                if ( ! empty( $v['ai'] ) ) {
+                    $ai++;
+                } else {
+                    $human++;
+                }
+            }
+            // Trim to filtered set to prevent growth
+            $visits[ $id ] = array_values( $filtered );
+            update_option( self::VISIT_KEY, $visits, false );
+        }
+
+        return [ 'human' => $human, 'ai' => $ai ];
     }
 }


### PR DESCRIPTION
## Summary
- extend stats system to track council page visits
- email admin when a single council exceeds 50 visits within 15 minutes
- show council ID and visit counts in the manage councils table

## Testing
- `composer install`
- `vendor/bin/phpunit --colors=never`

------
https://chatgpt.com/codex/tasks/task_e_685d282ed0e083318f88708e0bd51722