### PR TITLE
Preserve financial year when saving councils

### DIFF
--- a/admin/js/council-form.js
+++ b/admin/js/council-form.js
@@ -30,10 +30,26 @@
         var assignee = document.querySelector('select[name="assigned_user"]');
         var uploadBtn = document.getElementById('cdc-upload-doc');
         var msgArea = document.getElementById('cdc-status-msg');
+        var activeInput = document.getElementById('cdc-active-tab');
+        if(activeInput){
+            var current = document.querySelector('.tab-pane.show.active');
+            if(current){ activeInput.value = current.id.replace('tab-',''); }
+        }
+        if(msgArea){
+            var alertEl = msgArea.querySelector('.alert');
+            if(alertEl){
+                setTimeout(function(){
+                    var a = bootstrap.Alert.getOrCreateInstance(alertEl); a.close();
+                },6000);
+            }
+        }
         function flash(msg){
             if(!msgArea) return;
-            msgArea.innerHTML = '<div class="alert alert-success mb-0">'+msg+'</div>';
-            setTimeout(function(){ msgArea.innerHTML = ''; },3000);
+            msgArea.innerHTML = '<div class="alert alert-success alert-dismissible fade show mb-0" role="alert">'+msg+'<button type="button" class="btn-close" data-bs-dismiss="alert"></button></div>';
+            var el = msgArea.querySelector('.alert');
+            if(el){
+                setTimeout(function(){ var a=bootstrap.Alert.getOrCreateInstance(el); a.close(); },6000);
+            }
         }
         function sendToolbar(data){
             data.append('action','cdc_update_toolbar');
@@ -181,6 +197,7 @@
         document.querySelectorAll('button[data-bs-toggle="tab"]').forEach(function(btn){
             btn.addEventListener('shown.bs.tab', function(){
                 var tab = btn.getAttribute('data-bs-target').replace('#tab-','');
+                if(activeInput){ activeInput.value = tab; }
                 if(globalYear){
                     fetchYearValues(tab, globalYear.value);
                 }
@@ -484,7 +501,8 @@
             askAll.addEventListener('click',async function(ev){
                 ev.preventDefault();
                 var buttons=document.querySelectorAll('.cdc-ask-ai');
-                for(var i=0;i<buttons.length;i++){
+                var total=buttons.length;
+                for(var i=0;i<total;i++){
                     await askField(buttons[i].dataset.field);
                 }
             });

--- a/admin/views/councils-page.php
+++ b/admin/views/councils-page.php
@@ -7,6 +7,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 $req_action = isset( $_GET['action'] ) ? sanitize_text_field( $_GET['action'] ) : '';
 $council_id = isset( $_GET['post'] ) ? intval( $_GET['post'] ) : 0;
 
+// Preserve the selected financial year when returning to this page.
+$selected_year = isset( $_GET['year'] ) ? sanitize_text_field( $_GET['year'] ) : '';
+if ( $selected_year ) {
+        $GLOBALS['cdc_selected_year'] = $selected_year;
+}
+
 if ( 'delete' === $req_action && $council_id ) {
                 check_admin_referer( 'cdc_delete_council_' . $council_id );
                 wp_delete_post( $council_id, true );

--- a/includes/class-council-admin-page.php
+++ b/includes/class-council-admin-page.php
@@ -273,7 +273,8 @@ class Council_Admin_Page {
 
         Error_Logger::log_info( 'Council saved: ' . $post_id );
         $redirect_year = rawurlencode( $debt_year );
-        wp_safe_redirect( admin_url( 'admin.php?page=' . self::PAGE_SLUG . '&action=edit&post=' . $post_id . '&updated=1&year=' . $redirect_year ) );
+        $redirect_tab  = isset( $_POST['active_tab'] ) ? sanitize_key( $_POST['active_tab'] ) : 'general';
+        wp_safe_redirect( admin_url( 'admin.php?page=' . self::PAGE_SLUG . '&action=edit&post=' . $post_id . '&updated=1&year=' . $redirect_year . '&tab=' . rawurlencode( $redirect_tab ) ) );
         exit;
     }
 

--- a/includes/class-council-admin-page.php
+++ b/includes/class-council-admin-page.php
@@ -272,7 +272,8 @@ class Council_Admin_Page {
         }
 
         Error_Logger::log_info( 'Council saved: ' . $post_id );
-        wp_safe_redirect( admin_url( 'admin.php?page=' . self::PAGE_SLUG . '&action=edit&post=' . $post_id . '&updated=1' ) );
+        $redirect_year = rawurlencode( $debt_year );
+        wp_safe_redirect( admin_url( 'admin.php?page=' . self::PAGE_SLUG . '&action=edit&post=' . $post_id . '&updated=1&year=' . $redirect_year ) );
         exit;
     }
 


### PR DESCRIPTION
## Summary
- retain selected year when returning to council editor
- redirect back to the chosen year after save

## Testing
- `./vendor/bin/phpunit -c phpunit.xml`
- `./vendor/bin/phpcs -q` *(fails: found coding standard violations)*

------
https://chatgpt.com/codex/tasks/task_e_685d8da388348331871927859546d0da