### PR TITLE
Honor PDF year when confirming AI figures

### DIFF
--- a/admin/views/councils-page.php
+++ b/admin/views/councils-page.php
@@ -387,19 +387,20 @@ $readonly = true;
                                                                         <option value="draft_statement_of_accounts"><?php esc_html_e( 'Draft', 'council-debt-counters' ); ?></option>
                                                                         <option value="audited_statement_of_accounts"><?php esc_html_e( 'Audited', 'council-debt-counters' ); ?></option>
                                                                 </select>
-                                                                <button type="button" id="cdc-upload-doc" class="button button-secondary mt-2"><?php esc_html_e( 'Add Document', 'council-debt-counters' ); ?></button>
                                                         <?php endif; ?>
+                                                        <button type="button" id="cdc-upload-doc" class="btn btn-primary mt-2"><?php esc_html_e( 'Upload Document', 'council-debt-counters' ); ?></button>
                                                 </td>
                                         </tr>
                                 </table>
                                 <?php if ( ! empty( $docs ) ) : ?>
                                 <h2><?php esc_html_e( 'Uploaded Statements', 'council-debt-counters' ); ?></h2>
-                                <table id="cdc-docs-table" class="widefat">
+                                <table id="cdc-docs-table" class="table table-striped">
                                         <thead>
                                                 <tr>
                                                         <th><?php esc_html_e( 'File', 'council-debt-counters' ); ?></th>
                                                         <th><?php esc_html_e( 'Year', 'council-debt-counters' ); ?></th>
                                                         <th><?php esc_html_e( 'Type', 'council-debt-counters' ); ?></th>
+                                                        <th><?php esc_html_e( 'Size (MB)', 'council-debt-counters' ); ?></th>
                                                         <th><?php esc_html_e( 'Actions', 'council-debt-counters' ); ?></th>
                                                 </tr>
                                         </thead>
@@ -421,10 +422,20 @@ $readonly = true;
                                                                 </select>
                                                         </td>
                                                         <td>
-                                                                <button type="button" value="<?php echo esc_attr( $d->id ); ?>" class="button cdc-extract-ai"><span class="dashicons dashicons-lightbulb"></span> <?php esc_html_e( 'Extract Figures', 'council-debt-counters' ); ?></button>
+                                                                <?php
+                                                                $size = '';
+                                                                $p    = \CouncilDebtCounters\Docs_Manager::get_docs_path() . $d->filename;
+                                                                if ( file_exists( $p ) ) {
+                                                                        $size = number_format( filesize( $p ) / 1048576, 2 );
+                                                                }
+                                                                echo esc_html( $size );
+                                                                ?>
+                                                        </td>
+                                                        <td>
+                                                                <button type="button" value="<?php echo esc_attr( $d->id ); ?>" class="btn btn-outline-primary cdc-extract-ai"><span class="dashicons dashicons-lightbulb"></span> <?php esc_html_e( 'Extract Figures', 'council-debt-counters' ); ?></button>
 
-                                                                <button type="submit" name="update_doc" value="<?php echo esc_attr( $d->id ); ?>" class="button button-secondary"><?php esc_html_e( 'Update', 'council-debt-counters' ); ?></button>
-                                                                <button type="submit" name="delete_doc" value="<?php echo esc_attr( $d->id ); ?>" class="button button-link-delete" onclick="return confirm('<?php esc_attr_e( 'Delete this document?', 'council-debt-counters' ); ?>');"><?php esc_html_e( 'Delete', 'council-debt-counters' ); ?></button>
+                                                                <button type="submit" name="update_doc" value="<?php echo esc_attr( $d->id ); ?>" class="btn btn-secondary ms-1"><?php esc_html_e( 'Update', 'council-debt-counters' ); ?></button>
+                                                                <button type="submit" name="delete_doc" value="<?php echo esc_attr( $d->id ); ?>" class="btn btn-danger ms-1" onclick="return confirm('<?php esc_attr_e( 'Delete this document?', 'council-debt-counters' ); ?>');"><?php esc_html_e( 'Delete', 'council-debt-counters' ); ?></button>
                                                         </td>
                                                 </tr>
                                         <?php endforeach; ?>

--- a/includes/class-council-admin-page.php
+++ b/includes/class-council-admin-page.php
@@ -73,7 +73,7 @@ class Council_Admin_Page {
             'cdc-council-form',
             plugins_url( 'admin/js/council-form.js', dirname( __DIR__ ) . '/council-debt-counters.php' ),
             [],
-            '0.1.4',
+            '0.1.5',
             true
         );
         wp_enqueue_style( 'cdc-ai-progress', plugins_url( 'admin/css/ai-progress.css', dirname( __DIR__ ) . '/council-debt-counters.php' ), [], '0.1.0' );
@@ -100,6 +100,10 @@ class Council_Admin_Page {
             'typeSentence' => __( 'Short sentence', 'council-debt-counters' ),
             'responseLabel' => __( 'AI response', 'council-debt-counters' ),
             'accept' => __( 'Accept and Insert', 'council-debt-counters' ),
+            'confirmTitle' => __( 'Confirm Extraction', 'council-debt-counters' ),
+            'confirm' => __( 'Extract Now', 'council-debt-counters' ),
+            'yearLabel' => __( 'Year:', 'council-debt-counters' ),
+            'tokenLabel' => __( 'Estimated tokens:', 'council-debt-counters' ),
         ] );
         $council_id = isset( $_GET['post'] ) ? intval( $_GET['post'] ) : 0;
         wp_localize_script( 'cdc-council-form', 'cdcToolbarData', [


### PR DESCRIPTION
## Summary
- add new AJAX endpoint to report document year and token count
- store AI suggestions per year and include financial year in confirm and dismiss forms
- use document year when saving extracted figures
- require user confirmation of document year before running extraction
- expose new strings for confirmation modal

## Testing
- `composer install`
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_685ee71400c08331aaac71ec64345c4a