### PR TITLE
Add Power Editor admin page

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,9 +61,11 @@ The backend engine, developed as a WordPress plugin, gives site editors and admi
    - Go to **Debt Counters → Power Editor**.
    - Quickly edit figures for councils marked “Under Review.”
    - Inline-edit population, liabilities (including PFI/leases), spending,
-     deficit, income and interest in a spreadsheet-like table.
+   deficit, income, interest and whether the council has closed in a
+   spreadsheet-like table.
    - Select a year once to apply it to all edits.
    - A spinner in the top-right shows when your changes are saving.
+   - Ticking **Closed** adds a status message that the council no longer exists.
    - The header and column headings stay visible as you scroll.
 
 4. **Moderation Review**

--- a/README.md
+++ b/README.md
@@ -57,19 +57,24 @@ The backend engine, developed as a WordPress plugin, gives site editors and admi
    - Use **Ask AI** for individual fields or **Ask AI for All**.  
    - Save your changes; optionally submit for moderation review.
 
-3. **Moderation Review**  
+3. **Power Editor**
+   - Go to **Debt Counters → Power Editor**.
+   - Quickly edit figures for councils marked “Under Review.”
+   - Select a year once to apply it to all edits.
+
+4. **Moderation Review**
    - Go to **Debt Counters → Submissions**.  
    - Click **Review** on a pending submission.  
    - Compare existing vs submitted values, choose per field, then **Save**.  
    - All actions are logged to `moderation.log` for audit.
 
-4. **Publishing Shortcodes**
+5. **Publishing Shortcodes**
 
    Embed counters anywhere on the live site using: ` [council_counter id="123"] [total_debt_counter] [cdc_leaderboard type="debt_per_resident" limit="5"] `
 
    See the “Shortcodes” section below for full usage.
 
-5. **Troubleshooting & Logs**  
+6. **Troubleshooting & Logs**
 - **Debt Counters → Troubleshooting** to view AI and error logs.  
 - Adjust JavaScript debug levels (Verbose, Standard, Quiet).  
 - Inspect token-usage and progress overlays when AI runs.

--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ The backend engine, developed as a WordPress plugin, gives site editors and admi
    spreadsheet-like table.
    - Select a year once to apply it to all edits.
    - A spinner in the top-right shows when your changes are saving.
+   - Updating any debt figure automatically recalculates Total Debt and
+     clears its N/A flag.
    - Ticking **Closed** adds a status message that the council no longer exists,
      marks it active and removes the row.
    - Use **Confirm** to mark a council active and hide it from your list once
@@ -96,6 +98,7 @@ The backend engine, developed as a WordPress plugin, gives site editors and admi
   - `[total_debt_counter year="YYYY/YY"]`, `[total_spending_counter]`, `[total_deficit_counter]`, `[total_interest_counter]`, `[total_revenue_counter]` – Site-wide totals. Defaults use the year set in **Debt Counters → Settings**. These counters count up from zero to the total figure over fifteen seconds.
   - `[total_custom_counter type="reserves|income|consultancy"]` – Any custom metric.
   - `[cdc_leaderboard type="highest_debt|debt_per_resident|lowest_reserves" limit="…"]` – Ranked lists or tables with a year selector.
+  - Deficit counters switch to **Surplus** when the figure is negative, displaying the value as a positive.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,10 @@ The backend engine, developed as a WordPress plugin, gives site editors and admi
    spreadsheet-like table.
    - Select a year once to apply it to all edits.
    - A spinner in the top-right shows when your changes are saving.
-   - Ticking **Closed** adds a status message that the council no longer exists.
+   - Ticking **Closed** adds a status message that the council no longer exists,
+     marks it active and removes the row.
+   - Use **Confirm** to mark a council active and hide it from your list once
+     you are done editing.
    - The header and column headings stay visible as you scroll.
 
 4. **Moderation Review**

--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ The backend engine, developed as a WordPress plugin, gives site editors and admi
    - Inline-edit population, liabilities (including PFI/leases), spending,
      deficit, income and interest in a spreadsheet-like table.
    - Select a year once to apply it to all edits.
+   - A spinner in the top-right shows when your changes are saving.
+   - The header and column headings stay visible as you scroll.
 
 4. **Moderation Review**
    - Go to **Debt Counters → Submissions**.  

--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ The backend engine, developed as a WordPress plugin, gives site editors and admi
 3. **Power Editor**
    - Go to **Debt Counters → Power Editor**.
    - Quickly edit figures for councils marked “Under Review.”
+   - Inline-edit population, liabilities (including PFI/leases), spending,
+     deficit, income and interest in a spreadsheet-like table.
    - Select a year once to apply it to all edits.
 
 4. **Moderation Review**

--- a/admin/css/power-editor.css
+++ b/admin/css/power-editor.css
@@ -1,0 +1,24 @@
+#cdc-pe-header {
+    position: -webkit-sticky;
+    position: sticky;
+    top: 0;
+    left: 0;
+    right: 0;
+    z-index: 1040;
+    background: #fff;
+    padding: 0.5rem;
+    border-bottom: 1px solid #dee2e6;
+    display: flex;
+    align-items: center;
+}
+#cdc-pe-spinner {
+    position: absolute;
+    right: 1rem;
+    top: 0.75rem;
+}
+#cdc-power-table thead th {
+    position: sticky;
+    top: 58px;
+    background: #fff;
+    z-index: 1030;
+}

--- a/admin/js/power-editor.js
+++ b/admin/js/power-editor.js
@@ -51,12 +51,28 @@
   ready(function(){
     spinner=document.getElementById('cdc-pe-spinner');
     document.querySelectorAll('.cdc-pe-input').forEach(function(el){
-      el.addEventListener('change', function(){ save(el); });
+      el.addEventListener('change', function(){
+        save(el);
+      });
       el.addEventListener('keydown', function(e){
-        if(e.key==='Enter'){ e.preventDefault(); save(el); var next=el.closest('td').nextElementSibling; if(next){ next=next.querySelector('.cdc-pe-input'); } if(!next){ var nr=el.closest('tr').nextElementSibling; if(nr) next=nr.querySelector('.cdc-pe-input'); }
-        if(next){ next.focus(); }
+        if (e.key === 'Enter') {
+          e.preventDefault();
+          save(el);
+          var next = el.closest('td').nextElementSibling;
+          if (next) {
+            next = next.querySelector('.cdc-pe-input');
+          }
+          if (! next) {
+            var nr = el.closest('tr').nextElementSibling;
+            if (nr) {
+              next = nr.querySelector('.cdc-pe-input');
+            }
+          }
+          if (next) {
+            next.focus();
+          }
         }
-      );
+      });
     });
     var search=document.getElementById('cdc-pe-search');
     if(search){ search.addEventListener('input', filter); }

--- a/admin/js/power-editor.js
+++ b/admin/js/power-editor.js
@@ -23,7 +23,8 @@
     d.append('action','cdc_power_save');
     d.append('cid', cid);
     d.append('field', field);
-    d.append('value', input.value);
+    var value = input.type === 'checkbox' ? (input.checked ? '1' : '') : input.value;
+    d.append('value', value);
     d.append('year', year);
     d.append('nonce', cdcPower.nonce);
     showSpinner();
@@ -55,7 +56,7 @@
         save(el);
       });
       el.addEventListener('keydown', function(e){
-        if (e.key === 'Enter') {
+        if (e.key === 'Enter' && el.type !== 'checkbox') {
           e.preventDefault();
           save(el);
           var next = el.closest('td').nextElementSibling;

--- a/admin/js/power-editor.js
+++ b/admin/js/power-editor.js
@@ -1,6 +1,19 @@
 (function(){
   function ready(fn){ if(document.readyState!=='loading'){fn();} else {document.addEventListener('DOMContentLoaded',fn);} }
 
+  var pending=0;
+  var spinner;
+
+  function showSpinner(){
+    pending++;
+    if(spinner) spinner.classList.remove('d-none');
+  }
+
+  function hideSpinner(){
+    pending=Math.max(0,pending-1);
+    if(pending===0 && spinner){ spinner.classList.add('d-none'); }
+  }
+
   function save(input){
     var row = input.closest('tr');
     var cid = row.getAttribute('data-cid');
@@ -13,6 +26,7 @@
     d.append('value', input.value);
     d.append('year', year);
     d.append('nonce', cdcPower.nonce);
+    showSpinner();
     fetch(cdcPower.ajaxUrl,{method:'POST',credentials:'same-origin',body:d})
       .then(function(r){return r.json();})
       .then(function(res){
@@ -22,7 +36,8 @@
         }else{
           input.classList.add('bg-danger','text-white');
         }
-      });
+      })
+      .finally(hideSpinner);
   }
 
   function filter(){
@@ -34,6 +49,7 @@
   }
 
   ready(function(){
+    spinner=document.getElementById('cdc-pe-spinner');
     document.querySelectorAll('.cdc-pe-input').forEach(function(el){
       el.addEventListener('change', function(){ save(el); });
       el.addEventListener('keydown', function(e){

--- a/admin/js/power-editor.js
+++ b/admin/js/power-editor.js
@@ -32,8 +32,12 @@
       .then(function(r){return r.json();})
       .then(function(res){
         if(res && res.success){
-          input.classList.add('bg-success','text-white');
-          setTimeout(function(){input.classList.remove('bg-success','text-white');},1000);
+          if(field==='council_closed' && input.checked){
+            row.remove();
+          } else {
+            input.classList.add('bg-success','text-white');
+            setTimeout(function(){input.classList.remove('bg-success','text-white');},1000);
+          }
         }else{
           input.classList.add('bg-danger','text-white');
         }
@@ -47,6 +51,25 @@
       var name = tr.children[1].textContent.toLowerCase();
       tr.style.display = name.indexOf(term) !== -1 ? '' : 'none';
     });
+  }
+
+  function confirmRow(row){
+    var cid = row.getAttribute('data-cid');
+    var year = document.getElementById('cdc-pe-year').value;
+    var d = new FormData();
+    d.append('action','cdc_power_confirm');
+    d.append('cid',cid);
+    d.append('year',year);
+    d.append('nonce',cdcPower.nonce);
+    showSpinner();
+    fetch(cdcPower.ajaxUrl,{method:'POST',credentials:'same-origin',body:d})
+      .then(function(r){return r.json();})
+      .then(function(res){
+        if(res && res.success){
+          row.remove();
+        }
+      })
+      .finally(hideSpinner);
   }
 
   ready(function(){
@@ -73,6 +96,11 @@
             next.focus();
           }
         }
+      });
+    });
+    document.querySelectorAll('.cdc-pe-confirm').forEach(function(btn){
+      btn.addEventListener('click', function(){
+        confirmRow(btn.closest('tr'));
       });
     });
     var search=document.getElementById('cdc-pe-search');

--- a/admin/js/power-editor.js
+++ b/admin/js/power-editor.js
@@ -1,0 +1,48 @@
+(function(){
+  function ready(fn){ if(document.readyState!=='loading'){fn();} else {document.addEventListener('DOMContentLoaded',fn);} }
+
+  function save(input){
+    var row = input.closest('tr');
+    var cid = row.getAttribute('data-cid');
+    var field = input.getAttribute('data-field');
+    var year = document.getElementById('cdc-pe-year').value;
+    var d = new FormData();
+    d.append('action','cdc_power_save');
+    d.append('cid', cid);
+    d.append('field', field);
+    d.append('value', input.value);
+    d.append('year', year);
+    d.append('nonce', cdcPower.nonce);
+    fetch(cdcPower.ajaxUrl,{method:'POST',credentials:'same-origin',body:d})
+      .then(function(r){return r.json();})
+      .then(function(res){
+        if(res && res.success){
+          input.classList.add('bg-success','text-white');
+          setTimeout(function(){input.classList.remove('bg-success','text-white');},1000);
+        }else{
+          input.classList.add('bg-danger','text-white');
+        }
+      });
+  }
+
+  function filter(){
+    var term = document.getElementById('cdc-pe-search').value.toLowerCase();
+    document.querySelectorAll('#cdc-power-table tbody tr').forEach(function(tr){
+      var name = tr.children[1].textContent.toLowerCase();
+      tr.style.display = name.indexOf(term) !== -1 ? '' : 'none';
+    });
+  }
+
+  ready(function(){
+    document.querySelectorAll('.cdc-pe-input').forEach(function(el){
+      el.addEventListener('change', function(){ save(el); });
+      el.addEventListener('keydown', function(e){
+        if(e.key==='Enter'){ e.preventDefault(); save(el); var next=el.closest('td').nextElementSibling; if(next){ next=next.querySelector('.cdc-pe-input'); } if(!next){ var nr=el.closest('tr').nextElementSibling; if(nr) next=nr.querySelector('.cdc-pe-input'); }
+        if(next){ next.focus(); }
+        }
+      );
+    });
+    var search=document.getElementById('cdc-pe-search');
+    if(search){ search.addEventListener('input', filter); }
+  });
+})();

--- a/admin/views/councils-page.php
+++ b/admin/views/councils-page.php
@@ -149,6 +149,11 @@ $readonly = true;
 <?php elseif ( 'financial_data_source_url' === $field->name ) : ?>
 <input data-cdc-field="<?php echo esc_attr( $field->name ); ?>" data-initial-required="<?php echo $is_required ? '1' : '0'; ?>" type="url" id="cdc-field-<?php echo esc_attr( $field->id ); ?>" value="<?php echo esc_attr( $val ); ?>" class="form-control" <?php echo $readonly ? 'readonly disabled' : 'name="cdc_fields[' . esc_attr( $field->id ) . ']"'; ?> <?php echo $is_required ? 'required' : ''; ?> placeholder="https://example.com/statement.pdf">
 <p class="description mt-1"><?php esc_html_e( 'Link to the published statement this data comes from.', 'council-debt-counters' ); ?></p>
+<?php elseif ( 'council_closed' === $field->name ) : ?>
+<div class="form-check">
+    <input type="checkbox" class="form-check-input" id="cdc-field-<?php echo esc_attr( $field->id ); ?>" name="cdc_fields[<?php echo esc_attr( $field->id ); ?>]" value="1" <?php checked( $val, '1' ); ?> <?php echo $readonly ? 'disabled' : ''; ?> />
+    <label for="cdc-field-<?php echo esc_attr( $field->id ); ?>" class="form-check-label"><?php esc_html_e( 'This council no longer exists', 'council-debt-counters' ); ?></label>
+</div>
 <?php elseif ( 'status_message_type' === $field->name ) : ?>
 <select id="cdc-field-<?php echo esc_attr( $field->id ); ?>" name="cdc_fields[<?php echo esc_attr( $field->id ); ?>]" class="form-select" <?php echo $is_required ? 'required' : ''; ?> <?php echo $readonly ? 'disabled' : ''; ?>>
 <?php foreach ( array( 'info', 'warning', 'danger' ) as $t ) : ?>

--- a/admin/views/councils-page.php
+++ b/admin/views/councils-page.php
@@ -181,6 +181,9 @@ $readonly = true;
         <div class="invalid-feedback"><?php esc_html_e( 'Required', 'council-debt-counters' ); ?></div>
     <?php endif; ?>
 </div>
+<?php if ( 'annual_deficit' === $field->name ) : ?>
+<p class="description mt-1"><?php esc_html_e( 'Enter surpluses as a negative figure.', 'council-debt-counters' ); ?></p>
+<?php endif; ?>
 <?php else : ?>
 <?php $na_val = $council_id ? get_post_meta( $council_id, 'cdc_na_' . $field->name, true ) : ''; ?>
 <div class="input-group">

--- a/admin/views/power-editor-page.php
+++ b/admin/views/power-editor-page.php
@@ -1,7 +1,11 @@
 <?php
+use CouncilDebtCounters\CDC_Utils;
+use CouncilDebtCounters\Custom_Fields;
+
 if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
+
 $year  = CDC_Utils::current_financial_year();
 $years = CDC_Utils::council_years();
 $query = new WP_Query([

--- a/admin/views/power-editor-page.php
+++ b/admin/views/power-editor-page.php
@@ -15,7 +15,19 @@ $query = new WP_Query([
     'orderby'        => 'title',
     'order'          => 'asc',
 ]);
-$fields = [ 'population', 'current_liabilities', 'long_term_liabilities', 'interest_paid' ];
+// Fields to display/edit in the Power Editor. We include the core debt
+// figures plus PFI, spending, deficit and income so power users can
+// rapidly work through the most common data points.
+$fields = [
+'population',
+'current_liabilities',
+'long_term_liabilities',
+'finance_lease_pfi_liabilities',
+'annual_spending',
+'annual_deficit',
+'total_income',
+'interest_paid',
+];
 ?>
 <div class="wrap">
     <h1><?php esc_html_e( 'Power Editor', 'council-debt-counters' ); ?></h1>
@@ -35,6 +47,10 @@ $fields = [ 'population', 'current_liabilities', 'long_term_liabilities', 'inter
                 <th><?php esc_html_e( 'Population', 'council-debt-counters' ); ?></th>
                 <th><?php esc_html_e( 'Current Liabilities', 'council-debt-counters' ); ?></th>
                 <th><?php esc_html_e( 'Long-Term Liabilities', 'council-debt-counters' ); ?></th>
+                <th><?php esc_html_e( 'PFI Liabilities', 'council-debt-counters' ); ?></th>
+                <th><?php esc_html_e( 'Spending', 'council-debt-counters' ); ?></th>
+                <th><?php esc_html_e( 'Deficit', 'council-debt-counters' ); ?></th>
+                <th><?php esc_html_e( 'Income', 'council-debt-counters' ); ?></th>
                 <th><?php esc_html_e( 'Interest Paid', 'council-debt-counters' ); ?></th>
             </tr>
         </thead>

--- a/admin/views/power-editor-page.php
+++ b/admin/views/power-editor-page.php
@@ -27,6 +27,7 @@ $fields = [
 'annual_deficit',
 'total_income',
 'interest_paid',
+'council_closed',
 ];
 ?>
 <div class="wrap">
@@ -53,6 +54,7 @@ $fields = [
                 <th><?php esc_html_e( 'Deficit', 'council-debt-counters' ); ?></th>
                 <th><?php esc_html_e( 'Income', 'council-debt-counters' ); ?></th>
                 <th><?php esc_html_e( 'Interest Paid', 'council-debt-counters' ); ?></th>
+                <th><?php esc_html_e( 'Closed', 'council-debt-counters' ); ?></th>
             </tr>
         </thead>
         <tbody>
@@ -62,7 +64,11 @@ $fields = [
                     <td><?php echo esc_html( get_the_title( $p ) ); ?></td>
                     <?php foreach ( $fields as $f ) : ?>
                         <?php $val = Custom_Fields::get_value( $p->ID, $f, $year ); ?>
-                        <td><input type="text" class="form-control form-control-sm cdc-pe-input" data-field="<?php echo esc_attr( $f ); ?>" value="<?php echo esc_attr( $val ); ?>" /></td>
+                        <?php if ( 'council_closed' === $f ) : ?>
+                            <td class="text-center"><input type="checkbox" class="form-check-input cdc-pe-input" data-field="<?php echo esc_attr( $f ); ?>" <?php checked( $val, '1' ); ?>></td>
+                        <?php else : ?>
+                            <td><input type="text" class="form-control form-control-sm cdc-pe-input" data-field="<?php echo esc_attr( $f ); ?>" value="<?php echo esc_attr( $val ); ?>" /></td>
+                        <?php endif; ?>
                     <?php endforeach; ?>
                 </tr>
             <?php endforeach; wp_reset_postdata(); ?>

--- a/admin/views/power-editor-page.php
+++ b/admin/views/power-editor-page.php
@@ -38,6 +38,7 @@ $fields = [
             <?php endforeach; ?>
         </select>
         <input id="cdc-pe-search" type="search" class="form-control" placeholder="<?php esc_attr_e( 'Search councils…', 'council-debt-counters' ); ?>" style="max-width:200px;" />
+        <span id="cdc-pe-spinner" class="spinner-border spinner-border-sm align-self-center ms-2 d-none" role="status" aria-hidden="true"></span>
     </div>
     <table class="table table-striped table-hover" id="cdc-power-table">
         <thead>

--- a/admin/views/power-editor-page.php
+++ b/admin/views/power-editor-page.php
@@ -31,14 +31,14 @@ $fields = [
 ?>
 <div class="wrap">
     <h1><?php esc_html_e( 'Power Editor', 'council-debt-counters' ); ?></h1>
-    <div class="d-flex mb-3">
+    <div id="cdc-pe-header" class="d-flex align-items-center mb-3">
         <select id="cdc-pe-year" class="form-select me-2" style="width:auto;">
             <?php foreach ( $years as $y ) : ?>
                 <option value="<?php echo esc_attr( $y ); ?>" <?php selected( $year, $y ); ?>><?php echo esc_html( $y ); ?></option>
             <?php endforeach; ?>
         </select>
         <input id="cdc-pe-search" type="search" class="form-control" placeholder="<?php esc_attr_e( 'Search councils…', 'council-debt-counters' ); ?>" style="max-width:200px;" />
-        <span id="cdc-pe-spinner" class="spinner-border spinner-border-sm align-self-center ms-2 d-none" role="status" aria-hidden="true"></span>
+        <span id="cdc-pe-spinner" class="spinner-border spinner-border-sm d-none" role="status" aria-hidden="true"></span>
     </div>
     <table class="table table-striped table-hover" id="cdc-power-table">
         <thead>

--- a/admin/views/power-editor-page.php
+++ b/admin/views/power-editor-page.php
@@ -55,6 +55,7 @@ $fields = [
                 <th><?php esc_html_e( 'Income', 'council-debt-counters' ); ?></th>
                 <th><?php esc_html_e( 'Interest Paid', 'council-debt-counters' ); ?></th>
                 <th><?php esc_html_e( 'Closed', 'council-debt-counters' ); ?></th>
+                <th><?php esc_html_e( 'Confirm', 'council-debt-counters' ); ?></th>
             </tr>
         </thead>
         <tbody>
@@ -70,6 +71,7 @@ $fields = [
                             <td><input type="text" class="form-control form-control-sm cdc-pe-input" data-field="<?php echo esc_attr( $f ); ?>" value="<?php echo esc_attr( $val ); ?>" /></td>
                         <?php endif; ?>
                     <?php endforeach; ?>
+                    <td><button type="button" class="btn btn-sm btn-success cdc-pe-confirm"><?php esc_html_e( 'Confirm', 'council-debt-counters' ); ?></button></td>
                 </tr>
             <?php endforeach; wp_reset_postdata(); ?>
         </tbody>

--- a/admin/views/power-editor-page.php
+++ b/admin/views/power-editor-page.php
@@ -1,0 +1,50 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+$year  = CDC_Utils::current_financial_year();
+$years = CDC_Utils::council_years();
+$query = new WP_Query([
+    'post_type'      => 'council',
+    'post_status'    => 'under_review',
+    'posts_per_page' => -1,
+    'orderby'        => 'title',
+    'order'          => 'asc',
+]);
+$fields = [ 'population', 'current_liabilities', 'long_term_liabilities', 'interest_paid' ];
+?>
+<div class="wrap">
+    <h1><?php esc_html_e( 'Power Editor', 'council-debt-counters' ); ?></h1>
+    <div class="d-flex mb-3">
+        <select id="cdc-pe-year" class="form-select me-2" style="width:auto;">
+            <?php foreach ( $years as $y ) : ?>
+                <option value="<?php echo esc_attr( $y ); ?>" <?php selected( $year, $y ); ?>><?php echo esc_html( $y ); ?></option>
+            <?php endforeach; ?>
+        </select>
+        <input id="cdc-pe-search" type="search" class="form-control" placeholder="<?php esc_attr_e( 'Search councils…', 'council-debt-counters' ); ?>" style="max-width:200px;" />
+    </div>
+    <table class="table table-striped table-hover" id="cdc-power-table">
+        <thead>
+            <tr>
+                <th><?php esc_html_e( 'ID', 'council-debt-counters' ); ?></th>
+                <th><?php esc_html_e( 'Council', 'council-debt-counters' ); ?></th>
+                <th><?php esc_html_e( 'Population', 'council-debt-counters' ); ?></th>
+                <th><?php esc_html_e( 'Current Liabilities', 'council-debt-counters' ); ?></th>
+                <th><?php esc_html_e( 'Long-Term Liabilities', 'council-debt-counters' ); ?></th>
+                <th><?php esc_html_e( 'Interest Paid', 'council-debt-counters' ); ?></th>
+            </tr>
+        </thead>
+        <tbody>
+            <?php foreach ( $query->posts as $p ) : ?>
+                <tr data-cid="<?php echo esc_attr( $p->ID ); ?>">
+                    <td><?php echo intval( $p->ID ); ?></td>
+                    <td><?php echo esc_html( get_the_title( $p ) ); ?></td>
+                    <?php foreach ( $fields as $f ) : ?>
+                        <?php $val = Custom_Fields::get_value( $p->ID, $f, $year ); ?>
+                        <td><input type="text" class="form-control form-control-sm cdc-pe-input" data-field="<?php echo esc_attr( $f ); ?>" value="<?php echo esc_attr( $val ); ?>" /></td>
+                    <?php endforeach; ?>
+                </tr>
+            <?php endforeach; wp_reset_postdata(); ?>
+        </tbody>
+    </table>
+</div>

--- a/council-debt-counters.php
+++ b/council-debt-counters.php
@@ -46,6 +46,7 @@ require_once plugin_dir_path( __FILE__ ) . 'includes/class-stats-page.php';
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-sharing-meta.php';
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-year-maintenance.php';
 require_once plugin_dir_path( __FILE__ ) . 'includes/class-calculations-page.php';
+require_once plugin_dir_path( __FILE__ ) . 'includes/class-power-editor-page.php';
 
 register_activation_hook(
 	__FILE__,
@@ -92,6 +93,7 @@ add_action(
                 \CouncilDebtCounters\Sharing_Meta::init();
                 \CouncilDebtCounters\Year_Maintenance::init();
                 \CouncilDebtCounters\Calculations_Page::init();
+                \CouncilDebtCounters\Power_Editor_Page::init();
         }
 );
 

--- a/includes/class-council-admin-page.php
+++ b/includes/class-council-admin-page.php
@@ -155,6 +155,10 @@ class Council_Admin_Page {
             $tab   = Custom_Fields::get_field_tab( $field->name );
             $year  = isset( $tab_years[ $tab ] ) ? sanitize_text_field( $tab_years[ $tab ] ) : CDC_Utils::current_financial_year();
             Custom_Fields::update_value( $post_id, $field->name, wp_unslash( $value ), $year );
+            if ( 'council_closed' === $field->name && $value ) {
+                Custom_Fields::update_value( $post_id, 'status_message', __( 'This council no longer exists', 'council-debt-counters' ), CDC_Utils::current_financial_year() );
+                Custom_Fields::update_value( $post_id, 'status_message_type', 'warning', CDC_Utils::current_financial_year() );
+            }
             $meta_key = 'cdc_na_' . $field->name;
             if ( isset( $na_flags[ $field->name ] ) ) {
                 update_post_meta( $post_id, $meta_key, '1' );

--- a/includes/class-custom-fields.php
+++ b/includes/class-custom-fields.php
@@ -39,6 +39,7 @@ class Custom_Fields {
         'interest_paid'                 => 'interest',
         'usable_reserves'               => 'reserves',
         'consultancy_spend'             => 'consultancy',
+        'council_closed'                => 'general',
     ];
 
     const DEFAULT_FIELDS = [
@@ -67,6 +68,7 @@ class Custom_Fields {
         ['name' => 'financial_data_source_url', 'label' => 'Financial Data Source URL', 'type' => 'text', 'required' => 0],
         ['name' => 'status_message', 'label' => 'Status Message', 'type' => 'text', 'required' => 0],
         ['name' => 'status_message_type', 'label' => 'Status Message Type', 'type' => 'text', 'required' => 0],
+        ['name' => 'council_closed', 'label' => 'Council Closed', 'type' => 'text', 'required' => 0],
     ];
 
     /**

--- a/includes/class-power-editor-page.php
+++ b/includes/class-power-editor-page.php
@@ -78,6 +78,10 @@ class Power_Editor_Page {
         }
 
         Custom_Fields::update_value( $cid, $field, $value, $year );
+        if ( 'council_closed' === $field && $value ) {
+            Custom_Fields::update_value( $cid, 'status_message', __( 'This council no longer exists', 'council-debt-counters' ), CDC_Utils::current_financial_year() );
+            Custom_Fields::update_value( $cid, 'status_message_type', 'warning', CDC_Utils::current_financial_year() );
+        }
         delete_post_meta( $cid, 'cdc_na_' . $field );
         $tab = Custom_Fields::get_field_tab( $field );
         delete_post_meta( $cid, 'cdc_na_tab_' . $tab );

--- a/includes/class-power-editor-page.php
+++ b/includes/class-power-editor-page.php
@@ -88,6 +88,12 @@ class Power_Editor_Page {
         delete_post_meta( $cid, 'cdc_na_' . $field );
         $tab = Custom_Fields::get_field_tab( $field );
         delete_post_meta( $cid, 'cdc_na_tab_' . $tab );
+        if ( 'debt' === $tab ) {
+            delete_post_meta( $cid, 'cdc_na_total_debt' );
+            if ( method_exists( '\\CouncilDebtCounters\\Council_Post_Type', 'calculate_total_debt' ) ) {
+                Council_Post_Type::calculate_total_debt( $cid, $year );
+            }
+        }
 
         $years = (array) get_post_meta( $cid, 'cdc_enabled_years', true );
         if ( ! in_array( $year, $years, true ) ) {
@@ -145,6 +151,10 @@ class Power_Editor_Page {
 
         if ( $active ) {
             wp_update_post( [ 'ID' => $cid, 'post_status' => 'publish' ] );
+        }
+        delete_post_meta( $cid, 'cdc_na_total_debt' );
+        if ( method_exists( '\\CouncilDebtCounters\\Council_Post_Type', 'calculate_total_debt' ) ) {
+            Council_Post_Type::calculate_total_debt( $cid, $year );
         }
         delete_post_meta( $cid, 'cdc_under_review' );
 

--- a/includes/class-power-editor-page.php
+++ b/includes/class-power-editor-page.php
@@ -42,11 +42,18 @@ class Power_Editor_Page {
         wp_enqueue_style( 'bootstrap-5', $bootstrap_css, [], '5.3.1' );
         wp_enqueue_script( 'bootstrap-5', $bootstrap_js, [], '5.3.1', true );
 
+        wp_enqueue_style(
+            'cdc-power-editor',
+            plugins_url( 'admin/css/power-editor.css', dirname( __DIR__ ) . '/council-debt-counters.php' ),
+            [],
+            '0.1.0'
+        );
+
         wp_enqueue_script(
             'cdc-power-editor',
             plugins_url( 'admin/js/power-editor.js', dirname( __DIR__ ) . '/council-debt-counters.php' ),
             [],
-            '0.1.0',
+            '0.1.1',
             true
         );
         wp_localize_script( 'cdc-power-editor', 'cdcPower', [

--- a/includes/class-power-editor-page.php
+++ b/includes/class-power-editor-page.php
@@ -1,0 +1,90 @@
+<?php
+namespace CouncilDebtCounters;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class Power_Editor_Page {
+    const SLUG = 'cdc-power-editor';
+
+    public static function init() {
+        add_action( 'admin_menu', [ __CLASS__, 'add_menu' ] );
+        add_action( 'admin_enqueue_scripts', [ __CLASS__, 'enqueue_assets' ] );
+        add_action( 'wp_ajax_cdc_power_save', [ __CLASS__, 'ajax_save' ] );
+    }
+
+    public static function add_menu() {
+        add_submenu_page(
+            'council-debt-counters',
+            __( 'Power Editor', 'council-debt-counters' ),
+            __( 'Power Editor', 'council-debt-counters' ),
+            'manage_options',
+            self::SLUG,
+            [ __CLASS__, 'render_page' ]
+        );
+    }
+
+    public static function enqueue_assets( $hook ) {
+        if ( 'debt-counters_page_' . self::SLUG !== $hook ) {
+            return;
+        }
+        $plugin_file = dirname( __DIR__ ) . '/council-debt-counters.php';
+        $use_cdn     = apply_filters( 'cdc_use_cdn', (bool) get_option( 'cdc_use_cdn_assets', 0 ) );
+
+        if ( $use_cdn ) {
+            $bootstrap_css = 'https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/css/bootstrap.min.css';
+            $bootstrap_js  = 'https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/js/bootstrap.bundle.min.js';
+        } else {
+            $bootstrap_css = plugins_url( 'public/css/bootstrap.min.css', $plugin_file );
+            $bootstrap_js  = plugins_url( 'public/js/bootstrap.bundle.min.js', $plugin_file );
+        }
+        wp_enqueue_style( 'bootstrap-5', $bootstrap_css, [], '5.3.1' );
+        wp_enqueue_script( 'bootstrap-5', $bootstrap_js, [], '5.3.1', true );
+
+        wp_enqueue_script(
+            'cdc-power-editor',
+            plugins_url( 'admin/js/power-editor.js', dirname( __DIR__ ) . '/council-debt-counters.php' ),
+            [],
+            '0.1.0',
+            true
+        );
+        wp_localize_script( 'cdc-power-editor', 'cdcPower', [
+            'ajaxUrl' => admin_url( 'admin-ajax.php' ),
+            'nonce'   => wp_create_nonce( 'cdc_power_save' ),
+        ] );
+    }
+
+    public static function ajax_save() {
+        if ( ! current_user_can( 'manage_options' ) ) {
+            wp_send_json_error( __( 'Permission denied.', 'council-debt-counters' ), 403 );
+        }
+        check_ajax_referer( 'cdc_power_save', 'nonce' );
+
+        $cid   = isset( $_POST['cid'] ) ? intval( $_POST['cid'] ) : 0;
+        $field = isset( $_POST['field'] ) ? sanitize_key( $_POST['field'] ) : '';
+        $value = $_POST['value'] ?? '';
+        $year  = isset( $_POST['year'] ) ? sanitize_text_field( $_POST['year'] ) : CDC_Utils::current_financial_year();
+
+        if ( ! $cid || ! $field ) {
+            wp_send_json_error();
+        }
+
+        Custom_Fields::update_value( $cid, $field, $value, $year );
+        delete_post_meta( $cid, 'cdc_na_' . $field );
+        $tab = Custom_Fields::get_field_tab( $field );
+        delete_post_meta( $cid, 'cdc_na_tab_' . $tab );
+
+        $years = (array) get_post_meta( $cid, 'cdc_enabled_years', true );
+        if ( ! in_array( $year, $years, true ) ) {
+            $years[] = $year;
+            update_post_meta( $cid, 'cdc_enabled_years', $years );
+        }
+
+        wp_send_json_success();
+    }
+
+    public static function render_page() {
+        include dirname( __DIR__ ) . '/admin/views/power-editor-page.php';
+    }
+}

--- a/includes/class-power-editor-page.php
+++ b/includes/class-power-editor-page.php
@@ -81,6 +81,20 @@ class Power_Editor_Page {
             update_post_meta( $cid, 'cdc_enabled_years', $years );
         }
 
+        // If at least one tab has figures, mark the council as Active.
+        $enabled_tabs = (array) get_option( 'cdc_enabled_counters', array() );
+        $active       = false;
+        foreach ( $enabled_tabs as $tab_key ) {
+            if ( '1' !== get_post_meta( $cid, 'cdc_na_tab_' . $tab_key, true ) ) {
+                $active = true;
+                break;
+            }
+        }
+        if ( $active ) {
+            wp_update_post( [ 'ID' => $cid, 'post_status' => 'publish' ] );
+            delete_post_meta( $cid, 'cdc_under_review' );
+        }
+
         wp_send_json_success();
     }
 


### PR DESCRIPTION
## Summary
- add Power Editor page and JavaScript for quick entry
- render under-review councils in spreadsheet-style table
- ensure saved data activates year and clears N/A flags
- document new admin feature in README

## Testing
- `composer install`
- `vendor/bin/phpunit --dont-report-useless-tests`

------
https://chatgpt.com/codex/tasks/task_e_685f1e1493148331b52fb48c65c8696c