### PR TITLE
Add financial year management

### DIFF
--- a/admin/css/years-progress.css
+++ b/admin/css/years-progress.css
@@ -1,0 +1,12 @@
+#cdc-years-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(255,255,255,0.8);
+    z-index: 10000;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}

--- a/admin/css/years-progress.css
+++ b/admin/css/years-progress.css
@@ -10,3 +10,11 @@
     align-items: center;
     justify-content: center;
 }
+
+#cdc-years-message.cdc-years-success {
+    color: #155724;
+}
+
+#cdc-years-message.cdc-years-error {
+    color: #721c24;
+}

--- a/admin/js/years.js
+++ b/admin/js/years.js
@@ -6,6 +6,8 @@
     function hide(){ if(overlay) overlay.style.display='none'; }
     var tbody=document.querySelector('#cdc-years-table tbody');
     var addBtn=document.getElementById('cdc-add-year-btn');
+    var saveBtn=document.getElementById('cdc-save-years');
+    var message=document.getElementById('cdc-years-message');
     var newInput=document.getElementById('cdc-new-year');
     function addRow(year){
       var tr=document.createElement('tr');
@@ -26,6 +28,36 @@
         fetch(cdcYears.ajaxUrl,{method:'POST',credentials:'same-origin',body:d})
           .then(r=>r.json())
           .then(res=>{ if(res&&res.success){ addRow(y); newInput.value=''; } })
+          .finally(hide);
+      });
+    }
+    if(saveBtn){
+      saveBtn.addEventListener('click',function(){
+        var rows=tbody.querySelectorAll('tr');
+        var years=[];
+        rows.forEach(function(r){
+          var val=r.querySelector('.cdc-year-input').value.trim();
+          if(/^\d{4}\/\d{2}$/.test(val)) years.push(val);
+        });
+        var def=tbody.querySelector('input[name="cdc_default_year"]:checked');
+        var defVal=def?def.value:'';
+        show();
+        var d=new FormData();
+        d.append('action','cdc_save_years');
+        d.append('nonce',cdcYears.nonce);
+        d.append('years',JSON.stringify(years));
+        d.append('default',defVal);
+        fetch(cdcYears.ajaxUrl,{method:'POST',credentials:'same-origin',body:d})
+          .then(r=>r.json())
+          .then(res=>{
+            if(message){
+              message.textContent=res&&res.success?cdcYears.saved:cdcYears.error;
+              message.classList.toggle('cdc-years-success',!!(res&&res.success));
+              message.classList.toggle('cdc-years-error',!(res&&res.success));
+              message.style.display='inline';
+              setTimeout(function(){message.style.display='none';},3000);
+            }
+          })
           .finally(hide);
       });
     }

--- a/admin/js/years.js
+++ b/admin/js/years.js
@@ -1,0 +1,78 @@
+(function(){
+  function ready(fn){ if(document.readyState!=='loading'){fn();} else {document.addEventListener('DOMContentLoaded',fn);} }
+  ready(function(){
+    var overlay=document.getElementById('cdc-years-overlay');
+    function show(){ if(overlay) overlay.style.display='flex'; }
+    function hide(){ if(overlay) overlay.style.display='none'; }
+    var tbody=document.querySelector('#cdc-years-table tbody');
+    var addBtn=document.getElementById('cdc-add-year-btn');
+    var newInput=document.getElementById('cdc-new-year');
+    function addRow(year){
+      var tr=document.createElement('tr');
+      tr.innerHTML='<td><input type="text" class="cdc-year-input form-control" data-original="'+year+'" value="'+year+'"></td>'+
+                   '<td><input type="radio" name="cdc_default_year" value="'+year+'"></td>'+
+                   '<td><button type="button" class="button cdc-delete-year">Delete</button></td>';
+      tbody.appendChild(tr);
+    }
+    if(addBtn){
+      addBtn.addEventListener('click',function(){
+        var y=newInput.value.trim();
+        if(!/^\d{4}\/\d{2}$/.test(y)) return;
+        show();
+        var d=new FormData();
+        d.append('action','cdc_add_year');
+        d.append('nonce',cdcYears.nonce);
+        d.append('year',y);
+        fetch(cdcYears.ajaxUrl,{method:'POST',credentials:'same-origin',body:d})
+          .then(r=>r.json())
+          .then(res=>{ if(res&&res.success){ addRow(y); newInput.value=''; } })
+          .finally(hide);
+      });
+    }
+    if(tbody){
+      tbody.addEventListener('change',function(e){
+        if(e.target.classList.contains('cdc-year-input')){
+          var old=e.target.getAttribute('data-original');
+          var val=e.target.value.trim();
+          if(!/^\d{4}\/\d{2}$/.test(val)) { e.target.value=old; return; }
+          show();
+          var d=new FormData();
+          d.append('action','cdc_update_year');
+          d.append('nonce',cdcYears.nonce);
+          d.append('old',old);
+          d.append('new',val);
+          fetch(cdcYears.ajaxUrl,{method:'POST',credentials:'same-origin',body:d})
+            .then(r=>r.json())
+            .then(res=>{ if(res&&res.success){ e.target.setAttribute('data-original',val); } else { e.target.value=old; } })
+            .finally(hide);
+        }
+        if(e.target.name==='cdc_default_year'){
+          var val=e.target.value;
+          show();
+          var d=new FormData();
+          d.append('action','cdc_set_default_year');
+          d.append('nonce',cdcYears.nonce);
+          d.append('year',val);
+          fetch(cdcYears.ajaxUrl,{method:'POST',credentials:'same-origin',body:d})
+            .finally(hide);
+        }
+      });
+      tbody.addEventListener('click',function(e){
+        if(e.target.classList.contains('cdc-delete-year')){
+          if(!confirm(cdcYears.deleteConfirm)) return;
+          var row=e.target.closest('tr');
+          var val=row.querySelector('.cdc-year-input').value;
+          show();
+          var d=new FormData();
+          d.append('action','cdc_delete_year');
+          d.append('nonce',cdcYears.nonce);
+          d.append('year',val);
+          fetch(cdcYears.ajaxUrl,{method:'POST',credentials:'same-origin',body:d})
+            .then(r=>r.json())
+            .then(res=>{ if(res&&res.success){ row.remove(); } })
+            .finally(hide);
+        }
+      });
+    }
+  });
+})();

--- a/admin/views/settings-page.php
+++ b/admin/views/settings-page.php
@@ -186,4 +186,30 @@ $types = [
         </table>
         <?php submit_button(); ?>
     </form>
+    <h2 class="mt-4"><?php esc_html_e( 'Available Financial Years', 'council-debt-counters' ); ?></h2>
+    <div id="cdc-years-overlay" style="display:none"><span class="spinner is-active"></span></div>
+    <?php $years = get_option( 'cdc_financial_years', \CouncilDebtCounters\Docs_Manager::default_years() ); ?>
+    <?php $def_year = get_option( 'cdc_default_financial_year', '2023/24' ); ?>
+    <table class="widefat" id="cdc-years-table">
+        <thead>
+            <tr>
+                <th><?php esc_html_e( 'Year', 'council-debt-counters' ); ?></th>
+                <th><?php esc_html_e( 'Default', 'council-debt-counters' ); ?></th>
+                <th><?php esc_html_e( 'Actions', 'council-debt-counters' ); ?></th>
+            </tr>
+        </thead>
+        <tbody>
+            <?php foreach ( $years as $y ) : ?>
+                <tr>
+                    <td><input type="text" class="cdc-year-input form-control" data-original="<?php echo esc_attr( $y ); ?>" value="<?php echo esc_attr( $y ); ?>" /></td>
+                    <td><input type="radio" name="cdc_default_year" value="<?php echo esc_attr( $y ); ?>" <?php checked( $def_year, $y ); ?> /></td>
+                    <td><button type="button" class="button cdc-delete-year"><?php esc_html_e( 'Delete', 'council-debt-counters' ); ?></button></td>
+                </tr>
+            <?php endforeach; ?>
+        </tbody>
+    </table>
+    <p class="mt-2">
+        <input type="text" id="cdc-new-year" class="regular-text" placeholder="YYYY/YY" />
+        <button type="button" id="cdc-add-year-btn" class="button"><?php esc_html_e( 'Add Year', 'council-debt-counters' ); ?></button>
+    </p>
 </div>

--- a/admin/views/settings-page.php
+++ b/admin/views/settings-page.php
@@ -211,5 +211,7 @@ $types = [
     <p class="mt-2">
         <input type="text" id="cdc-new-year" class="regular-text" placeholder="YYYY/YY" />
         <button type="button" id="cdc-add-year-btn" class="button"><?php esc_html_e( 'Add Year', 'council-debt-counters' ); ?></button>
+        <button type="button" id="cdc-save-years" class="button button-primary ms-2"><?php esc_html_e( 'Save Financial Years', 'council-debt-counters' ); ?></button>
+        <span id="cdc-years-message" style="display:none" class="ms-2"></span>
     </p>
 </div>

--- a/council-debt-counters.php
+++ b/council-debt-counters.php
@@ -50,10 +50,13 @@ require_once plugin_dir_path( __FILE__ ) . 'includes/class-power-editor-page.php
 
 register_activation_hook(
 	__FILE__,
-	function () {
-		\CouncilDebtCounters\Custom_Fields::install();
-		\CouncilDebtCounters\Docs_Manager::install();
-	}
+        function () {
+                \CouncilDebtCounters\Custom_Fields::install();
+                \CouncilDebtCounters\Docs_Manager::install();
+                if ( ! get_option( 'cdc_financial_years', false ) ) {
+                        update_option( 'cdc_financial_years', \CouncilDebtCounters\Docs_Manager::default_years() );
+                }
+        }
 );
 
 // Ensure custom error handling does not persist after deactivation.

--- a/includes/class-docs-manager.php
+++ b/includes/class-docs-manager.php
@@ -26,18 +26,35 @@ class Docs_Manager {
     }
 
     /**
-     * Return a list of financial years including the current year and
-     * the previous $count years.
+     * Get the list of financial years configured for the plugin.
+     * Falls back to default_years() if none saved.
      */
     public static function financial_years( int $count = 10 ) {
+        $years = get_option( 'cdc_financial_years', [] );
+        if ( empty( $years ) ) {
+            $years = self::default_years();
+        }
+        $years = array_values( $years );
+        return array_slice( $years, 0, $count + 2 );
+    }
+
+    /**
+     * Generate the default list of available financial years.
+     * Includes the last ten years and the future years 2024/25 and 2025/26.
+     */
+    public static function default_years() {
         $current = self::current_financial_year();
-        list( $start, $end ) = explode( '/', $current );
+        list( $start ) = explode( '/', $current );
         $start = (int) $start;
         $years = [];
-        for ( $i = 0; $i <= $count; $i++ ) {
-            $y = $start - $i;
+        for ( $i = 0; $i < 10; $i++ ) {
+            $y       = $start - $i;
             $years[] = sprintf( '%d/%02d', $y, ( $y + 1 ) % 100 );
         }
+        $years[] = '2024/25';
+        $years[] = '2025/26';
+        $years   = array_unique( $years );
+        rsort( $years );
         return $years;
     }
 

--- a/includes/class-docs-manager.php
+++ b/includes/class-docs-manager.php
@@ -33,6 +33,9 @@ class Docs_Manager {
         $years = get_option( 'cdc_financial_years', [] );
         if ( empty( $years ) ) {
             $years = self::default_years();
+            // Persist defaults so they remain available if settings are saved
+            // without a financial year list present.
+            update_option( 'cdc_financial_years', $years );
         }
         $years = array_values( $years );
         return array_slice( $years, 0, $count + 2 );

--- a/tests/DocsManagerTest.php
+++ b/tests/DocsManagerTest.php
@@ -1,0 +1,16 @@
+<?php
+use PHPUnit\Framework\TestCase;
+use CouncilDebtCounters\Docs_Manager;
+
+require_once __DIR__ . '/../includes/class-docs-manager.php';
+
+class DocsManagerTest extends TestCase {
+    public function test_financial_years_include_future() {
+        update_option('cdc_financial_years', null);
+        update_option('cdc_default_financial_year', '2023/24');
+        $years = Docs_Manager::financial_years();
+        $this->assertContains('2024/25', $years);
+        $this->assertContains('2025/26', $years);
+        $this->assertGreaterThanOrEqual(12, count($years));
+    }
+}


### PR DESCRIPTION
## Summary
- provide admin interface for managing financial years
- support AJAX add/edit/delete/default year
- store available years in new option and populate on activation
- default list includes 2024/25, 2025/26 plus last ten years
- add tests for Docs_Manager financial years

## Testing
- `./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_685fa4cf8edc83319097a7b94a0ee22c