### PR TITLE
Refactor council finance fields

### DIFF
--- a/admin/views/power-editor-page.php
+++ b/admin/views/power-editor-page.php
@@ -25,7 +25,10 @@ $fields = [
 'finance_lease_pfi_liabilities',
 'annual_spending',
 'annual_deficit',
-'total_income',
+'non_council_tax_income',
+'council_tax_general_grants_income',
+'government_grants_income',
+'all_other_income',
 'interest_paid',
 'council_closed',
 ];
@@ -49,10 +52,13 @@ $fields = [
                 <th><?php esc_html_e( 'Population', 'council-debt-counters' ); ?></th>
                 <th><?php esc_html_e( 'Current Liabilities', 'council-debt-counters' ); ?></th>
                 <th><?php esc_html_e( 'Long-Term Liabilities', 'council-debt-counters' ); ?></th>
-                <th><?php esc_html_e( 'PFI Liabilities', 'council-debt-counters' ); ?></th>
-                <th><?php esc_html_e( 'Spending', 'council-debt-counters' ); ?></th>
-                <th><?php esc_html_e( 'Deficit', 'council-debt-counters' ); ?></th>
-                <th><?php esc_html_e( 'Income', 'council-debt-counters' ); ?></th>
+                <th><?php esc_html_e( 'PFI & Finance Lease Liabilities', 'council-debt-counters' ); ?></th>
+                <th><?php esc_html_e( 'Expenditure on Services', 'council-debt-counters' ); ?></th>
+                <th><?php esc_html_e( 'Reported Net Deficit (or Surplus)', 'council-debt-counters' ); ?></th>
+                <th><?php esc_html_e( 'Non-Council Tax Income', 'council-debt-counters' ); ?></th>
+                <th><?php esc_html_e( 'Income from Council Tax and General Grants', 'council-debt-counters' ); ?></th>
+                <th><?php esc_html_e( 'Government Grants', 'council-debt-counters' ); ?></th>
+                <th><?php esc_html_e( 'All Other Income', 'council-debt-counters' ); ?></th>
                 <th><?php esc_html_e( 'Interest Paid', 'council-debt-counters' ); ?></th>
                 <th><?php esc_html_e( 'Closed', 'council-debt-counters' ); ?></th>
                 <th><?php esc_html_e( 'Confirm', 'council-debt-counters' ); ?></th>

--- a/admin/views/settings-page.php
+++ b/admin/views/settings-page.php
@@ -4,9 +4,9 @@ $titles  = (array) get_option( 'cdc_counter_titles', [] );
 $total_titles = (array) get_option( 'cdc_total_counter_titles', [] );
 $types = [
     'debt' => __( 'Debt', 'council-debt-counters' ),
-    'spending' => __( 'Spending', 'council-debt-counters' ),
-    'income' => __( 'Income', 'council-debt-counters' ),
-    'deficit' => __( 'Deficit', 'council-debt-counters' ),
+    'spending' => __( 'Expenditure on Services', 'council-debt-counters' ),
+    'income' => __( 'Non-Council Tax Income', 'council-debt-counters' ),
+    'deficit' => __( 'Reported Net Deficit (or Surplus)', 'council-debt-counters' ),
     'interest' => __( 'Interest', 'council-debt-counters' ),
     'reserves' => __( 'Reserves', 'council-debt-counters' ),
     'consultancy' => __( 'Consultancy', 'council-debt-counters' ),
@@ -46,9 +46,9 @@ $types = [
                     <?php
                     $totals = [
                         'debt'        => [ 'label' => __( 'Total Debt', 'council-debt-counters' ),        'shortcode' => '[total_debt_counter]' ],
-                        'spending'    => [ 'label' => __( 'Total Spending', 'council-debt-counters' ),    'shortcode' => '[total_spending_counter]' ],
+                        'spending'    => [ 'label' => __( 'Total Expenditure on Services', 'council-debt-counters' ),    'shortcode' => '[total_spending_counter]' ],
                         'income'      => [ 'label' => __( 'Total Income', 'council-debt-counters' ),      'shortcode' => '[total_revenue_counter]' ],
-                        'deficit'     => [ 'label' => __( 'Total Deficit', 'council-debt-counters' ),     'shortcode' => '[total_deficit_counter]' ],
+                        'deficit'     => [ 'label' => __( 'Total Reported Net Deficit (or Surplus)', 'council-debt-counters' ),     'shortcode' => '[total_deficit_counter]' ],
                         'interest'    => [ 'label' => __( 'Total Interest', 'council-debt-counters' ),    'shortcode' => '[total_interest_counter]' ],
                         'reserves'    => [ 'label' => __( 'Total Reserves', 'council-debt-counters' ),    'shortcode' => '[total_custom_counter type="reserves"]' ],
                         'consultancy' => [ 'label' => __( 'Consultancy Spend', 'council-debt-counters' ), 'shortcode' => '[total_custom_counter type="consultancy"]' ],

--- a/includes/class-ai-extractor.php
+++ b/includes/class-ai-extractor.php
@@ -124,7 +124,8 @@ class AI_Extractor {
         $prompt = "You are analysing a UK council's statement of accounts. "
             . "Return ONLY a JSON object with these keys: "
             . "current_liabilities, long_term_liabilities, finance_lease_pfi_liabilities, "
-            . "interest_paid, annual_spending, total_income, "
+            . "interest_paid, annual_spending, non_council_tax_income, "
+            . "council_tax_general_grants_income, government_grants_income, all_other_income, total_income, "
             . "annual_deficit, usable_reserves, consultancy_spend. "
             . "Use 0 if a figure is not mentioned. Numbers should be digits without commas or currency symbols. "
             . "If the document shows figures in thousands of pounds (e.g. £000s), multiply them by 1000 before returning the values." 
@@ -164,6 +165,10 @@ class AI_Extractor {
             'finance_lease_pfi_liabilities',
             'interest_paid',
             'annual_spending',
+            'non_council_tax_income',
+            'council_tax_general_grants_income',
+            'government_grants_income',
+            'all_other_income',
             'total_income',
             'annual_deficit',
             'usable_reserves',

--- a/includes/class-calculations-page.php
+++ b/includes/class-calculations-page.php
@@ -44,6 +44,7 @@ class Calculations_Page {
         if ( 'move_2025_to_2023' === $action ) {
             Custom_Fields::move_year_data( $cid, '2025/26', '2023/24' );
             Council_Post_Type::calculate_total_debt( $cid, '2023/24' );
+            Council_Post_Type::calculate_total_income( $cid, '2023/24' );
             Error_Logger::log_info( "Moved 2025/26 data to 2023/24 for council $cid" );
             echo '<div class="notice notice-success"><p>' . esc_html__( 'Data moved.', 'council-debt-counters' ) . '</p></div>';
         } elseif ( 'check_zero' === $action ) {

--- a/includes/class-council-admin-page.php
+++ b/includes/class-council-admin-page.php
@@ -170,6 +170,7 @@ class Council_Admin_Page {
         delete_post_meta( $post_id, 'cdc_na_total_debt' );
         $debt_year = isset( $tab_years['debt'] ) ? sanitize_text_field( $tab_years['debt'] ) : CDC_Utils::current_financial_year();
         Council_Post_Type::calculate_total_debt( $post_id, $debt_year );
+        Council_Post_Type::calculate_total_income( $post_id, $debt_year );
 
         $default_year  = get_post_meta( $post_id, 'cdc_default_financial_year', true );
         $current_total = (float) Custom_Fields::get_value( $post_id, 'total_debt', $default_year );

--- a/includes/class-data-loader.php
+++ b/includes/class-data-loader.php
@@ -99,6 +99,12 @@ class Data_Loader {
                         if ( method_exists( '\\CouncilDebtCounters\\Council_Post_Type', 'calculate_total_debt' ) ) {
                                 Council_Post_Type::calculate_total_debt( $post_id, CDC_Utils::current_financial_year() );
                         }
+                        if ( method_exists( '\\CouncilDebtCounters\\Council_Post_Type', 'calculate_total_income' ) ) {
+                                Council_Post_Type::calculate_total_income( $post_id, CDC_Utils::current_financial_year() );
+                        }
+                        if ( method_exists( '\\CouncilDebtCounters\\Council_Post_Type', 'calculate_total_income' ) ) {
+                                Council_Post_Type::calculate_total_income( $post_id, CDC_Utils::current_financial_year() );
+                        }
 
 			++$count;
 		}
@@ -396,6 +402,9 @@ class Data_Loader {
 
                 if ( method_exists( '\\CouncilDebtCounters\\Council_Post_Type', 'calculate_total_debt' ) ) {
                         Council_Post_Type::calculate_total_debt( $post_id, CDC_Utils::current_financial_year() );
+                }
+                if ( method_exists( '\\CouncilDebtCounters\\Council_Post_Type', 'calculate_total_income' ) ) {
+                        Council_Post_Type::calculate_total_income( $post_id, CDC_Utils::current_financial_year() );
                 }
 
 		wp_send_json_success( array( 'id' => $post_id ) );

--- a/includes/class-docs-manager.php
+++ b/includes/class-docs-manager.php
@@ -361,6 +361,9 @@ class Docs_Manager {
         if ( method_exists( '\\CouncilDebtCounters\\Council_Post_Type', 'calculate_total_debt' ) ) {
             Council_Post_Type::calculate_total_debt( $cid, $year );
         }
+        if ( method_exists( '\\CouncilDebtCounters\\Council_Post_Type', 'calculate_total_income' ) ) {
+            Council_Post_Type::calculate_total_income( $cid, $year );
+        }
         $all = get_option( 'cdc_ai_suggestions', [] );
         if ( isset( $all[ $cid ][ $year ] ) ) {
             unset( $all[ $cid ][ $year ] );

--- a/includes/class-figure-submission-form.php
+++ b/includes/class-figure-submission-form.php
@@ -316,7 +316,7 @@ class Figure_Submission_Form {
                                                                               <?php
                                                                               $label = $field->label;
                                                                               if ( 'annual_spending' === $field->name ) {
-                                                                                      $label = __( 'Total Annual Expenditure', 'council-debt-counters' );
+      $label = __( 'Annual Expenditure on Services', 'council-debt-counters' );
                                                                               }
                                                                               ?>
                                                                               <label for="fig-<?php echo esc_attr( $field->name ); ?>" class="form-label"><?php echo esc_html( $label ); ?></label>
@@ -333,6 +333,10 @@ class Figure_Submission_Form {
                                        <?php if ( 'annual_spending' === $field->name ) : ?>
                                        <div class="form-text">
                                        <?php esc_html_e( 'This is the gross expenditure figure taken from the comprehensive income and expenditure statement.', 'council-debt-counters' ); ?>
+                                       </div>
+                                       <?php elseif ( 'all_other_income' === $field->name ) : ?>
+                                       <div class="form-text">
+                                       <?php esc_html_e( 'Use this field to add any other income sources from the comprehensive income and expenditure statement', 'council-debt-counters' ); ?>
                                        </div>
                                        <?php endif; ?>
                                                                </div>

--- a/includes/class-power-editor-page.php
+++ b/includes/class-power-editor-page.php
@@ -93,6 +93,10 @@ class Power_Editor_Page {
             if ( method_exists( '\\CouncilDebtCounters\\Council_Post_Type', 'calculate_total_debt' ) ) {
                 Council_Post_Type::calculate_total_debt( $cid, $year );
             }
+        } elseif ( 'income' === $tab ) {
+            if ( method_exists( '\\CouncilDebtCounters\\Council_Post_Type', 'calculate_total_income' ) ) {
+                Council_Post_Type::calculate_total_income( $cid, $year );
+            }
         }
 
         $years = (array) get_post_meta( $cid, 'cdc_enabled_years', true );
@@ -155,6 +159,9 @@ class Power_Editor_Page {
         delete_post_meta( $cid, 'cdc_na_total_debt' );
         if ( method_exists( '\\CouncilDebtCounters\\Council_Post_Type', 'calculate_total_debt' ) ) {
             Council_Post_Type::calculate_total_debt( $cid, $year );
+        }
+        if ( method_exists( '\\CouncilDebtCounters\\Council_Post_Type', 'calculate_total_income' ) ) {
+            Council_Post_Type::calculate_total_income( $cid, $year );
         }
         delete_post_meta( $cid, 'cdc_under_review' );
 

--- a/includes/class-shortcode-renderer.php
+++ b/includes/class-shortcode-renderer.php
@@ -14,9 +14,9 @@ class Shortcode_Renderer {
 	private static function default_labels(): array {
 			return array(
 				'debt'        => __( 'Debt', 'council-debt-counters' ),
-				'spending'    => __( 'Spending', 'council-debt-counters' ),
-				'income'      => __( 'Income', 'council-debt-counters' ),
-				'deficit'     => __( 'Deficit', 'council-debt-counters' ),
+                                'spending'    => __( 'Expenditure on Services', 'council-debt-counters' ),
+                                'income'      => __( 'Non-Council Tax Income', 'council-debt-counters' ),
+                                'deficit'     => __( 'Reported Net Deficit (or Surplus)', 'council-debt-counters' ),
 				'interest'    => __( 'Interest', 'council-debt-counters' ),
 				'reserves'    => __( 'Reserves', 'council-debt-counters' ),
 				'consultancy' => __( 'Consultancy', 'council-debt-counters' ),
@@ -33,9 +33,9 @@ class Shortcode_Renderer {
 	private static function total_default_labels(): array {
 			return array(
 				'debt'        => __( 'Total Debt', 'council-debt-counters' ),
-				'spending'    => __( 'Total Spending', 'council-debt-counters' ),
-				'income'      => __( 'Total Income', 'council-debt-counters' ),
-				'deficit'     => __( 'Total Deficit', 'council-debt-counters' ),
+                                'spending'    => __( 'Total Expenditure on Services', 'council-debt-counters' ),
+                                'income'      => __( 'Total Income', 'council-debt-counters' ),
+                                'deficit'     => __( 'Total Reported Net Deficit (or Surplus)', 'council-debt-counters' ),
 				'interest'    => __( 'Total Interest', 'council-debt-counters' ),
 				'reserves'    => __( 'Total Reserves', 'council-debt-counters' ),
 				'consultancy' => __( 'Consultancy Spend', 'council-debt-counters' ),
@@ -106,9 +106,9 @@ class Shortcode_Renderer {
 				$label = $obj && ! empty( $obj->label ) ? $obj->label : ucwords( str_replace( '_', ' ', $field ) );
 				$map   = array(
 					'debt'        => __( 'Debt figures not available', 'council-debt-counters' ),
-					'spending'    => __( 'Expenditure figures not available', 'council-debt-counters' ),
-					'income'      => __( 'Income figures not available', 'council-debt-counters' ),
-					'deficit'     => __( 'Reported deficit figures not available', 'council-debt-counters' ),
+                                        'spending'    => __( 'Expenditure on services figures not available', 'council-debt-counters' ),
+                                        'income'      => __( 'Income figures not available', 'council-debt-counters' ),
+                                        'deficit'     => __( 'Reported deficit or surplus figures not available', 'council-debt-counters' ),
 					'interest'    => __( 'Interest payments not available', 'council-debt-counters' ),
 					'reserves'    => __( 'Reserves figures not available', 'council-debt-counters' ),
 					'consultancy' => __( 'Consultancy spend figures not available', 'council-debt-counters' ),
@@ -620,7 +620,7 @@ class Shortcode_Renderer {
 				$spend = (float) Custom_Fields::get_value( $id, 'annual_spending', $year );
 				if ( $population > 0 && $spend > 0 ) {
 					$per = $spend / $population;
-					return sprintf( __( 'Spending per resident: £%s', 'council-debt-counters' ), number_format_i18n( $per, 2 ) );
+                                        return sprintf( __( 'Expenditure per resident: £%s', 'council-debt-counters' ), number_format_i18n( $per, 2 ) );
 				}
 				break;
                         case 'deficit':
@@ -631,7 +631,7 @@ class Shortcode_Renderer {
                                                 $per = abs( $per );
                                                 return sprintf( __( 'Surplus per resident: £%s', 'council-debt-counters' ), number_format_i18n( $per, 2 ) );
                                         }
-                                        return sprintf( __( 'Deficit per resident: £%s', 'council-debt-counters' ), number_format_i18n( $per, 2 ) );
+                                        return sprintf( __( 'Reported deficit per resident: £%s', 'council-debt-counters' ), number_format_i18n( $per, 2 ) );
                                 }
                                 break;
 			case 'interest':

--- a/tests/CouncilPostTypeTest.php
+++ b/tests/CouncilPostTypeTest.php
@@ -17,6 +17,11 @@ class CouncilPostTypeTest extends TestCase {
         Custom_Fields::add_field('finance_lease_pfi_liabilities','Lease','money');
         Custom_Fields::add_field('manual_debt_entry','Manual','money');
         Custom_Fields::add_field('total_debt','Total Debt','money');
+        Custom_Fields::add_field('non_council_tax_income','Non Council','money');
+        Custom_Fields::add_field('council_tax_general_grants_income','CT Grants','money');
+        Custom_Fields::add_field('government_grants_income','Gov Grants','money');
+        Custom_Fields::add_field('all_other_income','Other','money');
+        Custom_Fields::add_field('total_income','Total Income','money');
     }
 
     public function test_calculate_total_debt_skips_if_no_data() {
@@ -32,5 +37,15 @@ class CouncilPostTypeTest extends TestCase {
         Custom_Fields::update_value(1,'long_term_liabilities',50,$year);
         Council_Post_Type::calculate_total_debt(1,$year);
         $this->assertSame(150.0, Custom_Fields::get_value(1,'total_debt',$year));
+    }
+
+    public function test_calculate_total_income_sums_values() {
+        $year = CDC_Utils::current_financial_year();
+        Custom_Fields::update_value(1,'non_council_tax_income',100,$year);
+        Custom_Fields::update_value(1,'council_tax_general_grants_income',50,$year);
+        Custom_Fields::update_value(1,'government_grants_income',25,$year);
+        Custom_Fields::update_value(1,'all_other_income',5,$year);
+        Council_Post_Type::calculate_total_income(1,$year);
+        $this->assertSame(180.0, Custom_Fields::get_value(1,'total_income',$year));
     }
 }


### PR DESCRIPTION
## Summary
- overhaul income fields for councils
- add automatic calculation of total income
- rename various finance field labels
- update admin tools and tests

## Testing
- `composer install`
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_685fa6f456f88331a83238e609c8bad8