### PR TITLE
Port WP fields & totals logic to Laravel

### DIFF
--- a/laravel/council-finance-counters/app/Models/Council.php
+++ b/laravel/council-finance-counters/app/Models/Council.php
@@ -23,7 +23,28 @@ class Council extends Model
         'council_tax_general_grants_income',
         'government_grants_income',
         'all_other_income',
+        'council_type',
+        'council_location',
+        'minimum_revenue_provision',
+        'annual_spending',
+        'annual_deficit',
+        'interest_paid',
+        'capital_financing_requirement',
+        'usable_reserves',
+        'consultancy_spend',
+        'waste_report_count',
+        'statement_of_accounts',
+        'financial_data_source_url',
+        'status_message',
+        'status_message_type',
+        'council_closed',
+        'debt_adjustments',
         'total_debt',
         'total_income',
+    ];
+
+    protected $casts = [
+        'debt_adjustments' => 'array',
+        'council_closed' => 'boolean',
     ];
 }

--- a/laravel/council-finance-counters/app/Services/CouncilTotalsService.php
+++ b/laravel/council-finance-counters/app/Services/CouncilTotalsService.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Council;
+use Illuminate\Support\Collection;
+
+/**
+ * Service handling total debt and income calculations for councils.
+ * This mirrors the logic in the legacy WordPress plugin while
+ * keeping the implementation testable and extendable.
+ */
+class CouncilTotalsService
+{
+    /**
+     * Calculate the total debt for a council including any manual
+     * adjustments recorded in the debt_adjustments field.
+     */
+    public function calculateDebt(Council $council): float
+    {
+        $adjust = collect($council->debt_adjustments)->sum('amount');
+
+        return (float) $council->current_liabilities
+            + (float) $council->long_term_liabilities
+            + (float) $council->finance_lease_pfi_liabilities
+            + (float) $council->manual_debt_entry
+            + (float) $adjust;
+    }
+
+    /**
+     * Calculate the total income for a council.
+     */
+    public function calculateIncome(Council $council): float
+    {
+        return (float) $council->non_council_tax_income
+            + (float) $council->council_tax_general_grants_income
+            + (float) $council->government_grants_income
+            + (float) $council->all_other_income;
+    }
+
+    /**
+     * Persist updated totals on the provided council record.
+     */
+    public function updateTotals(Council $council): Council
+    {
+        $council->total_debt = $this->calculateDebt($council);
+        $council->total_income = $this->calculateIncome($council);
+        $council->save();
+
+        return $council;
+    }
+}

--- a/laravel/council-finance-counters/database/migrations/2025_06_30_093454_add_additional_fields_to_councils_table.php
+++ b/laravel/council-finance-counters/database/migrations/2025_06_30_093454_add_additional_fields_to_councils_table.php
@@ -1,0 +1,60 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('councils', function (Blueprint $table) {
+            $table->string('council_type')->nullable();
+            $table->string('council_location')->nullable();
+            $table->decimal('minimum_revenue_provision', 15, 2)->nullable();
+            $table->decimal('annual_spending', 15, 2)->nullable();
+            $table->decimal('annual_deficit', 15, 2)->nullable();
+            $table->decimal('interest_paid', 15, 2)->nullable();
+            $table->decimal('capital_financing_requirement', 15, 2)->nullable();
+            $table->decimal('usable_reserves', 15, 2)->nullable();
+            $table->decimal('consultancy_spend', 15, 2)->nullable();
+            $table->unsignedInteger('waste_report_count')->nullable();
+            $table->string('statement_of_accounts')->nullable();
+            $table->string('financial_data_source_url')->nullable();
+            $table->string('status_message')->nullable();
+            $table->string('status_message_type')->nullable();
+            $table->boolean('council_closed')->default(false);
+            $table->json('debt_adjustments')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('councils', function (Blueprint $table) {
+            $table->dropColumn([
+                'council_type',
+                'council_location',
+                'minimum_revenue_provision',
+                'annual_spending',
+                'annual_deficit',
+                'interest_paid',
+                'capital_financing_requirement',
+                'usable_reserves',
+                'consultancy_spend',
+                'waste_report_count',
+                'statement_of_accounts',
+                'financial_data_source_url',
+                'status_message',
+                'status_message_type',
+                'council_closed',
+                'debt_adjustments',
+            ]);
+        });
+    }
+};

--- a/laravel/council-finance-counters/phpunit.xml
+++ b/laravel/council-finance-counters/phpunit.xml
@@ -29,5 +29,6 @@
         <env name="QUEUE_CONNECTION" value="sync"/>
         <env name="SESSION_DRIVER" value="array"/>
         <env name="TELESCOPE_ENABLED" value="false"/>
+        <env name="APP_KEY" value="base64:WHC+kN7eb7i3qnSSpGnLmYNQGNeFDG5zZHay4yiNKS0="/>
     </php>
 </phpunit>

--- a/laravel/council-finance-counters/tests/Unit/CouncilTotalsServiceTest.php
+++ b/laravel/council-finance-counters/tests/Unit/CouncilTotalsServiceTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\Council;
+use App\Services\CouncilTotalsService;
+use PHPUnit\Framework\TestCase;
+
+class CouncilTotalsServiceTest extends TestCase
+{
+    public function test_calculates_totals_with_adjustments(): void
+    {
+        $council = new Council([
+            'current_liabilities' => 100,
+            'long_term_liabilities' => 200,
+            'finance_lease_pfi_liabilities' => 50,
+            'manual_debt_entry' => 25,
+            'debt_adjustments' => [
+                ['amount' => 10],
+                ['amount' => -5],
+            ],
+            'non_council_tax_income' => 1000,
+            'council_tax_general_grants_income' => 500,
+            'government_grants_income' => 200,
+            'all_other_income' => 300,
+        ]);
+
+        $service = new CouncilTotalsService();
+
+        $this->assertEquals(380, $service->calculateDebt($council));
+        $this->assertEquals(2000, $service->calculateIncome($council));
+    }
+}


### PR DESCRIPTION
## Summary
- map WordPress council fields to Laravel Council model
- add service for calculating council totals
- keep FinancialCalculator as thin proxy
- migrate database schema for new fields
- cover CouncilTotalsService with unit test
- configure phpunit with key for feature tests

## Testing
- `vendor/bin/phpunit --testdox`
- `vendor/bin/phpunit --testdox` in plugin root

------
https://chatgpt.com/codex/tasks/task_e_68625985f2ec8331990d268a4eaf78fe